### PR TITLE
alias PASSWORD to PASS in msg cmds

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0 (CVS):
 
+  - Alias PASSWORD to PASS in msg cmds
+    Patch by: Geo
+
   - Add option to disable ident lookup
     Patch by: manuel
 

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -1147,6 +1147,7 @@ static cmd_t C_msg[] = {
   {"op",      "",    (IntFunc) msg_op,      NULL},
   {"halfop",  "",    (IntFunc) msg_halfop,  NULL},
   {"pass",    "",    (IntFunc) msg_pass,    NULL},
+  {"password","",    (IntFunc) msg_pass,    NULL},
   {"rehash",  "m",   (IntFunc) msg_rehash,  NULL},
   {"reset",   "m",   (IntFunc) msg_reset,   NULL},
   {"save",    "m",   (IntFunc) msg_save,    NULL},


### PR DESCRIPTION
In reference to #148, msg'ing the bot both pass and password:

[23:02] -> _bot_ pass
[23:02] -bot- You have a password set.
[23:02] -> _bot_ password
[23:02] -bot- You have a password set.
