### PR TITLE
Mode change after host add

### DIFF
--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -583,7 +583,7 @@ static int tcl_setuser STDVAR
       return TCL_OK; /* Silently ignore user * */
   }
   me = module_find("irc", 0, 0);
-  if (me && !strcmp(argv[2], "hosts") && argc == 3) {
+  if (me && !strcasecmp(argv[2], "hosts") && argc == 3) {
     Function *func = me->funcs;
 
     (func[IRC_CHECK_THIS_USER]) (argv[1], 1, NULL);
@@ -601,7 +601,7 @@ static int tcl_setuser STDVAR
       (struct list_type *) e)))
     nfree(e);
     /* else maybe already freed... (entry_type==HOSTS) <drummer> */
-  if (me && !strcmp(argv[2], "hosts") && argc == 4) {
+  if (me && !strcasecmp(argv[2], "hosts") && argc == 4) {
     Function *func = me->funcs;
 
     (func[IRC_CHECK_THIS_USER]) (argv[1], 0, NULL);


### PR DESCRIPTION
While helping a user having issues with a tcl script, it was discovered that
eggdrop did not execute any flag actions (ie, op'ing a user) after a host
was added via 'setuser handle HOSTS hostmask'. Digging in to the code, it
turns out the comparison used on that argument for setuser was case
sensitive, and set to 'hosts' as opposed to 'HOSTS' as listed in the
documentation. This patch simply turns the strcmp into strcasecmp so as to
alleviate case-sensitivity issues. Thanks to thommey for finding the actual
problem
