### PR TITLE
Fixes format string warnings (#195)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -518,7 +518,7 @@ static void do_arg(char *s)
         break;                  /* this should never be reached */
       case 'h':
         printf("\n%s\n\n", version);
-        printf(EGG_USAGE);
+        printf("%s\n", EGG_USAGE);
         printf("\n");
         bg_send_quit(BG_ABORT);
         exit(0);
@@ -1076,7 +1076,7 @@ int main(int arg_c, char **arg_v)
   putlog(LOG_ALL, "*", "--- Loading %s (%s)", ver, s);
   chanprog();
   if (!encrypt_pass) {
-    printf(MOD_NOCRYPT);
+    printf("%s\n", MOD_NOCRYPT);
     bg_send_quit(BG_ABORT);
     exit(1);
   }

--- a/src/main.c
+++ b/src/main.c
@@ -519,7 +519,6 @@ static void do_arg(char *s)
       case 'h':
         printf("\n%s\n\n", version);
         printf("%s\n", EGG_USAGE);
-        printf("\n");
         bg_send_quit(BG_ABORT);
         exit(0);
         break;                  /* this should never be reached */
@@ -1076,7 +1075,7 @@ int main(int arg_c, char **arg_v)
   putlog(LOG_ALL, "*", "--- Loading %s (%s)", ver, s);
   chanprog();
   if (!encrypt_pass) {
-    printf("%s\n", MOD_NOCRYPT);
+    printf("%s", MOD_NOCRYPT);
     bg_send_quit(BG_ABORT);
     exit(1);
   }

--- a/src/misc.c
+++ b/src/misc.c
@@ -599,8 +599,8 @@ void putlog EGG_VARARGS_DEF(int, arg1)
                * then reset repeats. We want the current time here,
                * so put that in the file first.
                */
-              fprintf(logs[i].f, "%s\n", stamp);
-              fprintf(logs[i].f, "%s %d\n", MISC_LOGREPEAT, logs[i].repeats);
+              fprintf(logs[i].f, "%s", stamp);
+              fprintf(logs[i].f, "%s %d", MISC_LOGREPEAT, logs[i].repeats);
               logs[i].repeats = 0;
               /* No need to reset logs[i].szlast here
                * because we update it later on...

--- a/src/misc.c
+++ b/src/misc.c
@@ -599,8 +599,8 @@ void putlog EGG_VARARGS_DEF(int, arg1)
                * then reset repeats. We want the current time here,
                * so put that in the file first.
                */
-              fprintf(logs[i].f, stamp);
-              fprintf(logs[i].f, MISC_LOGREPEAT, logs[i].repeats);
+              fprintf(logs[i].f, "%s\n", stamp);
+              fprintf(logs[i].f, "%s %d\n", MISC_LOGREPEAT, logs[i].repeats);
               logs[i].repeats = 0;
               /* No need to reset logs[i].szlast here
                * because we update it later on...

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -969,7 +969,7 @@ static void add_server(const char *ss)
 Eggdrop was not compiled with SSL libraries. Skipping...");
   return;
   }
-#endif  
+#endif
 
   x = nmalloc(sizeof(struct server_list));
   x->next = 0;
@@ -1601,7 +1601,7 @@ static void dcc_chat_hostresolved(int i)
   buf[0] = 0;
   dcc[i].sock = getsock(dcc[i].sockname.family, 0);
   if (dcc[i].sock < 0 || open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0)
-    snprintf(buf, sizeof buf, strerror(errno));
+    snprintf(buf, sizeof buf, "%s", strerror(errno));
 #ifdef TLS
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT, tls_vfydcc,
                                        LOG_MISC, dcc[i].host, &dcc_chat_sslcb))

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -783,7 +783,7 @@ static void display_dcc_send(int idx, char *buf)
 
 static void display_dcc_fork_send(int idx, char *buf)
 {
-  sprintf(buf, TRANSFER_CONN_SEND);
+  sprintf(buf, "%s", TRANSFER_CONN_SEND);
 }
 
 static int expmem_dcc_xfer(void *x)


### PR DESCRIPTION
Found by:
Patch by: Andy Alt
Fixes: #195 

One-line summary: This fixes the warnings that show when eggdrop is built with  -Wformat -Werror=format-security

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
