### PR TITLE
Prevent msg commands from functioning without a password set

### DIFF
--- a/src/userrec.c
+++ b/src/userrec.c
@@ -355,7 +355,12 @@ struct userrec *get_user_by_equal_host(char *host)
 }
 
 /* Try: pass_match_by_host("-",host)
- * will return 1 if no password is set for that host
+ * If a '-' is sent as the password, it denotes the intent
+ *   to merely check if a password is set for that user.
+ * Returns 0 if password is set and does not match
+ * Returns 1 if password matches, or if we are
+ *   checking if a password is set and it is not
+ *   (via the '-' char).
  */
 int u_pass_match(struct userrec *u, char *pass)
 {
@@ -364,8 +369,11 @@ int u_pass_match(struct userrec *u, char *pass)
   if (!u)
     return 0;
   cmp = get_user(&USERENTRY_PASS, u);
-  if (!cmp && (!pass[0] || (pass[0] == '-')))
+  if (!cmp && (pass[0] == '-'))
     return 1;
+/* If password is not set in userrecord, or password
+ * is not sent, or '-' is sent
+ */
   if (!cmp || !pass || !pass[0] || (pass[0] == '-'))
     return 0;
   if (u->flags & USER_BOT) {


### PR DESCRIPTION
Found by: elWanderino
Patch by: Geo
Fixes: #188 

One-line summary:
Prevent msg commands from functioning without a password set

Additional description (if needed):
#188 - If a user does not have a password set, msg commands that require a password for that user can be used without providing one.

Test cases demonstrating functionality (if applicable):
Fresh install:

```
./eggdrop -mnt patchtest.conf
```

Let's try it out:

```
[22:04] -> *bot* rehash
```

//nothing happens//

```
[22:04] -> *bot* hello
[22:04] -bot- Hi Geo!  I'm bot, an egdrop bot.
[22:04] -bot- I'l recognize you by hostmask '*!*foo@bar.com' from now on.
[22:04] -bot- YOU ARE THE OWNER ON THIS BOT NOW
[22:04] -bot- As master you really need to set a password: with /MSG bot pass <your-chosen-password>.
[22:04] -bot- All major commands are used from DCC chat. From now on, you don't need to use the -m option when starting the bot. Enjoy !!!
[22:04] -> *bot* rehash
```

//nothing happens//

Now, let's try some of the other commands, such as PASS, which uses the same function to check if a password is set for the user:

```
[22:23] -> *bot* pass
[22:23] -bot- You don't have a password set.
[22:23] -> *bot* pass hi
[22:23] -bot- Please use at least 6 characters.
[22:23] -> *bot* pass hellothere
[22:23] -bot- Pasword set to: 'hellothere'.
[22:23] -> *bot* pass
[22:23] -bot- You have a password set.
[2:23] -> *bot* pass hhhhhh
[22:23] -bot- You already have a password set.
[2:24] -> *bot* pass hellothere hithere
[22:24] -bot- Password changed to: 'hithere'.
```

I think this covers the potential use cases - I skimmed through the rest of the codebase and nothing jumps out at me as failing as a result. 
