### PR TITLE
Add byte-based flood option

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -634,6 +634,7 @@ set global-flood-kick 3:10
 set global-flood-join 5:60
 set global-flood-ctcp 3:60
 set global-flood-nick 5:60
+set global-flood-size 1024:60
 set global-aop-delay 5:30
 set global-idle-kick 0
 set global-chanmode "nt"
@@ -796,6 +797,11 @@ set global-chanset {
 #    Set here how many nick changes in how many seconds from one host
 #    constitutes a flood. Setting this to 0 or 0:0 disables nick flood
 #    protection for the channel.
+#
+# flood-size 1024:60
+#    Set here how many bytes in how many seconds from one host constitutes
+#    a flood. Setting this to 0 or 0:0 disables size flood protection for
+#    the channel.
 #
 # A complete list of all available channel settings:
 #

--- a/src/chan.h
+++ b/src/chan.h
@@ -176,6 +176,8 @@ struct chanset_t {
   int flood_ctcp_time;
   int flood_nick_thr;
   int flood_nick_time;
+  int flood_size_thr;
+  int flood_size_time;
   int aop_min;
   int aop_max;
   long status;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -590,8 +590,9 @@ struct dupwait_info {
 #define FLOOD_JOIN       4
 #define FLOOD_KICK       5
 #define FLOOD_DEOP       6
+#define FLOOD_SIZE       7
 
-#define FLOOD_CHAN_MAX   7
+#define FLOOD_CHAN_MAX   8
 #define FLOOD_GLOBAL_MAX 3
 
 /* For local console: */

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -47,7 +47,8 @@ static char glob_chanset[512];
 /* Global flood settings */
 static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
            gfld_kick_thr, gfld_kick_time, gfld_join_thr, gfld_join_time,
-           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time;
+           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time,
+           gfld_size_thr, gfld_size_time;
 
 #include "channels.h"
 #include "cmdschan.c"
@@ -419,7 +420,7 @@ static void write_channels()
             "revenge-mode %d need-op %s need-invite %s need-key %s "
             "need-unban %s need-limit %s flood-chan %d:%d flood-ctcp %d:%d "
             "flood-join %d:%d flood-kick %d:%d flood-deop %d:%d "
-            "flood-nick %d:%d aop-delay %d:%d ban-type %d ban-time %d "
+            "flood-nick %d:%d flood-size %d:%d aop-delay %d:%d ban-type %d ban-time %d "
             "exempt-time %d invite-time %d %cenforcebans %cdynamicbans "
             "%cuserbans %cautoop %cautohalfop %cbitch %cgreet %cprotectops "
             "%cprotecthalfops %cprotectfriends %cdontkickops %cstatuslog "
@@ -434,6 +435,7 @@ static void write_channels()
             chan->flood_kick_thr, chan->flood_kick_time,
             chan->flood_deop_thr, chan->flood_deop_time,
             chan->flood_nick_thr, chan->flood_nick_time,
+            chan->flood_size_thr, chan->flood_size_time,
             chan->aop_min, chan->aop_max, chan->ban_type, chan->ban_time,
             chan->exempt_time, chan->invite_time,
             PLSMNS(channel_enforcebans(chan)),
@@ -832,6 +834,7 @@ static tcl_coups mychan_tcl_coups[] = {
   {"global-flood-join", &gfld_join_thr,  &gfld_join_time},
   {"global-flood-ctcp", &gfld_ctcp_thr,  &gfld_ctcp_time},
   {"global-flood-nick", &gfld_nick_thr,  &gfld_nick_time},
+  {"global-flood-size", &gfld_size_thr,  &gfld_size_time},
   {"global-aop-delay",  &global_aop_min, &global_aop_max},
   {NULL,                NULL,                       NULL}
 };
@@ -951,6 +954,10 @@ char *channels_start(Function *global_funcs)
   gfld_join_time = 60;
   gfld_ctcp_thr = 5;
   gfld_ctcp_time = 60;
+  gfld_nick_thr = 5;
+  gfld_nick_time = 60;
+  gfld_size_thr = 1024;
+  gfld_size_time = 60;
   global_idle_kick = 0;
   global_aop_min = 5;
   global_aop_max = 30;

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1426,15 +1426,17 @@ static void cmd_chaninfo(struct userrec *u, int idx, char *par)
     }
 
 
-    dprintf(idx, "flood settings: chan ctcp join kick deop nick\n");
-    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d\n",
+    dprintf(idx, "flood settings: chan ctcp join kick deop nick size\n");
+    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d %4d\n",
             chan->flood_pub_thr, chan->flood_ctcp_thr,
             chan->flood_join_thr, chan->flood_kick_thr,
-            chan->flood_deop_thr, chan->flood_nick_thr);
-    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d\n",
+            chan->flood_deop_thr, chan->flood_nick_thr,
+            chan->flood_size_thr);
+    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d  %3d\n",
             chan->flood_pub_time, chan->flood_ctcp_time,
             chan->flood_join_time, chan->flood_kick_time,
