### PR TITLE
Add 'basic' config file option to Eggdrop

### DIFF
--- a/basic.eggdrop.conf
+++ b/basic.eggdrop.conf
@@ -1,0 +1,405 @@
+#! /path/to/executable/eggdrop
+# ^- This should contain a fully qualified path to your Eggdrop executable.
+
+## This is the basic version of Eggdrop's config file and contains only the
+## most commonly used settings for a standard Eggdrop setup.
+## PLEASE see eggdrop.conf that ships with Eggdrop for the full documentation
+## and list settings you can use here. Or, you can just use eggdrop.conf
+## instead!
+##
+## The pound signs (#) that you see at the beginning of some lines mean that
+## the remainder of that line is a comment, or just for your information. By
+## adding or deleting pound signs, you can comment or uncomment a setting,
+## respectively.
+##
+## Arguments for a command or setting may be inclosed in <>'s or []'s in the
+## example/description. Arguments in <>'s are required, while [] means optional.
+##
+## More detailed descriptions of all these settings can be found in
+## doc/settings/.
+
+## These are the common modules loaded by eggdrop for an IRC-connected bot.
+## For a complete description of each module, please consult eggdrop.conf
+loadmodule blowfish  ; # Userfile encryption
+loadmodule dns       ; # Asynchronous DNS support
+loadmodule channels  ; # Channel support
+loadmodule server    ; # Core server support
+loadmodule ctcp      ; # CTCP functionality
+loadmodule irc       ; # Basic IRC functionality
+#loadmodule transfer ; # DCC SEND/GET and Userfile transfer
+#loadmodule share    ; # Userfile sharing
+#loadmodule compress ; # Compress userfiles for transfer
+#loadmodule filesys  ; # File server support
+loadmodule notes     ; # Note storing for users
+loadmodule console   ; # Console setting storage
+#loadmodule seen     ; # Basic seen functionality
+#loadmodule assoc    ; # Party line channel naming
+loadmodule uptime    ; # Centralized uptime stat collection (http://uptime.eggheads.org)
+
+
+##### BASIC SETTINGS #####
+
+## Set the nick the bot uses on IRC, and on the botnet unless you specify a
+## separate botnet-nick, here.
+set nick "Lamestbot"
+
+## Set the alternative nick which the bot uses on IRC if the nick specified
+## by 'set nick' is unavailable. All '?' characters will be replaced by random
+## numbers.
+set altnick "Llamab?t"
+
+## Set what should be displayed in the real-name field for the bot on IRC.
+## This can not be blank, it has to contain something.
+set realname "/msg LamestBot hello"
+
+## This setting defines the username the bot uses on IRC. This setting has
+## no effect if an ident daemon is running on your bot's machine.
+set username "lamest"
+
+## This setting defines which contact person should be shown in .status,
+## /msg help, and other places. You really should include this information.
+set admin "Lamer <email: lamer@lamest.lame.org>"
+
+## This setting is used only for info to share with others on your botnet.
+## Set this to the IRC network your bot is connected to.
+set network "I.didn't.edit.my.config.file.net"
+
+## This is the bot's server list. The bot will start at the first server listed,
+## and cycle through them whenever it gets disconnected. You need to change these
+## servers to YOUR network's servers.
+##
+## The format is:
+##   server[:port[:password]]
+## Prefix the port with a plus sign to attempt a SSL connection:
+##   server:+port[:password]
+## If you need to specify a numeric server IPv6 address, enclose it in square
+## brackets.
+##
+## Both the port and password fields are optional; however, if you want to set a
+## password or use SSL you must also set a port. If a port isn't specified it
+## will default to your default-port setting.
+set servers {
+  you.need.to.change.this:6667
+  another.example.com:7000:password
+  [2001:db8:618:5c0:263::]:6669:password
+  ssl.example.net:+6697
+}
+
+
+###########################################################################
+## Network settings overview
+## With the addition of IPv6 and the associated config changes, here are some
+## BASIC common networking scenarios, along with the appropriate settings
+## needed:
+##
+## SHELL PROVIDER (MULTIPLE IPs/VHOSTS)
+## * set vhost4 or vhost6 to the IP/vhost you want to use
+## * set listen-addr to the same IP/vhost as above
+##
+## HOME COMPUTER/VPS, DIRECT INTERNET CONNETION (SINGLE IP, NO NAT)
+## * do not set vhost4/vhost6
+## * do not set listen-addr
+##
+## HOME COMPUTER, BEHIND A NAT
+## * do not set vhost4/vhost6
+## * do not set listen-addr
+## * set nat-ip to your external IP
+##
+## Below is a detailed description of each setting, please read them to
+## learn more about their function.
+############################################################################
+
+## If your host has multiple IPv4 addresses, uncomment and set this variable
+## to the IP you wish to use for connecting to IRC.
+#set vhost4 "virtual.host.com"
+#set vhost4 "99.99.0.0"
+
+# If your host has multiple IPv6 addresses, uncomment and set this variable
+# to the IP you wish to use for connecting to IRC.
+#set vhost6 "my.ipv6.host.com"
+#set vhost6 "2001:db8::c001:b07"
+
+## IPv4/IPv6 address (or hostname) to bind for listening. If you don't set
+## this variable, eggdrop will listen on all available IPv4 or IPv6 interfaces,
+## depending on the 'prefer-ipv6' variable (see below).
+## Note that eggdrop will accept IPv4 connections with IPv6 sockets too.
+#set listen-addr "99.99.0.0"
+#set listen-addr "2001:db8:618:5c0:263::"
+#set listen-addr "virtual.host.com"
+
+## If you have a NAT firewall, enter your outside IP here. This IP
+## is used for transfers and CTCP replies only, and is different than the
+## vhost4/6 and listen-addr settings. You likely still need to set them.
+#set nat-ip "127.0.0.1"
+
+## If you want all dcc file transfers to use a particular portrange either
+## because you're behind a firewall, or for other security reasons, set it
+## here.
+#set reserved-portrange 2010:2020
+
+## Prefer IPv6 over IPv4 for connections and dns resolution?
+## If the preferred protocol family is not supported, the other one
+## will be tried.
+set prefer-ipv6 0
+
+## If you want to have your Eggdrop messages displayed in a language other
+## than English, change this setting to match your preference. An alternative
+## would be to set the environment variable EGG_LANG to that value.
+##
+## Languages included with Eggdrop: Danish, English, French, Finnish, German.
+#addlang "english"
+
+##### LOG FILES #####
+
+## See eggdrop.conf for documentation on the logfile flags and settings.
+
+## This creates a logfile named eggdrop.log containing private msgs/ctcps,
+## commands, errors, and misc. info from any channel.
+logfile mco * "logs/eggdrop.log"
+
+## This creates a logfile named lamest.log containing joins, parts,
+## netsplits, kicks, bans, mode changes, and public chat on the
+## channel #lamest.
+#logfile jpk #lamest "logs/lamest.log"
+
+## This should be 0 for disk space restricted shells, and 1 if you want to
+## generate channel statistics with tools such as pisg.
+## If it is 0, eggdrop will delete logfiles older than 2 days.
+## If it is 1, eggdrop will keep logging into the specified logfiles forever.
+## See eggdrop.conf for more detailed settings.
+set log-forever 0
+
+## Code to set settings based on the above setting, do not edit this.
+if {${log-forever}} {
+	set switch-logfiles-at 2500
+	set keep-all-logs 0
+}
+
+## "Writing user file..." and "Writing channel file..." messages won't be logged
+## anymore if this option is enabled. If you set it to 2, the "Backing up user
+## file..." and "Backing up channel file..." messages will also not be logged.
+## In addition to this, you can disable the "Switching logfiles..." and the new
+## date message at midnight, by setting this to 3.
+set quiet-save 0
+
+##### FILES AND DIRECTORIES #####
+
+# Specify here the filename your userfile should be saved as.
+set userfile "LamestBot.user"
+
+##### BOTNET/DCC/TELNET #####
+
+## If you want to use a different nickname on the botnet than you use on
+## IRC (i.e. if you're on an un-trusted botnet), un-comment the next line
+## and set it to the nick you would like to use.
+#set botnet-nick "LlamaBot"
+
+## This opens a telnet port by which you and other bots can interact with the
+## Eggdrop by telneting in.
+##
+## There are more options for the listen command in doc/tcl-commands.doc. Note
+## that if you are running more than one bot on the same machine, you will want
+## to space the telnet ports at LEAST 5 apart, although 10 is even better.
+##
+## Valid ports are typically anything between 1025 and 65535 assuming the
+## port is not already in use.
+##
+## If you would like the bot to listen for users and bots in separate ports,
+## use the following format:
+##
+##   listen 3333 bots
+##   listen 4444 users
+##
+## If you wish to use only one port, use this format:
+##
+##   listen 3333 all
+##
+## You can setup a SSL port by prepending a plus sign to it:
+##
+##   listen +5555 all
+##
+## You need to un-comment this line and change the port number in order to open
+## the listen port. You should not keep this set to 3333.
+#listen 3333 all
+
+##### SSL SETTINGS #####
+
+## Settings in this section take effect when eggdrop is compiled with TLS
+## support. If you didn't generate SSL keys already, you can type 
+## 'make sslcert' in yuor eggdrop source directory.
+##
+## IMPORTANT: The following two settings MUST be uncommented in order to
+## use SSL functionality!
+#set ssl-privatekey "eggdrop.key"
+
+## Specify the filename where your SSL certificate is located. If you
+## don't set this, eggdrop will not be able to act as a server in SSL
+## connections. Must be in PEM format.
+#set ssl-certificate "eggdrop.crt"
+
+## Specify the location at which CA certificates for verification purposes
+## are located. These certificates are trusted. If you don't set this,
+## certificate verification will not work.
+set ssl-capath "/etc/ssl/"
+
+## Enable certificate authorization. Set to 1 to allow users and bots to
+## identify automatically by their certificate fingerprints. Setting it
+## to 2 to will force fingerprint logins. With a value of 2, users without
+## a fingerprint set or with a certificate UID not matching their handle
+## won't be allowed to login on SSL enabled telnet ports. Fingerprints
+## must be set in advance with the .fprint and .chfinger commands.
+## NOTE: this setting has no effect on plain-text ports.
+#set ssl-cert-auth 0
+
+## You can control SSL certificate verification using the following variables.
+## All of them are flag-based. You can set them by adding together the numbers
+## for all exceptions you want to enable. By default certificate verification
+## is disabled and all certificates are assumed to be valid. The numbers are
+## the following:
+##
+## Enable certificate verification - 1
+## Allow self-signed certificates - 2
+## Don't check peer common or alt names - 4
+## Allow expired certificates - 8
+## Allow certificates which are not valid yet - 16
+## Allow revoked certificates - 32
+## A value of 0 disables verification.
+
+## Control certificate verification for IRC servers
+#set ssl-verify-server 0
+
+## Control certificate verification for DCC chats (only /dcc chat botnick)
+#set ssl-verify-dcc 0
+
+## Control certificate verification for linking to hubs
+#set ssl-verify-bots 0
+
+## Control cerfificate verification for SSL listening ports. This includes
+## leaf bots connecting, users telneting in and /ctcp bot chat.
+#set ssl-verify-clients 0
+
+
+##### COMMON MODULES SETTINGS #####
+
+## Below are various settings for the modules included with Eggdrop.
+## PLEASE READ AND EDIT THEM CAREFULLY, even if you're an old hand at
+## Eggdrop, things change.
+
+## This path specifies the path were Eggdrop should look for its modules.
+## If you run the bot from the compilation directory, you will want to set
+## this to "". If you use 'make install' (like all good kiddies do ;), this
+## is a fine default. Otherwise, use your head :)
+set mod-path "modules/"
+
+#### DNS MODULE ####
+
+## In case your bot has trouble finding dns servers or you want to use
+## specific ones, you can set them here. The value is a list of dns servers.
+## The order doesn't matter. You can also specify a non-standard port.
+## The default is to use the system specified dns servers. 
+#set dns-servers "8.8.8.8 8.8.4.4"
+
+#### CHANNELS MODULE ####
+
+## Enter here the filename where dynamic channel settings are stored.
+set chanfile "LamestBot.chan"
+
+#### SERVER MODULE ####
+
+## What is your network?
+##   0 = EFnet
+##   1 = IRCnet
+##   2 = Undernet
+##   3 = DALnet
+##   4 = +e/+I/max-modes 20 Hybrid
+##   5 = Others. See eggdrop.conf for settings related to this.
+set net-type 0
+
+## This is a Tcl script to be run immediately after connecting to a server.
+bind evnt - init-server evnt:init_server
+
+proc evnt:init_server {type} {
+  global botnick
+  putquick "MODE $botnick +i-ws"
+}
+
+## Set the default port which should be used if none is specified with
+## '.jump' or in 'set servers'.
+set default-port 6667
+
+## This setting allows you to specify the maximum nick-length supported by your
+## network. The default setting is 9. The maximum supported length by Eggdrop
+## is 32.
+#set nick-len 9
+
+#### CTCP MODULE ####
+
+## Set here how the ctcp module should answer ctcps. There are 3 possible
+## operating modes:
+##   0: Normal behavior is used.
+##   1: The bot ignores all ctcps, except for CHAT and PING requests
+##      by users with the +o flag.
+##   2: Normal behavior is used, however the bot will not answer more
+##      than X ctcps in Y seconds (defined by 'set flood-ctcp').
+set ctcp-mode 0
+
+#### IRC MODULE ####
+
+## Many takeover attempts occur due to lame users blindly /msg ident'ing to
+## the bot and attempting to guess passwords. We now unbind this command by
+## default to discourage them. You can enable these commands by commenting the
+## following two lines.
+unbind msg - ident *msg:ident
+unbind msg - addhost *msg:addhost
+
+#### NOTES MODULE ####
+
+## Set here the filename where private notes between users are stored.
+set notefile "LamestBot.notes"
+
+##### SCRIPTS #####
+
+## This is a good place to load scripts to use with your bot.
+
+## This line loads script.tcl from the scripts directory inside your Eggdrop's
+## directory. All scripts should be put there, although you can place them where
+## you like as long as you can supply a fully qualified path to them.
+##
+## source scripts/script.tcl
+## The 3 scripts below are default and shouldn't be removed.
+
+source scripts/alltools.tcl
+source scripts/action.fix.tcl
+source scripts/dccwhois.tcl
+
+## This script provides many useful informational functions, like setting
+## users' URLs, e-mail address, ICQ numbers, etc. You can modify it to add
+## extra entries.
+source scripts/userinfo.tcl
+loadhelp userinfo.help
+
+## Use this script for Tcl and Eggdrop backwards compatibility.
+## NOTE: This can also cause problems with some newer scripts.
+#source scripts/compat.tcl
+
+## This next line checks if eggdrop is being executed from the source directory, do not remove it
+if {[file exists aclocal.m4]} { die {You are attempting to run Eggdrop from the source directory. Please finish installing Eggdrop by running "make install" and run it from the install location.} }
+
+## A few IRC networks (EFnet and Undernet) have added some simple checks to
+## prevent drones from connecting to the IRC network. While these checks are
+## fairly trivial, they will prevent your Eggdrop from automatically
+## connecting. In an effort to work-around these, we have developed a couple of
+## TCL scripts to automate the process.
+
+if {[info exists net-type]} {
+  switch -- ${net-type} {
+    "0" {
+      # EFnet
+      source scripts/quotepong.tcl
+    }
+    "2" {
+      # Undernet
+      source scripts/quotepass.tcl
+    }
+  }
+}


### PR DESCRIPTION
Found by:
Patch by: Geo
Fixes: #164 

One-line summary:
Add basic.eggdrop.conf

Additional description (if needed):
Move loadmodules to top, mod a few other settings

Comment trim

Basic conf improvements

Rename basic config file

Add +x to basic.eggdrop.conf

Update intro text

Test cases demonstrating functionality (if applicable):
