### PR TITLE
Return -1 for idletime if user not on channel

### DIFF
--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -798,7 +798,7 @@ marked with vertical bars (|) on the left.
 
 
   getchanidle <nickname> <channel>
-    Returns: number of minutes that person has been idle; 0 if the
+    Returns: number of minutes that person has been idle; -1 if the
       specified user isn't on the channel
     Module: irc
 

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -530,7 +530,7 @@ static int tcl_getchanidle STDVAR
     Tcl_AppendResult(irp, s, NULL);
     return TCL_OK;
   }
-  Tcl_AppendResult(irp, "0", NULL);
+  Tcl_AppendResult(irp, "-1", NULL);
   return TCL_OK;
 }
 


### PR DESCRIPTION
Currently getchanidle returns 0 if the user is not on channel- the same
value it would return if a user has spoken within the previous 60 seconds.
This patch updates the return value for a user not existing on the channel
from '0' to a more intuitive and non-conflicting '-1' return code. 
