### PR TITLE
Add CTCP chat src IPv6 settings/selection logic

### DIFF
--- a/doc/IPV6
+++ b/doc/IPV6
@@ -80,7 +80,7 @@ Last revised: Jul 29, 2010
          the address to bind to for listening (telnet/bot ports, /ctcp chat,
          file send, script listen, etc.). Can be either an IPv4/IPv6 IP or a
          hostname. If a hostname resolves to both type of addresses,
-         prefer-ipv6 will determine which to be used. 
+         prefer-ipv6 will determine which is to be used. 
 
     Other affected variables:
 
@@ -114,7 +114,7 @@ Last revised: Jul 29, 2010
         * If nat-ip is set, this IP will be used.
 
         * If nat-ip is not set and listen-addr is set to a valid IPv4 address,
-          Eggdrop will used the IP.
+          Eggdrop will use the IP.
 
         * If listen-addr is not set, or set to :: or /0.0.0.0 (listening on
           all available interfaces), Eggdrop will check if vhost4 contains a

--- a/doc/IPV6
+++ b/doc/IPV6
@@ -56,7 +56,8 @@ Last revised: Jul 29, 2010
     Among other examples, these options can be useful in cases where an
     Eggdrop is configured to prefer IPv6 addresses, but a client only has
     IPv4 available.
-    
+
+    The same usage applies when using SCHAT4/SCHAT6.
 
 
   4. Settings

--- a/doc/IPV6
+++ b/doc/IPV6
@@ -48,6 +48,7 @@ Last revised: Jul 29, 2010
     are documented in the help files and the html documentation, so you can
     consult them when in doubt.
 
+
   4. Settings
  
     There are four new IPv6 related config variables:
@@ -77,6 +78,40 @@ Last revised: Jul 29, 2010
 
       nat-ip works with IPv4 as it used to. It has no meaning for IPv6 and is
         not queried for IPv6 connections.
+
+  5. Precedence
+
+    With all these settings, it can be confusing to follow what settings may 
+    override others when sending an IP for CTCP chat or file transfer. Here
+    is a quick overview of the network logic used by Eggdrop:
+
+      - If prefer-ipv6 is set to 1:
+
+        * If listen-addr is set to a valid IPv6 address, Eggdrop will use
+          the IP. 
+        
+        * If listen-addr is not set, or set to :: or 0.0.0.0 (listening on
+          all available interfaces), Eggdrop will check if vhost6 contains a
+          valid IPv6 address and, if so, use that IP.
+
+        * If vhost6 is not set, Eggdrop will attempt to resolve the hostname
+          of the machine to an IPv6 address via DNS lookup.
+
+      - If prefer-ipv6 is set to 0, OR is set to 1 but fails to identify an
+        address using the steps above:
+
+        * If nat-ip is set, this IP will be used.
+
+        * If nat-ip is not set and listen-addr is set to a valid IPv4 address,
+          Eggdrop will used the IP.
+
+        * If listen-addr is not set, or set to :: or /0.0.0.0 (listening on
+          all available interfaces), Eggdrop will check if vhost4 contains a
+          valid IPv4 address and, if so, use that IP. 
+
+        * If vhost4 is not set, Eggdrop will attempt to resolve the hostname
+          of the machine to an IPv4 address via DNS lookup.
+
     _____________________________________________________________________
 
   Copyright (C) 2010 - 2016 Eggheads Development Team

--- a/doc/IPV6
+++ b/doc/IPV6
@@ -47,6 +47,16 @@ Last revised: Jul 29, 2010
     the colon character (:) from being interpreted as a port separator. These
     are documented in the help files and the html documentation, so you can
     consult them when in doubt.
+ 
+    To specify which IP version you wish to use as a client, you can initiate
+    a DCC session by using /ctcp bot CHAT4 (which will require the bot to
+    initiate an IPv4 session) or /ctcp bot CHAT6 (which will require the bot
+    to initiate an IPv6 session). Using /ctcp bot CHAT will allow the bot's
+    configuration to determine whether an IPv4 or IPv6 connection is used.
+    Among other examples, these options can be useful in cases where an
+    Eggdrop is configured to prefer IPv6 addresses, but a client only has
+    IPv4 available.
+    
 
 
   4. Settings
