### PR TITLE
Clarify SSL documentation and errors

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -77,12 +77,24 @@ Last revised: July 24, 2004
 
          [The following is performed from the directory installed above.]
 
-      5. Edit your config file completely.
+      5. By default, version 1.8 uses SSL to protect botnet links. If you intend
+         on linking 1.8 bots together, you must run:
 
-      6. Start the bot with the "-m" option to create a user file, i.e. './eggdrop
+            make ssl-cert
+
+         Or, if you installed your eggdrop to a different directory in step 4, you
+         will want to run:
+
+           make ssl-cert DEST=<directory>
+
+         Read docs/TLS for more info on this process.
+
+      6. Edit your config file completely.
+
+      7. Start the bot with the "-m" option to create a user file, i.e. './eggdrop
          -m LamestBot.conf'.
 
-      7. When starting the bot in the future, drop the "-m". If you have edited
+      8. When starting the bot in the future, drop the "-m". If you have edited
          your config file correctly, you can type:
 
            chmod u+x <my-config-file-name>
@@ -96,12 +108,12 @@ Last revised: July 24, 2004
          to start up your bot. For this to work, the top line of your script
          MUST contain the correct path to the Eggdrop executable.
 
-      8. It's advisable to run your bot via crontab, so that it will
+      9. It's advisable to run your bot via crontab, so that it will
          automatically restart if the machine goes down or (heaven forbid)
          the bot should crash. Look at 'scripts/botchk' and 'scripts/autobotchk'
          for a great start with crontabbing the bot.
 
-      9. Smile, and if you haven't already read the README file in its
+      10. Smile, and if you haven't already read the README file in its
          entirety, go take a long walk off a short pier.
 
   (3) MODULES

--- a/Makefile.in
+++ b/Makefile.in
@@ -293,8 +293,9 @@ modtest: conftest
 
 sslcert:
 	@if test ! -d $(DEST); then \
-		echo "You haven't installed eggdrop yet.";\
+		echo "You haven't installed eggdrop yet, or you installed using the DEST= flag.";\
 		echo "Please run \"make install\" first.";\
+		echo "If you have already run \"make install\" and used the DEST= command, please use it again here";\
 		exit 1;\
 	fi
 	@if test -f $(DEST)/eggdrop.key; then \
@@ -465,6 +466,8 @@ install-scripts:
 install-end:
 	@echo
 	@echo "Installation completed."
+	@echo ""
+	@echo "If you intend to use this bot as a botnet hub, please run \"make sslcert\" now,"
 	@echo ""
 	@echo "You MUST ensure that you edit/verify your configuration file."
 	@echo "An example configuration file, eggdrop.conf, is distributed with Eggdrop."

--- a/Makefile.in
+++ b/Makefile.in
@@ -295,7 +295,7 @@ sslcert:
 	@if test ! -d $(DEST); then \
 		echo "You haven't installed eggdrop yet, or you installed using the DEST= flag.";\
 		echo "Please run \"make install\" first.";\
-		echo "If you have already run \"make install\" and used the DEST= command, please use it again here";\
+		echo "If you have already run \"make install\" and used the DEST= option, please use it again here";\
 		exit 1;\
 	fi
 	@if test -f $(DEST)/eggdrop.key; then \
@@ -467,7 +467,9 @@ install-end:
 	@echo
 	@echo "Installation completed."
 	@echo ""
-	@echo "If you intend to use this bot as a botnet hub, please run \"make sslcert\" now,"
+	@echo "If you intend to use this bot as a botnet hub for other 1.8 bots using SSL,"
+    @echo "please run \"make sslcert\" now. If you installed eggdrop to a custom path"
+    @echo "during the make install process, use the same DEST= option here."
 	@echo ""
 	@echo "You MUST ensure that you edit/verify your configuration file."
 	@echo "An example configuration file, eggdrop.conf, is distributed with Eggdrop."

--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -5,6 +5,8 @@ Eggdrop Changes (since version 1.8.0)
     _____________________________________________________________________
 
 1.8.0 (CVS):
+  - Clarify SSL documentation, add error messages
+    Patch by: Geo
 
   - Throw error when writing to read-only variables in server module.
     Patch by: chrfle / Found by: thommey

