### PR TITLE
fix assoc module local channels

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -6,6 +6,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0 (CVS):
 
+  - Fixed assoc module ability to work with local partyline channels.
+    Patch by: Geo / Found by: mw
+
   - Update botname after +i/+x
     Patch by: Pixelz / Found by: Domino
 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1854,7 +1854,9 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
 static void cmd_chat(struct userrec *u, int idx, char *par)
 {
   char *arg;
-  int newchan, oldchan;
+  int localchan = 0;
+  int newchan = 0;
+  int oldchan;
   module_entry *me;
 
   arg = newsplit(&par);
@@ -1906,6 +1908,9 @@ static void cmd_chat(struct userrec *u, int idx, char *par)
           if ((Tcl_VarEval(interp, "assoc ", "$_chan", NULL) == TCL_OK) &&
               !tcl_resultempty())
             newchan = tcl_resultint();
+            if ((newchan >= GLOBAL_CHANS) && (newchan <= 199999)) {
+              localchan = 1;
+            }
           else
             newchan = -1;
         }
@@ -1915,7 +1920,8 @@ static void cmd_chat(struct userrec *u, int idx, char *par)
         }
       } else
         newchan = atoi(arg);
-      if ((newchan < 0) || (newchan >= GLOBAL_CHANS)) {
+      if ((newchan < 0) || ((newchan >= GLOBAL_CHANS) && (!localchan)) ||
+          (newchan >= 199999)) {
         dprintf(idx, "Channel number out of range: must be between 0 and %d."
                 "\n", GLOBAL_CHANS);
         return;


### PR DESCRIPTION
This patch addresses issue #105 

To summarize the issue:

<me> .assoc *3 asdasd
<bot> [13:29:24] #me# assoc 100003 asdasd
<bot> Okay, channel *3 is 'asdasd' now.
<me> .chat asdasd
<bot> Channel number out of range: must be between 0 and 100000.

Added a variable to track if the channel returned by the tcl 'assoc' command
was in the local channel range, and then use that when cmds.c checking to
see if the channel # is outside the allowed channel range. 

A few test cases:

<me> .assoc *3 asdasd
<me> .chat asdasd
<bot> Joining channel 'asdasd'...
<me> .tcl getchan [hand2idx me]
<bot> Tcl: 100003

<me> .assoc *0 asd
<me> .chat asd
<bot> Joining channel 'asd'...
<me> .tcl getchan [hand2idx me]
<bot> Tcl: 100000

<me> .chat 100004
<bot> Channel number out of range: must be between 0 and 100000.

<me> .chat _4
<bot> Joining channel '_4'...
<me> .tcl getchan [hand2idx me]
<bot> Tcl: 100004
