### PR TITLE
Reset channel info on server disconnect

### DIFF
--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -408,7 +408,7 @@ static int any_ops(struct chanset_t *chan)
 
 /* Reset channel information.
  */
-static void reset_chan_info(struct chanset_t *chan, int reset)
+void reset_chan_info(struct chanset_t *chan, int reset)
 {
   /* Leave the channel if we aren't supposed to be there */
   if (channel_inactive(chan)) {
@@ -1196,6 +1196,7 @@ static Function irc_table[] = {
   (Function) me_voice,
   /* 24 - 27 */
   (Function) getchanmode,
+  (Function) reset_chan_info
 };
 
 char *irc_start(Function *global_funcs)

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -64,7 +64,7 @@ static void refresh_who_chan(char *);
 #define resetinvites(chan)  resetmasks((chan), (chan)->channel.invite,       \
                                        (chan)->invites, global_invites, 'I')
 
-static void reset_chan_info(struct chanset_t *, int);
+void reset_chan_info(struct chanset_t *, int);
 static void recheck_channel(struct chanset_t *, int);
 static void set_key(struct chanset_t *, char *);
 static void maybe_revenge(struct chanset_t *, char *, char *, int);

--- a/src/mod/modvals.h
+++ b/src/mod/modvals.h
@@ -77,6 +77,7 @@
 #define IRC_DO_CHANNEL_PART       19
 #define IRC_CHECK_THIS_BAN        20
 #define IRC_CHECK_THIS_USER       21
+#define IRC_RESET_CHAN_INFO       25
 /* Notes */
 #define NOTES_CMD_NOTE            4
 /* Console */


### PR DESCRIPTION
Found by: renols
Patch by: Geo
Fixes: #203 

One-line summary:
Update channel info on server disconnect

Additional description (if needed):
Previous fix addressed channel parts/kicks, but missed separate code thread of dealing with server disconnects, such as when utilized via .jump. This exports reset_chan_info() to the server mod and calls when using from nuke_server().

Thanks to @rco133 for his continued persistence on this bug! 

Test cases demonstrating functionality (if applicable):

```
.tcl botonchan #geo
Tcl: 1
.jump
[18:52:21] #Geo# jump
Jumping servers......
[18:52:21] Trying server [foo.com]:+7000
[18:52:21] Failed connect to foo.com (Operation now in progress)
.tcl botonchan #geo
Tcl: 0
....
....
[19:02:20] myBot joined #geo
.tcl botonchan #geo
Tcl: 1
```
