### PR TITLE
Fix DNS module not working with --disable-ipv6

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -190,7 +190,7 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
     addr->addr.s4.sin_family = AF_INET;
   }
 #else
-  int i; 
+  int i, count; 
 
   egg_bzero(addr, sizeof(sockname_t));
 
@@ -204,12 +204,19 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
  * Go internet.
  */
   if (!inet_pton(AF_INET, src, &addr->addr.s4.sin_addr)) {
-    /* Awesome way to count :s */
-    for (i=0; src[i]; src[i]==':' ? i++ : *src++);
-    if (i > 1) {
+    /* Boring way to count :s */
+    count = 0;
+    for (i = 0; src[i]; i++) {
+      if (src[i] == ':') {
+        count++;
+        if (count == 2)
+          break;
+      }
+    }
+    if (count > 1) {
       putlog(LOG_MISC, "*", "ERROR: This looks like an IPv6 address, \
 but this Eggdrop was not compiled with IPv6 support.");
-      af = AF_INET6;
+      af = AF_UNSPEC;
     }
     else if (allowres) {
     /* src is a hostname. Attempt to resolve it.. */


### PR DESCRIPTION
Found by: raclure
Patch by: Geo, thommey
Fixes: #93 #207 

One-line summary:
setsockname should return AF_UNSPEC when allowres is 0, which the DNS module uses to do non-blocking DNS lookups. 

Test cases demonstrating functionality (if applicable):

Fixed not-resolving hostnames with --disable-ipv6:

```
[19:59:42] Trying server [sinisalo.freenode.net]:6667
[19:59:42] DNS Resolver: Lookup successful: sinisalo.freenode.net
[19:59:42] DNS resolved sinisalo.freenode.net to 91.217.189.42
```

Additionally, instead of treating an IPv6 as a hostname, it now skips resolution and returns an error

```
[19:38:04] Trying server [2001:778:627f::1:0:49]:6667
[19:38:04] ERROR: Attempted to use IPv6 address, but IPv6 is not enabled on this eggdrop
[19:38:04] Warning: Can't create new socket: Address family not supported by protocol!
[19:38:04] ERROR: Attempted to use IPv6 address, but IPv6 is not enabled on this eggdrop
[19:38:04] Failed connect to 2001:778:627f::1:0:49 (Bad file descriptor)
```
