### PR TITLE
fix failing alt hub links

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1068,6 +1068,7 @@ static void botlink_resolve_failure(int i)
 
 static void botlink_resolve_success(int i)
 {
+  int ret;
   int idx = dcc[i].u.dns->ibuf;
   char *linker = dcc[i].u.dns->cptr;
 
@@ -1080,8 +1081,8 @@ static void botlink_resolve_success(int i)
   nfree(linker);
   setsnport(dcc[i].sockname, dcc[i].port);
   dcc[i].sock = getsock(dcc[i].sockname.family, SOCK_STRONGCONN);
-  if (dcc[i].sock < 0 ||
-      open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0)
+  ret = open_telnet_raw(dcc[i].sock, &dcc[i].sockname);
+  if (dcc[i].sock < 0 || ret < 0)
     failed_link(i);
 #ifdef TLS
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -276,7 +276,7 @@ void failed_link(int idx)
   /* Try next port, if it makes sense (no AF_UNSPEC, ...) */
   killsock(dcc[idx].sock);
   dcc[idx].timeval = now;
-  if (open_telnet(idx, dcc[idx].host, dcc[idx].port + 1) == -1)
+  if (open_telnet(idx, dcc[idx].host, dcc[idx].port + 1) < 0)
     failed_link(idx);
 }
 


### PR DESCRIPTION
This patch addresses issue #80 , "Alternate hub linking not working,"
reported by Robby:

"When the primary (+h) hub goes down, the 1.8.0 eggdrop doesn't link to the
alternate (+a) hub on its own. This works perfect in eggdrop 1.6.20 though."

This issue here was the (errno == EINPROGRESS) . while the socket is waiting
for the three way handshake, that errno says "that socket is still in
progress of being built (ie, the three-way handshake hasn't completed), but
it should be done soon." The fault was that it then passes along the socket
descriptor, assuming success. If the socket does NOT succeed, such as in the
case of the hub being down, the socket descriptor has already been returned
as valid, and was not revisited to see if the connection had actually
succeeded or not. Thus the 'failed connection' portion of the code was never
triggered to start looking for an alternate hub. 

This was tested and shown to trigger the restructure upon a bot being
terminated, and ran for about a month with no noted adverse side effects.
While not extensive in the testing (high latency or unreliable networks,
etc) no bots spontaneously combusted while running the patch. 

 I think there's still room to improve this, but it is certainly a 90%
solution to fixing the initial bug.
