### PR TITLE
Typo: "timer <seconds>" should be "utimer <seconds>"

### DIFF
--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -1971,7 +1971,7 @@ timer <minutes> <tcl-command> [count]
 
   Module: core
 
-timer <seconds> <tcl-command> [count]
+utimer <seconds> <tcl-command> [count]
 
   Description: executes the given Tcl command after a certain number of
   seconds have passed. If count is specified, the command will be


### PR DESCRIPTION
Found by: sirfz
Patch by: sirfz
Fixes: documentation typo about the `utimer` TCL command

One-line summary: The `utimer` command is incorrectly called `timer` in the documentation.

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
