### PR TITLE
Allow botmasters to add shared bot hostmasks

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0 (CVS):
 
+  - Allow botmasters to add hosts to shared bots.
+    Patch by: Geo
+
   - Fix init_channel logic/memory leak
     Patch by: Geo / Found by: Phiber2000
 
@@ -95,7 +98,7 @@ Eggdrop Changes (since version 1.8.0)
 
   - Add Tcl8.6 and /usr/lib/x86_64-linux-gnu to Tcl search paths.
   - Ran autotools.
-    Patch by: Freeder
+    Patch by: Geo
 
   - Changed IRCnet's max-bans/max-modes to 64.
     Patch by: ente

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2629,7 +2629,7 @@ static void cmd_pls_host(struct userrec *u, int idx, char *par)
       dprintf(idx, "You can't add hostmasks to non-bots.\n");
       return;
     }
-    if (!glob_owner(fr) && glob_bot(fr2) && (bot_flags(u2) & BOT_SHARE)) {
+    if (!(glob_owner(fr) || glob_botmast(fr)) && glob_bot(fr2) && (bot_flags(u2) & BOT_SHARE)) {
       dprintf(idx, "You can't add hostmasks to share bots.\n");
       return;
     }


### PR DESCRIPTION
Existing +host code had this logic:

```
if (!glob_owner(fr) && glob_bot(fr2) && (bot_flags(u2) & BOT_SHARE)) {
dprintf(idx, "You can't add hostmasks to share bots.\n");
```

 I can't think of any reason a botmaster should not be able to add a host for
a shared bot. The userfile is shared, so if the botmaster is able to log on
one bot, the botmaster can log in to ANY bot, and just as easily add the
host that way. The current code just prevents the botmaster from doing it
when logged on to a different bot. This patch changes the logic to allow a
global botmaster (or owner) to make the change
