### PR TITLE
Remove a trailing space in eggdrop.conf.

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -300,7 +300,7 @@ set protect-telnet 0
 set dcc-sanitycheck 0
 
 # This setting defines the time in seconds the bot should wait for ident reply
-# before the lookup fails. The default ident on timeout is 'telnet'. A value of 
+# before the lookup fails. The default ident on timeout is 'telnet'. A value of
 # 0 disables the ident lookup entirely.
 set ident-timeout 5
 


### PR DESCRIPTION
Found by: Robby
Patch by: Robby
Fixes: Remove a trailing space in eggdrop.conf.

One-line summary:
Remove a trailing space in eggdrop.conf.

Additional description (if needed):
N/A

Test cases demonstrating functionality (if applicable):
N/A
