### PR TITLE
Fix init_channel logic/memory leak

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0 (CVS):
 
+  - Fix init_channel logic/memory leak
+    Patch by: Geo / Found by: Phiber2000
+
   - Prevent the user from installing into the source directory.
     Patch by: thommey / Found by: boubou
 

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1936,16 +1936,26 @@ static void init_channel(struct chanset_t *chan, int reset)
 {
   int flags = reset ? reset : CHAN_RESETALL;
 
-  chan->channel.key = nmalloc(1);
-  chan->channel.key[0] = 0;
-  chan->channel.members = 0;
-  chan->channel.member = nmalloc(sizeof(memberlist));
-  chan->channel.member->nick[0] = 0;
-  chan->channel.member->next = NULL;
+  if (flags & CHAN_RESETWHO) {
+    if (chan->channel.member) {
+      nfree(chan->channel.member); 
+    }
+    chan->channel.members = 0;
+    chan->channel.member = nmalloc(sizeof(memberlist));
+    chan->channel.member->nick[0] = 0;
+    chan->channel.member->next = NULL;
+  }
+
   if (flags & CHAN_RESETMODES) {
     chan->channel.mode = 0;
     chan->channel.maxmembers = 0;
+    if (chan->channel.key) {
+      nfree(chan->channel.key);
+    }
+    chan->channel.key = nmalloc(1);
+    chan->channel.key[0] = 0;
   }
+
   if (flags & CHAN_RESETBANS) {
     chan->channel.ban = nmalloc(sizeof(masklist));
     init_masklist(chan->channel.ban);


### PR DESCRIPTION
Fixes #141 

[06:53:39] [@] nick!user@host.com MODE #chan +o bot
[06:53:39] #chan: mode change '+o bot' by nick!user@host.com
[06:53:39] [!m] MODE #chan +eI
[06:53:39] [m->] MODE #chan +eI
[06:53:39] [@] kornbluth.freenode.net 349 bot #chan :End of Channel Exception List
[06:53:40] [@] kornbluth.freenode.net 347 bot #chan of Channel Invite List
.channel #chan
Channel #chan, 2 members, mode +stn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME    HANDLE     JOIN  IDLE  USER@HOST
@bot      bot    ---  N     <- it's me!
@user         user    ---  N      nick!user@host.com
