### PR TITLE
Fail if SSL server attempted with no SSL support

### DIFF
--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -75,17 +75,16 @@ static void cmd_dump(struct userrec *u, int idx, char *par)
 static void cmd_jump(struct userrec *u, int idx, char *par)
 {
   char *other;
-#ifdef TLS
   char *sport;
-#endif
   int port;
 
   if (par[0]) {
     other = newsplit(&par);
-#ifdef TLS
     sport = newsplit(&par);
-    if (*sport == '+')
+    if (*sport == '+') {
+#ifdef TLS
       use_ssl = 1;
+    }
     else
       use_ssl = 0;
     port = atoi(sport);
@@ -96,7 +95,11 @@ static void cmd_jump(struct userrec *u, int idx, char *par)
     putlog(LOG_CMDS, "*", "#%s# jump %s %s%d %s", dcc[idx].nick, other,
            use_ssl ? "+" : "", port, par);
 #else
-    port = atoi(newsplit(&par));
+    putlog(LOG_MISC, "*", "Error: Attempted to jump to SSL-enabled \
+server, but Eggdrop was not compiled with SSL libraries. Skipping...");
+      return;
+    }
+    port = atoi(sport);
     if (!port)
       port = default_port;
     putlog(LOG_CMDS, "*", "#%s# jump %s %d %s", dcc[idx].nick, other,

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -963,6 +963,14 @@ static void add_server(const char *ss)
       !sscanf(ss, "%255[^:]:%10[+0-9]:%120s", name, port, pass))
     return;
 
+#ifndef TLS
+  if (port[0] == '+') {
+    putlog(LOG_MISC, "*", "ERROR: Attempted to add SSL-enabled server, but \
+Eggdrop was not compiled with SSL libraries. Skipping...");
+  return;
+  }
+#endif  
+
   x = nmalloc(sizeof(struct server_list));
   x->next = 0;
   x->realname = 0;


### PR DESCRIPTION
Patch by: Geo / Found by: thommey
Fixes #163 

Patch checks for SSL servers attempted to be loaded from config, and via the .jump command when the bot is not compiled with SSL support

When loading the bot:

```
[05:11:34] Module loaded: server          
[05:11:34] ERROR: Attempted to add SSL-enabled server, but Eggdrop was not compiled with SSL libraries. Skipping...
```

And when jumping the bot:

```
[05:12:24] .jump irc.com +7000
[05:12:25] Error: Attempted to jump to SSL-enabled server, but Eggdrop was not compiled with SSL libraries. Skipping...
```
