### PR TITLE
Reply to server CTCPs

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -484,6 +484,9 @@ static int gotmsg(char *from, char *msg)
   fixcolon(msg);
   strncpyz(uhost, from, sizeof(buf));
   nick = splitnick(&uhost);
+  /* Apparently servers can send CTCPs now too, not just nicks */
+  if (nick[0] == '\0')
+    nick = uhost;
  
   /* Check for CTCP: */
   ctcp_reply[0] = 0;


### PR DESCRIPTION
A user had a unique situation where a server was sending CTCP requests to
eggdrop. While it was determined in discussion there was no particular need
to have eggdrop reply to a server CTCP (because it just feels dirty), the
code does contain a bug where if the uhost sent is not in a standard
nick!ident at hostname.com <mailto:nick!ident at hostname.com>  format (like a
server would appear in the format "I.am.a.server"), it uses "" as the CTCP
reply nick, and the code ends up using the intended reply string as the
nickname

 

In this case, user!foo at bar.com <mailto:user!foo at bar.com>  versioned the bot,
this is what it sends back:

[h->] NOTICE user :VERSION eggdrop v1.8.0+preinit

 

Now, the server I.Am.A.Server versions the bot:

[h->] NOTICE  :VERSION eggdrop v1.8.0+preinit
 

Alas, no user! 
 

This patch checks to see if a nick is extracted from the hostmask that sent
the CTCP request and, if not, uses the entire hostmask as the reply
destination. 