### PR TITLE
Commit ChangeLog to develop before gen'ing RC/Releases

### DIFF
--- a/misc/releaseprep
+++ b/misc/releaseprep
@@ -132,6 +132,12 @@ echo "Regenerating ChangeLog file..."
 regenerate_changelog $LASTVER
 echo ""
 
+# Commit ChangeLog to develop branch before proceeding
+# (otherwise it never gets done!)
+git add ChangeLog
+git commit -m "Update ChangeLog"
+git push origin develop
+
 # Change default make from "debug" to "eggdrop"...
 echo -n "Changing default make..."
 change_default_make
@@ -184,6 +190,9 @@ echo Current patch: `misc/addpatch -s`
 echo "Complete."
 echo ""
 
+exit
+
+### Maybe for the future...
 echo "This next step will commit, tag, and push to GitHub."
 echo "IT IS NOT REVERSIBLE!"
 echo "This is, like, the real deal."


### PR DESCRIPTION
Found by: irc user
Patch by: Geo
Fixes: #246 

One-line summary:
Commit ChangeLog to develop before gen'ing RC/Releases

Additional description (if needed):
As releaseprep stands now, ChangeLog is only sent to the RC or Release tree, and is never updated on the develop branch. This generates ChangeLog on the develop first as part of the release process. 

Test cases demonstrating functionality (if applicable):