-            chan->flood_deop_time, chan->flood_nick_time);
+            chan->flood_deop_time, chan->flood_nick_time,
+            chan->flood_size_time);
     putlog(LOG_CMDS, "*", "#%s# chaninfo %s", dcc[idx].nick, chname);
   }
 }

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -784,6 +784,8 @@ static int tcl_channel_info(Tcl_Interp *irp, struct chanset_t *chan)
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->flood_nick_thr, chan->flood_nick_time);
   Tcl_AppendElement(irp, s);
+  simple_sprintf(s, "%d:%d", chan->flood_size_thr, chan->flood_size_time);
+  Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->aop_min, chan->aop_max);
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d", chan->ban_type);
@@ -1109,6 +1111,8 @@ static int tcl_channel_get(Tcl_Interp *irp, struct chanset_t *chan,
     simple_sprintf(s, "%d %d", chan->flood_deop_thr, chan->flood_deop_time);
   else if (!strcmp(setting, "flood-nick"))
     simple_sprintf(s, "%d %d", chan->flood_nick_thr, chan->flood_nick_time);
+  else if (!strcmp(setting, "flood-size"))
+    simple_sprintf(s, "%d %d", chan->flood_size_thr, chan->flood_size_time);
   else if (!strcmp(setting, "aop-delay"))
     simple_sprintf(s, "%d %d", chan->aop_min, chan->aop_max);
   else if CHKFLAG_POS(CHAN_ENFORCEBANS, "enforcebans", chan->status)
@@ -1500,6 +1504,9 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
       } else if (!strcmp(item[i] + 6, "nick")) {
         pthr = &chan->flood_nick_thr;
         ptime = &chan->flood_nick_time;
+      } else if (!strcmp(item[i] + 6, "size")) {
+        pthr = &chan->flood_size_thr;
+        ptime = &chan->flood_size_time;
       } else {
         if (irp)
           Tcl_AppendResult(irp, "illegal channel flood type: ", item[i], NULL);
@@ -2062,6 +2069,8 @@ static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
     chan->flood_kick_time = gfld_kick_time;
     chan->flood_nick_thr = gfld_nick_thr;
     chan->flood_nick_time = gfld_nick_time;
+    chan->flood_size_thr = gfld_size_thr;
+    chan->flood_size_time = gfld_size_time;
     chan->stopnethack_mode = global_stopnethack_mode;
     chan->revenge_mode = global_revenge_mode;
     chan->ban_type = global_ban_type;

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -71,7 +71,7 @@ static void recheck_channel(struct chanset_t *, int);
 static void set_key(struct chanset_t *, char *);
 static void maybe_revenge(struct chanset_t *, char *, char *, int);
 static int detect_chan_flood(char *, char *, char *, struct chanset_t *, int,
-                             char *);
+                             char *, int);
 static void newmask(masklist *, char *, char *);
 static char *quickban(struct chanset_t *, char *);
 static void got_op(struct chanset_t *chan, char *nick, char *from, char *who,

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -655,7 +655,7 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
 
   /* Check for mass deop */
   if (nick[0])
-    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who);
+    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who, 0);
 
   /* Having op hides your +v and +h status -- so now that someone's lost ops,
    * check to see if they have +v or +h


### PR DESCRIPTION
Hi,

This is a patch for per host message length flood detection.  The variable
"flood-size" has been added to control this flood detection.  It is meant
to detect flood bots that send long lines of garbage to the channel but not
fast enough to trigger per message flood detection.  The code triggers the
same tcl binds that flood-chan triggers.  I wrote it for #C on EFNet.  We
found it useful and thought others might too.  I've set the defaults to
1024 bytes per client per 60 seconds.  The code has been running for about
a month and we have not yet had any false positives and caught plenty of
flood bots.

Thank you for your consideration.

Ralph Covelli

=voidptr= flood settings: chan ctcp join kick deop nick size
=voidptr= number:           14    3    4    3    3    5 1024
=voidptr= time  :           60   60   60   10   10   60   60