@@ -85,7 +95,7 @@ Last revised: Jul 29, 2010
     override others when sending an IP for CTCP chat or file transfer. Here
     is a quick overview of the network logic used by Eggdrop:
 
-      - If prefer-ipv6 is set to 1:
+      - If prefer-ipv6 is set to 1 (and the client does not use CHAT4):
 
         * If listen-addr is set to a valid IPv6 address, Eggdrop will use
           the IP. 
@@ -98,7 +108,7 @@ Last revised: Jul 29, 2010
           of the machine to an IPv6 address via DNS lookup.
 
       - If prefer-ipv6 is set to 0, OR is set to 1 but fails to identify an
-        address using the steps above:
+        address using the steps above, AND the client does not use CHAT6:
 
         * If nat-ip is set, this IP will be used.
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -49,10 +49,35 @@ set offset "5"
 # but instead everywhere possible, un-comment the following line.
 #set env(TZ) "$timezone$offset"
 
+############################################################################
+# Network settings overview
+# With the addition of IPv6 and the associated config changes, here are some
+# BASIC common networking scenarios, along with the appropriate settings
+# needed:
+#
+# SHELL PROVIDER (MULTIPLE IPs/VHOSTS)
+# * set vhost4 or vhost6 to the IP/vhost you want to use
+# * set listen-addr to the same IP/vhost as above
+# 
+# HOME COMPUTER/VPS, DIRECT INTERNET CONNETION (SINGLE IP, NO NAT)
+# * do not set vhost4/vhost6
+# * do not set listen-addr
+#
+# HOME COMPUTER, BEHIND A NAT
+# * do not set vhost4/vhost6
+# * do not set listen-addr
+# * set nat-ip to your external IP
+#
+# Below is a detailed description of each setting, please read them to
+# learn more about their function.
+############################################################################
+
 # If you're using virtual hosting (your machine has more than 1 IP), you
 # may want to specify the particular IP to bind to. You can specify either
 # by hostname or by IP. Note that this is not used for listening. Use the
-# 'listen-addr' variable to specify the listening address.
+# 'listen-addr' variable to specify the listening address. If you are 
+# behind a NAT, you will likely want to leave this commented out as Eggdrop
+# should determine the correct IP on its own. 
 #set vhost4 "virtual.host.com"
 #set vhost4 "99.99.0.0"
 
@@ -457,8 +482,8 @@ set ssl-capath "/etc/ssl/"
 # address to a unique address for your box) or you have IP masquerading
 # between you and the rest of the world, and /dcc chat, /ctcp chat or
 # userfile sharing aren't working, enter your outside IP here. This IP
-# is used for transfers only, and has nothing to do with the vhost4/6
-# or listen-addr settings. You may still need to set them.
+# is used for transfers and CTCP replies only, and is different than the
+# vhost4/6 and listen-addr settings. You likely still need to set them.
 #set nat-ip "127.0.0.1"
 
 # If you want all dcc file transfers to use a particular portrange either

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -160,16 +160,20 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
 // * Check if SSL, IPv4, or IPv6 were requested
     if (
 #ifdef IPV6
-    (!egg_strcasecmp(keyword, "CHAT6"))) {
+    (!egg_strcasecmp(keyword, "CHAT6")) ||
+        (!egg_strcasecmp(keyword, "SCHAT6"))) {
       chatv = AF_INET6;
     } else if (
 #endif
 #ifdef TLS
-    (!egg_strcasecmp(keyword, "SCHAT"))) {
+    (!egg_strcasecmp(keyword, "SCHAT")) ||
+        (!egg_strcasecmp(keyword, "SCHAT4")) ||
+        (!egg_strcasecmp(keyword, "SCHAT6"))) {
       ssl = 1;
     } else if (
 #endif
-    (!egg_strcasecmp(keyword, "CHAT4"))) {
+    (!egg_strcasecmp(keyword, "CHAT4")) ||
+        (!egg_strcasecmp(keyword, "SCHAT4"))) {
       chatv = AF_INET;
     }
   
@@ -220,6 +224,8 @@ static cmd_t myctcp[] = {
 #endif
 #ifdef TLS
   {"SCHAT",      "",   ctcp_CHAT,       NULL},
+  {"SCHAT4",     "",   ctcp_CHAT,       NULL},
+  {"SCHAT6",     "",   ctcp_CHAT,       NULL},
 #endif
   {NULL,         NULL, NULL,            NULL}
 };

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -167,8 +167,10 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
 #endif
 #ifdef TLS
     (!egg_strcasecmp(keyword, "SCHAT")) ||
