### PR TITLE
Removes the EMAIL and URL fields from tcl-commands.doc

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -5,6 +5,9 @@ Eggdrop Changes (since version 1.8.0)
     _____________________________________________________________________
 
 1.8.0 (CVS):
+  
+  - Remove deprecated EMAIL and URL fields from tcl-commands.doc
+    Patch by: Geo
 
   - Throw error when writing to read-only variables in server module.
     Patch by: chrfle / Found by: thommey

--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -798,7 +798,7 @@ marked with vertical bars (|) on the left.
 
 
   getchanidle <nickname> <channel>
-    Returns: number of minutes that person has been idle; 0 if the
+    Returns: number of minutes that person has been idle; -1 if the
       specified user isn't on the channel
     Module: irc
 

--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -148,8 +148,6 @@ marked with vertical bars (|) on the left.
         INFO    - returns the user's global info line
         XTRA    - returns the user's XTRA info
         COMMENT - returns the master-visible only comment for the user
-        EMAIL   - returns the user's e-mail address
-        URL     - returns the user's url
         HANDLE  - returns the user's handle as it is saved in the userfile
         PASS    - returns the user's encrypted password
     Returns: info specific to each entry-type

--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -150,6 +150,8 @@ marked with vertical bars (|) on the left.
         COMMENT - returns the master-visible only comment for the user
         HANDLE  - returns the user's handle as it is saved in the userfile
         PASS    - returns the user's encrypted password
+      For additional custom user fields, to include the deprecated "EMAIL"
+      and "URL" fields, reference scripts/userinfo.tcl
     Returns: info specific to each entry-type
     Module: core
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -634,6 +634,7 @@ set global-flood-kick 3:10
 set global-flood-join 5:60
 set global-flood-ctcp 3:60
 set global-flood-nick 5:60
+set global-flood-size 1024:60
 set global-aop-delay 5:30
 set global-idle-kick 0
 set global-chanmode "nt"
