### PR TITLE
fix duplicate array mask value

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -247,10 +247,9 @@
 #define dcc_total (*(int*)global[111])
 /* 112 - 115 */
 #define tempdir ((char *)(global[112]))
-#define natip ((char *)(global[113]))
 #ifdef TLS
-#  define tls_vfyclients (*(int *)(global[114]))
-#  define tls_vfydcc (*(int *)(global[115]))
+#  define tls_vfyclients (*(int *)(global[113]))
+#  define tls_vfydcc (*(int *)(global[114]))
 #else
 /* was natip -- UNUSED */
 /* was hostname -- UNUSED */


### PR DESCRIPTION
A user (didn't save the nick, sorry!) noticed that module.h contained both 

```
#  define tls_vfydcc (*(int *)(global[115]))
```

 and 

```
#define origbotname ((char *)(global[115]))
```

Whoops! After waaaay too much thought on how to avoid the duplication
(moving it around, etc) I finally realized that it appears when the SSL
shizz was inserted to this section, the coder forgot to delete natip (which
is mentioned in the notes as being done.) and then kept counting from the
now off-by-one value. Comparing this to the structure in modules.c also
confirms this. This patch simply removes natip as was intended, and properly
renumbers the array so as to avoid conflicts. 
