### PR TITLE
Log failed logins due to invalid handles to LOG_MISC instead of LOG_BOTS.

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1537,7 +1537,7 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
 
   if (!ok) {
     dprintf(idx, "You don't have access.\n");
-    putlog(LOG_BOTS, "*", DCC_INVHANDLE, dcc[idx].host, buf);
+    putlog(LOG_MISC, "*", DCC_INVHANDLE, dcc[idx].host, buf);
     killsock(dcc[idx].sock);
     lostdcc(idx);
     return;


### PR DESCRIPTION
Log failed logins due to invalid handles to LOG_MISC instead of LOG_BOTS.
Fixes #184
