### PR TITLE
Removes the EMAIL and URL fields from tcl-commands.doc

### DIFF
--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -148,8 +148,6 @@ marked with vertical bars (|) on the left.
         INFO    - returns the user's global info line
         XTRA    - returns the user's XTRA info
         COMMENT - returns the master-visible only comment for the user
-        EMAIL   - returns the user's e-mail address
-        URL     - returns the user's url
         HANDLE  - returns the user's handle as it is saved in the userfile
         PASS    - returns the user's encrypted password
     Returns: info specific to each entry-type


### PR DESCRIPTION
these were removed some time ago in code, but documentation appears not to have been updated along with it.

Example:

*** *** ***

<user> .tcl getuser user LASTON

<bot> Tcl: 1413684437 partyline


<user> .tcl getuser user EMAIL

<bot> Tcl error: No such info type: EMAIL

<user> .tcl getuser user URL

<bot> Tcl error: No such info type: URL