-        (!egg_strcasecmp(keyword, "SCHAT4")) ||
-        (!egg_strcasecmp(keyword, "SCHAT6"))) {
+#ifdef IPV6
+        (!egg_strcasecmp(keyword, "SCHAT6")) ||
+#endif
+        (!egg_strcasecmp(keyword, "SCHAT4"))) {
       ssl = 1;
     } else if (
 #endif

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -225,7 +225,9 @@ static cmd_t myctcp[] = {
 #ifdef TLS
   {"SCHAT",      "",   ctcp_CHAT,       NULL},
   {"SCHAT4",     "",   ctcp_CHAT,       NULL},
+#ifdef IPV6
   {"SCHAT6",     "",   ctcp_CHAT,       NULL},
+#endif
 #endif
   {NULL,         NULL, NULL,            NULL}
 };

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -503,6 +503,8 @@
 /* 300 - 303 */
 #define tcl_resultint ((int (*)(void))global[300])
 #define tcl_resultstring ((const char *(*)(void))global[301])
+#define getdccfamilyaddr ((int (*) (sockname_t *, char *, socklen_t, int))global[302])
+
 
 /* hostmasking */
 #define maskhost(a,b) maskaddr((a),(b),3)

--- a/src/modules.c
+++ b/src/modules.c
@@ -605,9 +605,10 @@ Function global_table[] = {
   (Function) increase_socks_max,
   (Function) log_ts,
   (Function) tcl_resultempty,
-  /* 300 - 304 */
+  /* 300 - 303 */
   (Function) tcl_resultint,
-  (Function) tcl_resultstring
+  (Function) tcl_resultstring,
+  (Function) getdccfamilyaddr
 };
 
 void init_modules(void)

--- a/src/proto.h
+++ b/src/proto.h
@@ -277,6 +277,7 @@ int open_telnet_raw(int, sockname_t *);
 int open_telnet(int, char *, int);
 int answer(int, sockname_t *, unsigned short *, int);
 int getdccaddr(sockname_t *, char *, size_t);
+int getdccfamilyaddr(sockname_t *, char *, size_t, int);
 void tputs(int, char *, unsigned int);
 void dequeue_sockets();
 int preparefdset(fd_set *, sock_list *, int, int, int);


### PR DESCRIPTION
Patch by Geo / Found by Geo, thommey, Robby
(sort of) fixes #159 

Note: if the host doesn't have an IPv6 AAAA DNS record, (obviously) DNS lookups will fail, potentially resulting in an IPv4 address being returned when you would expect an IPv6

Here are some peturbations of config and source IP combos, to give an idea of how this works:

```
set vhost6 "::::::::"
set prefer-ipv6 1
<no listen-addr>
```

DCC CHAT from Broney [x:6f00:877::y:9a91 port 8014] *Note: this IP is the IPv6 AAAA record returned by DNS for the machine hostname

```
set vhost6 "::::::::"
set prefer-ipv6 0
<no listen-addr>
```

DCC CHAT from Broney [x.109.218.y port 8014] *Note: this IP is the IPv4 A record returned by DNS for the machine hostname

```
set vhost6 "x:6f00:877::y:7dbc"
set prefer-ipv6 0
<no listen-addr>
```

DCC CHAT from Broney [x.109.218.y port 8014] *Note: this IP is the IPv4 A record returned by DNS for the machine hostname

```
set vhost6 "x:6f00:877::y:7dbc"
set prefer-ipv6 1
<no listen-addr>
```

DCC CHAT from Broney [x:6f00:877::y:7dbc port 8014] *Note: vhost6 is used

```
set vhost6 "x:6f00:877::y:7dbc"
set listen-addr "x:6f00:877::y:9a91"
set prefer-ipv6 1
```

DCC CHAT from Broney [x:6f00:877::y:9a91 port 8014]

```
set vhost6 "x:6f00:877::y:7dbc"
set listen-addr "x:6f00:877::y:9a91"
set prefer-ipv6 0
```

DCC CHAT from Broney [x:6f00:877::y:9a91 port 8014]   \* Note: listen-addr trumps prefer-ipv6