@@ -796,6 +797,11 @@ set global-chanset {
 #    Set here how many nick changes in how many seconds from one host
 #    constitutes a flood. Setting this to 0 or 0:0 disables nick flood
 #    protection for the channel.
+#
+# flood-size 1024:60
+#    Set here how many bytes in how many seconds from one host constitutes
+#    a flood. Setting this to 0 or 0:0 disables size flood protection for
+#    the channel.
 #
 # A complete list of all available channel settings:
 #

--- a/src/chan.h
+++ b/src/chan.h
@@ -176,6 +176,8 @@ struct chanset_t {
   int flood_ctcp_time;
   int flood_nick_thr;
   int flood_nick_time;
+  int flood_size_thr;
+  int flood_size_time;
   int aop_min;
   int aop_max;
   long status;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -590,8 +590,9 @@ struct dupwait_info {
 #define FLOOD_JOIN       4
 #define FLOOD_KICK       5
 #define FLOOD_DEOP       6
+#define FLOOD_SIZE       7
 
-#define FLOOD_CHAN_MAX   7
+#define FLOOD_CHAN_MAX   8
 #define FLOOD_GLOBAL_MAX 3
 
 /* For local console: */

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -47,7 +47,8 @@ static char glob_chanset[512];
 /* Global flood settings */
 static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
            gfld_kick_thr, gfld_kick_time, gfld_join_thr, gfld_join_time,
-           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time;
+           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time,
+           gfld_size_thr, gfld_size_time;
 
 #include "channels.h"
 #include "cmdschan.c"
@@ -419,7 +420,7 @@ static void write_channels()
             "revenge-mode %d need-op %s need-invite %s need-key %s "
             "need-unban %s need-limit %s flood-chan %d:%d flood-ctcp %d:%d "
             "flood-join %d:%d flood-kick %d:%d flood-deop %d:%d "
-            "flood-nick %d:%d aop-delay %d:%d ban-type %d ban-time %d "
+            "flood-nick %d:%d flood-size %d:%d aop-delay %d:%d ban-type %d ban-time %d "
             "exempt-time %d invite-time %d %cenforcebans %cdynamicbans "
             "%cuserbans %cautoop %cautohalfop %cbitch %cgreet %cprotectops "
             "%cprotecthalfops %cprotectfriends %cdontkickops %cstatuslog "
@@ -434,6 +435,7 @@ static void write_channels()
             chan->flood_kick_thr, chan->flood_kick_time,
             chan->flood_deop_thr, chan->flood_deop_time,
             chan->flood_nick_thr, chan->flood_nick_time,
+            chan->flood_size_thr, chan->flood_size_time,
             chan->aop_min, chan->aop_max, chan->ban_type, chan->ban_time,
             chan->exempt_time, chan->invite_time,
             PLSMNS(channel_enforcebans(chan)),
@@ -832,6 +834,7 @@ static tcl_coups mychan_tcl_coups[] = {
   {"global-flood-join", &gfld_join_thr,  &gfld_join_time},
   {"global-flood-ctcp", &gfld_ctcp_thr,  &gfld_ctcp_time},
   {"global-flood-nick", &gfld_nick_thr,  &gfld_nick_time},
+  {"global-flood-size", &gfld_size_thr,  &gfld_size_time},
   {"global-aop-delay",  &global_aop_min, &global_aop_max},
   {NULL,                NULL,                       NULL}
 };
@@ -951,6 +954,10 @@ char *channels_start(Function *global_funcs)
   gfld_join_time = 60;
   gfld_ctcp_thr = 5;
   gfld_ctcp_time = 60;
+  gfld_nick_thr = 5;
+  gfld_nick_time = 60;
+  gfld_size_thr = 1024;
+  gfld_size_time = 60;
   global_idle_kick = 0;
   global_aop_min = 5;
   global_aop_max = 30;

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1426,15 +1426,17 @@ static void cmd_chaninfo(struct userrec *u, int idx, char *par)
     }
 
 
-    dprintf(idx, "flood settings: chan ctcp join kick deop nick\n");
-    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d\n",
+    dprintf(idx, "flood settings: chan ctcp join kick deop nick size\n");
+    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d %4d\n",
             chan->flood_pub_thr, chan->flood_ctcp_thr,
             chan->flood_join_thr, chan->flood_kick_thr,
-            chan->flood_deop_thr, chan->flood_nick_thr);
-    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d\n",
+            chan->flood_deop_thr, chan->flood_nick_thr,
+            chan->flood_size_thr);
+    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d  %3d\n",
             chan->flood_pub_time, chan->flood_ctcp_time,
             chan->flood_join_time, chan->flood_kick_time,
-            chan->flood_deop_time, chan->flood_nick_time);
+            chan->flood_deop_time, chan->flood_nick_time,
+            chan->flood_size_time);
     putlog(LOG_CMDS, "*", "#%s# chaninfo %s", dcc[idx].nick, chname);
   }
 }

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -784,6 +784,8 @@ static int tcl_channel_info(Tcl_Interp *irp, struct chanset_t *chan)
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->flood_nick_thr, chan->flood_nick_time);
   Tcl_AppendElement(irp, s);
