### PR TITLE
Fix IPv6 pref_af #ifdef bug

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -687,7 +687,11 @@ int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
 #endif
      /* If IPv6 didn't work, or it's listening on an IPv4
         0.0.0.0 address, try using vhost4 as the source */
-    if ((!pref_af || af) && (restrict_af != AF_INET6)) {
+    if ((
+#ifdef IPV6
+      !pref_af ||
+#endif
+      af) && (restrict_af != AF_INET6)) {
       if (!egg_inet_aton(vhost, &r->addr.s4.sin_addr)) {
         /* And if THAT fails, try DNS resolution of hostname */
         r = &name;


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: NA

One-line summary:
Fix IPv6 pref_af #ifdef bug

Additional description (if needed):
    If compiled without IPv6 support, pref_af is improperly attempted for use. This adds
    the appropriate IPv6 #ifdef to exclude it from the conditional if IPv6 support is not
    compiled.

Test cases demonstrating functionality (if applicable):
