### PR TITLE
Reset channel info on part/kick

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -6,6 +6,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0 (CVS):
 
+  - Reset channel info on part/kick
+    Patch by: Geo / Found by: multiple users
+
   - Fix duplicate array value in module API
     Patch by: Geo / Found by: IRC user
 

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1938,16 +1938,13 @@ static void init_channel(struct chanset_t *chan, int reset)
 {
   int flags = reset ? reset : CHAN_RESETALL;
 
-  if (!reset) {
-    chan->channel.key = nmalloc(1);
-    chan->channel.key[0] = 0;
-    chan->channel.members = 0;
-    chan->channel.member = nmalloc(sizeof(memberlist));
-    chan->channel.member->nick[0] = 0;
-    chan->channel.member->next = NULL;
-  }
+  chan->channel.key = nmalloc(1);
+  chan->channel.key[0] = 0;
+  chan->channel.members = 0;
+  chan->channel.member = nmalloc(sizeof(memberlist));
+  chan->channel.member->nick[0] = 0;
+  chan->channel.member->next = NULL;
   if (flags & CHAN_RESETMODES) {
-    if (!reset)
     chan->channel.mode = 0;
     chan->channel.maxmembers = 0;
   }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1157,7 +1157,7 @@ static int got315(char *from, char *msg)
   if (!ismember(chan, botname)) {      /* Am I on the channel now?          */
     putlog(LOG_MISC | LOG_JOIN, chan->dname, "Oops, I'm not really on %s.",
            chan->dname);
-    clear_channel(chan, 1);
+    clear_channel(chan, CHAN_RESETALL);
     chan->status &= ~CHAN_ACTIVE;
 
     key = chan->channel.key[0] ? chan->channel.key : chan->key_prot;
@@ -1989,7 +1989,7 @@ static int gotpart(char *from, char *msg)
   fixcolon(msg);
   chan = findchan(chname);
   if (chan && channel_inactive(chan)) {
-    clear_channel(chan, 1);
+    clear_channel(chan, CHAN_RESETALL);
     chan->status &= ~(CHAN_ACTIVE | CHAN_PEND);
     return 0;
   }
@@ -2023,7 +2023,7 @@ static int gotpart(char *from, char *msg)
              chan->dname);
     /* If it was me, all hell breaks loose... */
     if (match_my_nick(nick)) {
-      clear_channel(chan, 1);
+      clear_channel(chan, CHAN_RESETALL);
       chan->status &= ~(CHAN_ACTIVE | CHAN_PEND);
       if (!channel_inactive(chan)) {
 
@@ -2071,7 +2071,7 @@ static int gotkick(char *from, char *origmsg)
     else
       dprintf(DP_SERVER, "JOIN %s\n",
               chan->name[0] ? chan->name : chan->dname);
-    clear_channel(chan, 1);
+    clear_channel(chan, CHAN_RESETALL);
     return 0;                   /* rejoin if kicked before getting needed info <Wcc[08/08/02]> */
   }
   if (channel_active(chan)) {
@@ -2119,7 +2119,7 @@ static int gotkick(char *from, char *origmsg)
       else
         dprintf(DP_SERVER, "JOIN %s\n",
                 chan->name[0] ? chan->name : chan->dname);
-      clear_channel(chan, 1);
+      clear_channel(chan, CHAN_RESETALL);
     } else {
       killmember(chan, nick);
       check_lonely_channel(chan);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1132,7 +1132,7 @@ static char *irc_close()
   dprintf(DP_MODE, "JOIN 0\n");
 
   for (chan = chanset; chan; chan = chan->next)
-    clear_channel(chan, 1);
+    clear_channel(chan, CHAN_RESETALL);
   del_bind_table(H_topc);
   del_bind_table(H_splt);
   del_bind_table(H_sign);


### PR DESCRIPTION
Referencing issue #112 (which is actually a symptom of a larger problem, fixed by this PR). 

When the rest channel code was updated, it (awesomely) added the ability to selectively reset certain aspects of channel info, and the value used to specify what you wanted to reset was passed to clear_channel(). Previous to this update, clear_channel() was called usually in the form of:

```
clear_channel(channel, 1)
```

However, the update changed clear_channel() to take the 2nd arg as a bitmask for 'reset', which would contain which values you wanted to clear:

```
int flags = reset ? reset : CHAN_RESETALL;
```

 Other calls to clear_channel() were missed from the update and still continued to use pass '1' as the reset value, which now maps to CHAN_RESETMODES- thus, only modes were being reset on a channel part. By modifying these calls to use CHAN_RESETALL (0x3F), peace and harmony is restored to the world again (and more importantly, the bot knows when its not on a channel after it parts or is kicked)

Testing:

```
.+chan #fffddd
[04:26:41] #user# +chan #fffddd
[04:26:42] bot joined #fffddd.
.tcl botonchan #fffddd
Tcl: 1
.chanset #fffddd +inactive
Successfully set modes { +inactive  } on #fffddd.
[04:26:55] #user# chanset #fffddd +inactive 
.tcl botonchan #fffddd
Tcl: 0
.chanset #fffddd -inactive
Successfully set modes { -inactive  } on #fffddd.
[04:27:11] #user# chanset #fffddd -inactive 
[04:27:13] bot joined #fffddd.
.tcl botonchan #fffddd
Tcl: 1
[04:27:26] #fffddd: mode change '+b *!*@cpe.com' by user!user@cpe.com
[04:27:29] bot kicked from #fffddd by user: bot
.tcl botonchan #fffddd
Tcl: 0
```