+  simple_sprintf(s, "%d:%d", chan->flood_size_thr, chan->flood_size_time);
+  Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->aop_min, chan->aop_max);
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d", chan->ban_type);
@@ -1109,6 +1111,8 @@ static int tcl_channel_get(Tcl_Interp *irp, struct chanset_t *chan,
     simple_sprintf(s, "%d %d", chan->flood_deop_thr, chan->flood_deop_time);
   else if (!strcmp(setting, "flood-nick"))
     simple_sprintf(s, "%d %d", chan->flood_nick_thr, chan->flood_nick_time);
+  else if (!strcmp(setting, "flood-size"))
+    simple_sprintf(s, "%d %d", chan->flood_size_thr, chan->flood_size_time);
   else if (!strcmp(setting, "aop-delay"))
     simple_sprintf(s, "%d %d", chan->aop_min, chan->aop_max);
   else if CHKFLAG_POS(CHAN_ENFORCEBANS, "enforcebans", chan->status)
@@ -1500,6 +1504,9 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
       } else if (!strcmp(item[i] + 6, "nick")) {
         pthr = &chan->flood_nick_thr;
         ptime = &chan->flood_nick_time;
+      } else if (!strcmp(item[i] + 6, "size")) {
+        pthr = &chan->flood_size_thr;
+        ptime = &chan->flood_size_time;
       } else {
         if (irp)
           Tcl_AppendResult(irp, "illegal channel flood type: ", item[i], NULL);
@@ -2062,6 +2069,8 @@ static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
     chan->flood_kick_time = gfld_kick_time;
     chan->flood_nick_thr = gfld_nick_thr;
     chan->flood_nick_time = gfld_nick_time;
+    chan->flood_size_thr = gfld_size_thr;
+    chan->flood_size_time = gfld_size_time;
     chan->stopnethack_mode = global_stopnethack_mode;
     chan->revenge_mode = global_revenge_mode;
     chan->ban_type = global_ban_type;

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -71,7 +71,7 @@ static void recheck_channel(struct chanset_t *, int);
 static void set_key(struct chanset_t *, char *);
 static void maybe_revenge(struct chanset_t *, char *, char *, int);
 static int detect_chan_flood(char *, char *, char *, struct chanset_t *, int,
-                             char *);
+                             char *, int);
 static void newmask(masklist *, char *, char *);
 static char *quickban(struct chanset_t *, char *);
 static void got_op(struct chanset_t *chan, char *nick, char *from, char *who,

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -655,7 +655,7 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
 
   /* Check for mass deop */
   if (nick[0])
-    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who);
+    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who, 0);
 
   /* Having op hides your +v and +h status -- so now that someone's lost ops,
    * check to see if they have +v or +h

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -530,7 +530,7 @@ static int tcl_getchanidle STDVAR
     Tcl_AppendResult(irp, s, NULL);
     return TCL_OK;
   }
-  Tcl_AppendResult(irp, "0", NULL);
+  Tcl_AppendResult(irp, "-1", NULL);
   return TCL_OK;
 }
 

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -247,10 +247,9 @@
 #define dcc_total (*(int*)global[111])
 /* 112 - 115 */
 #define tempdir ((char *)(global[112]))
-#define natip ((char *)(global[113]))
 #ifdef TLS
-#  define tls_vfyclients (*(int *)(global[114]))
-#  define tls_vfydcc (*(int *)(global[115]))
+#  define tls_vfyclients (*(int *)(global[113]))
+#  define tls_vfydcc (*(int *)(global[114]))
 #else
 /* was natip -- UNUSED */
 /* was hostname -- UNUSED */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -484,6 +484,9 @@ static int gotmsg(char *from, char *msg)
   fixcolon(msg);
   strncpyz(uhost, from, sizeof(buf));
   nick = splitnick(&uhost);
+  /* Apparently servers can send CTCPs now too, not just nicks */
+  if (nick[0] == '\0')
+    nick = uhost;
  
   /* Check for CTCP: */
   ctcp_reply[0] = 0;

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -583,7 +583,7 @@ static int tcl_setuser STDVAR
       return TCL_OK; /* Silently ignore user * */
   }
   me = module_find("irc", 0, 0);
-  if (me && !strcmp(argv[2], "hosts") && argc == 3) {
+  if (me && !strcasecmp(argv[2], "hosts") && argc == 3) {
     Function *func = me->funcs;
 
     (func[IRC_CHECK_THIS_USER]) (argv[1], 1, NULL);
@@ -601,7 +601,7 @@ static int tcl_setuser STDVAR
       (struct list_type *) e)))
     nfree(e);
     /* else maybe already freed... (entry_type==HOSTS) <drummer> */
-  if (me && !strcmp(argv[2], "hosts") && argc == 4) {
+  if (me && !strcasecmp(argv[2], "hosts") && argc == 4) {
     Function *func = me->funcs;
 
     (func[IRC_CHECK_THIS_USER]) (argv[1], 0, NULL);


### PR DESCRIPTION
Removes the EMAIL and URL fields from tcl-commands.doc . these were removed
some time ago in code, but documentation appears not to have been updated
along with it. 

Example:

---

<user> .tcl getuser user LASTON

<bot> Tcl: 1413684437 partyline

<user> .tcl getuser user EMAIL

<bot> Tcl error: No such info type: EMAIL

<user> .tcl getuser user URL

<bot> Tcl error: No such info type: URL
