### PR TITLE
Fix gcc 5 compile errors

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -560,7 +560,7 @@ int open_address_listen(sockname_t *addr)
 /* Returns a socket number for a listening socket that will accept any
  * connection -- port # is returned in port
  */
-inline int open_listen(int *port)
+extern inline int open_listen(int *port)
 {
   int sock;
   sockname_t name;

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -113,7 +113,7 @@ static inline void tcl_bind_list_delete(tcl_bind_list_t *tl)
   nfree(tl);
 }
 
-inline void garbage_collect_tclhash(void)
+extern inline void garbage_collect_tclhash(void)
 {
   tcl_bind_list_t *tl, *tl_next, *tl_prev;
   tcl_bind_mask_t *tm, *tm_next, *tm_prev;


### PR DESCRIPTION
Regarding issue #123 

Referencing https://gcc.gnu.org/gcc-5/porting_to.html, this patch removes the errors. It has been tested on gcc 4.8.4 (ubuntu 14.04) and gcc 5.2.1 (Debian sid/testing). 