--- a/doc/TLS
+++ b/doc/TLS
@@ -100,7 +100,7 @@ Last revised: Oct 17, 2010
     The easy way to create a key and a certificate is to type 'make sslcert'
     after compiling your bot (If you installed eggdrop to a non-standard
     location, use make sslcert DEST=/path/to/eggdrop). This will generate a
-    2048-bit private key (eggdrop.key) and a certificate (eggdrop.crt) after
+    4096-bit private key (eggdrop.key) and a certificate (eggdrop.crt) after
     you fill in therequired fields.
 
     To authenticate with a certificate instead of using password, you should

--- a/doc/TLS
+++ b/doc/TLS
@@ -98,9 +98,11 @@ Last revised: Oct 17, 2010
     public key infrastructure can be obtained from Internet. This document
     only contains eggdrop-specific information on the subject.
     The easy way to create a key and a certificate is to type 'make sslcert'
-    after compiling your bot. This will generate a 2048-bit private key
-    (eggdrop.key) and a certificate (eggdrop.crt) after you fill in the
-    required fields.
+    after compiling your bot (If you installed eggdrop to a non-standard
+    location, use make sslcert DEST=/path/to/eggdrop). This will generate a
+    2048-bit private key (eggdrop.key) and a certificate (eggdrop.crt) after
+    you fill in therequired fields.
+
     To authenticate with a certificate instead of using password, you should
     make a ssl certificate for yourself and enable ssl-cert-auth in the config
     file. Then either connect to the bot using SSL and type ".fprint +" or

--- a/doc/html/egg-core.html
+++ b/doc/html/egg-core.html
@@ -896,12 +896,12 @@
           
          <blockquote>
 <pre>
-openssl genrsa -out eggdrop.key 2048
+openssl genrsa -out eggdrop.key 4096
 </pre>
         </blockquote>
 
          
-        <p>It will create a 2048 bit RSA key, strong enough for eggdrop.
+        <p>It will create a 4096 bit RSA key, strong enough for eggdrop.
         This is required for SSL hubs/listen ports, secure file transfer and
         /ctcp botnick schat
         For your convenience, you can type 'make sslcert' after 'make

--- a/doc/settings/core.settings
+++ b/doc/settings/core.settings
@@ -536,9 +536,9 @@ Last revised: October 25, 2010
       File containing your private key, needed for the SSL certificate
       (see below). You can create one issuing the following command:
 
-        openssl genrsa -out eggdrop.key 2048
+        openssl genrsa -out eggdrop.key 4096
 
-      It will create a 2048 bit RSA key, strong enough for eggdrop.
+      It will create a 4096 bit RSA key, strong enough for eggdrop.
       This is required for SSL hubs/listen ports, secure file transfer and
       /ctcp botnick schat
       For your convenience, you can type 'make sslcert' after 'make install'

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -353,9 +353,9 @@ set resolve-timeout 7
 # File containing your private key, needed for the SSL certificate
 # (see below). You can create one issuing the following command:
 #
-#   openssl genrsa -out eggdrop.key 2048
+#   openssl genrsa -out eggdrop.key 4096
 #
-# It will create a 2048 bit RSA key, strong enough for eggdrop.
+# It will create a 4096 bit RSA key, strong enough for eggdrop.
 # For your convenience, you can type 'make sslcert' after 'make install'
 # and you'll get a key and a certificate in your eggdrop directory.
 # If you installed to a non-default location, use 'make sslcert DEST=...'

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -346,6 +346,9 @@ set resolve-timeout 7
 
 # Settings in this section take effect when eggdrop is compiled with TLS
 # support.
+#
+# IMPORTANT: The following two settings MUST be uncommented in order to
+# use SSL functionality!
 
 # File containing your private key, needed for the SSL certificate
 # (see below). You can create one issuing the following command:
@@ -353,10 +356,12 @@ set resolve-timeout 7
 #   openssl genrsa -out eggdrop.key 2048
 #
 # It will create a 2048 bit RSA key, strong enough for eggdrop.
-# This is required for SSL hubs/listen ports, secure file transfer and
-# /ctcp botnick schat
 # For your convenience, you can type 'make sslcert' after 'make install'
-# and you'll get a key and a certificate in your DEST directory.
+# and you'll get a key and a certificate in your eggdrop directory.
+# If you installed to a non-default location, use 'make sslcert DEST=...'
+#
+# THIS IS REQUIRED if you intend to use this bot as a hub for SSL hubs/
+# listen ports, secure file transfer and /ctcp botnick schat
 #set ssl-privatekey "eggdrop.key"
 
 # Specify the filename where your SSL certificate is located. If you
@@ -367,10 +372,12 @@ set resolve-timeout 7
 #
 #   openssl req -new -key eggdrop.key -x509 -out eggdrop.crt -days 365
 #
-# This is required for SSL hubs/listen ports, secure file transfer and
-# /ctcp botnick schat
 # For your convenience, you can type 'make sslcert' after 'make install'
-# and you'll get a key and a certificate in your DEST directory.
+# and you'll get a key and a certificate in your eggdrop directory.
+# If you installed to a non-default location, use 'make sslcert DEST=...'
+#
+# THIS IS REQUIRED if you intend to use this bot as a hub for SSL hubs/
+# listen ports, secure file transfer and /ctcp botnick schat
 #set ssl-certificate "eggdrop.crt"
 
 # Sets the maximum depth for the certificate chain verification that will

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -44,7 +44,7 @@ extern int egg_numver, connect_timeout, conmask, backgrd, max_dcc,
            par_telnet_flood;
 
 #ifdef TLS
-extern int tls_vfybots;
+extern int tls_vfybots, ssl_files_loaded;
 
 int tls_vfyclients = 0;         /* Certificate validation mode for clients    */
 int tls_vfydcc = 0;             /* Verify DCC chat/send user certificates     */
@@ -370,9 +370,12 @@ static void dcc_bot_new(int idx, char *buf, int x)
     if (dcc[idx].status & STAT_STARTTLS) {
       dcc[idx].ssl = 1;
       if (ssl_handshake(dcc[idx].sock, TLS_CONNECT, tls_vfybots, LOG_BOTS,
-                    dcc[idx].host, NULL))
+                    dcc[idx].host, NULL)) {
         putlog(LOG_BOTS, "*", "STARTTLS failed while linking to %s",
                dcc[idx].nick);
+        if !(ssl_files_loaded)
+          putlog(LOG_BOTS, "*", "SSL cert and/or key file not loaded");
+      }
       dcc[idx].status &= ~STAT_STARTTLS;
     }
 #endif

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -373,7 +373,7 @@ static void dcc_bot_new(int idx, char *buf, int x)
                     dcc[idx].host, NULL)) {
         putlog(LOG_BOTS, "*", "STARTTLS failed while linking to %s",
                dcc[idx].nick);
-        if !(ssl_files_loaded)
+        if (!ssl_files_loaded)
           putlog(LOG_BOTS, "*", "SSL cert and/or key file not loaded");
       }
       dcc[idx].status &= ~STAT_STARTTLS;

--- a/src/tls.c
+++ b/src/tls.c
@@ -38,6 +38,7 @@ extern int tls_vfydcc;
 extern struct dcc_t *dcc;
 
 int tls_maxdepth = 9;         /* Max certificate chain verification depth     */
+int ssl_files_loaded = 1;     /* Check for loaded SSL key/cert files          */
 SSL_CTX *ssl_ctx = NULL;      /* SSL context object                           */
 char *tls_randfile = NULL;    /* Random seed file for SSL                     */
 char tls_capath[121] = "";    /* Path to trusted CA certificates              */
@@ -140,9 +141,11 @@ int ssl_init()
   }
   /* Load our own certificate and private key. Mandatory for acting as
      server, because we don't support anonymous ciphers by default. */
-  if (SSL_CTX_use_certificate_chain_file(ssl_ctx, tls_certfile) != 1)
+  if (SSL_CTX_use_certificate_chain_file(ssl_ctx, tls_certfile) != 1) {
+    ssl_files_loaded = 0;
     debug1("TLS: unable to load own certificate: %s",
            ERR_error_string(ERR_get_error(), NULL));
+  }
   if (SSL_CTX_use_PrivateKey_file(ssl_ctx, tls_keyfile,
       SSL_FILETYPE_PEM) != 1)
     debug1("TLS: unable to load private key: %s",


### PR DESCRIPTION
This patch does three things: 
-          Updates error messages and documentation to identify issues with
  sslcert not installed to the proper locations if DEST= was used in the make
  install process,
-           clarify the eggdrop.conf file SSL documentation
-          Add debug error messages better identifying issues with ssl certs
-          Generally update SSL docs to make them clearer to folks who
  didn't write the code ;)
