### PR TITLE
(WIP) Add byte-based flood option

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -670,6 +670,7 @@ set global-flood-kick 3:10
 set global-flood-join 5:60
 set global-flood-ctcp 3:60
 set global-flood-nick 5:60
+set global-flood-size 1024:60
 set global-aop-delay 5:30
 set global-idle-kick 0
 set global-chanmode "nt"
@@ -832,6 +833,11 @@ set global-chanset {
 #    Set here how many nick changes in how many seconds from one host
 #    constitutes a flood. Setting this to 0 or 0:0 disables nick flood
 #    protection for the channel.
+#
+# flood-size 1024:60
+#    Set here how many bytes in how many seconds from one host constitutes
+#    a flood. Setting this to 0 or 0:0 disables size flood protection for
+#    the channel.
 #
 # A complete list of all available channel settings:
 #

--- a/src/chan.h
+++ b/src/chan.h
@@ -174,6 +174,8 @@ struct chanset_t {
   int flood_ctcp_time;
   int flood_nick_thr;
   int flood_nick_time;
+  int flood_size_thr;
+  int flood_size_time;
   int aop_min;
   int aop_max;
   long status;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -588,8 +588,9 @@ struct dupwait_info {
 #define FLOOD_JOIN       4
 #define FLOOD_KICK       5
 #define FLOOD_DEOP       6
+#define FLOOD_SIZE       7
 
-#define FLOOD_CHAN_MAX   7
+#define FLOOD_CHAN_MAX   8
 #define FLOOD_GLOBAL_MAX 3
 
 /* For local console: */

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -45,7 +45,8 @@ static char glob_chanset[512];
 /* Global flood settings */
 static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
            gfld_kick_thr, gfld_kick_time, gfld_join_thr, gfld_join_time,
-           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time;
+           gfld_ctcp_thr, gfld_ctcp_time, gfld_nick_thr, gfld_nick_time,
+           gfld_size_thr, gfld_size_time;
 
 #include "channels.h"
 #include "cmdschan.c"
@@ -417,7 +418,7 @@ static void write_channels()
             "revenge-mode %d need-op %s need-invite %s need-key %s "
             "need-unban %s need-limit %s flood-chan %d:%d flood-ctcp %d:%d "
             "flood-join %d:%d flood-kick %d:%d flood-deop %d:%d "
-            "flood-nick %d:%d aop-delay %d:%d ban-type %d ban-time %d "
+            "flood-nick %d:%d flood-size %d:%d aop-delay %d:%d ban-type %d ban-time %d "
             "exempt-time %d invite-time %d %cenforcebans %cdynamicbans "
             "%cuserbans %cautoop %cautohalfop %cbitch %cgreet %cprotectops "
             "%cprotecthalfops %cprotectfriends %cdontkickops %cstatuslog "
@@ -432,6 +433,7 @@ static void write_channels()
             chan->flood_kick_thr, chan->flood_kick_time,
             chan->flood_deop_thr, chan->flood_deop_time,
             chan->flood_nick_thr, chan->flood_nick_time,
+            chan->flood_size_thr, chan->flood_size_time,
             chan->aop_min, chan->aop_max, chan->ban_type, chan->ban_time,
             chan->exempt_time, chan->invite_time,
             PLSMNS(channel_enforcebans(chan)),
@@ -830,6 +832,7 @@ static tcl_coups mychan_tcl_coups[] = {
   {"global-flood-join", &gfld_join_thr,  &gfld_join_time},
   {"global-flood-ctcp", &gfld_ctcp_thr,  &gfld_ctcp_time},
   {"global-flood-nick", &gfld_nick_thr,  &gfld_nick_time},
+  {"global-flood-size", &gfld_size_thr,  &gfld_size_time},
   {"global-aop-delay",  &global_aop_min, &global_aop_max},
   {NULL,                NULL,                       NULL}
 };
@@ -949,6 +952,10 @@ char *channels_start(Function *global_funcs)
   gfld_join_time = 60;
   gfld_ctcp_thr = 5;
   gfld_ctcp_time = 60;
+  gfld_nick_thr = 5;
+  gfld_nick_time = 60;
+  gfld_size_thr = 1024;
+  gfld_size_time = 60;
   global_idle_kick = 0;
   global_aop_min = 5;
   global_aop_max = 30;

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1424,15 +1424,17 @@ static void cmd_chaninfo(struct userrec *u, int idx, char *par)
     }
 
 
-    dprintf(idx, "flood settings: chan ctcp join kick deop nick\n");
-    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d\n",
+    dprintf(idx, "flood settings: chan ctcp join kick deop nick size\n");
+    dprintf(idx, "number:          %3d  %3d  %3d  %3d  %3d  %3d %4d\n",
             chan->flood_pub_thr, chan->flood_ctcp_thr,
             chan->flood_join_thr, chan->flood_kick_thr,
-            chan->flood_deop_thr, chan->flood_nick_thr);
-    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d\n",
+            chan->flood_deop_thr, chan->flood_nick_thr,
+            chan->flood_size_thr);
+    dprintf(idx, "time  :          %3d  %3d  %3d  %3d  %3d  %3d  %3d\n",
             chan->flood_pub_time, chan->flood_ctcp_time,
             chan->flood_join_time, chan->flood_kick_time,
-            chan->flood_deop_time, chan->flood_nick_time);
+            chan->flood_deop_time, chan->flood_nick_time,
+            chan->flood_size_time);
     putlog(LOG_CMDS, "*", "#%s# chaninfo %s", dcc[idx].nick, chname);
   }
 }

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -782,6 +782,8 @@ static int tcl_channel_info(Tcl_Interp *irp, struct chanset_t *chan)
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->flood_nick_thr, chan->flood_nick_time);
   Tcl_AppendElement(irp, s);
+  simple_sprintf(s, "%d:%d", chan->flood_size_thr, chan->flood_size_time);
+  Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d:%d", chan->aop_min, chan->aop_max);
   Tcl_AppendElement(irp, s);
   simple_sprintf(s, "%d", chan->ban_type);
@@ -1107,6 +1109,8 @@ static int tcl_channel_get(Tcl_Interp *irp, struct chanset_t *chan,
     simple_sprintf(s, "%d %d", chan->flood_deop_thr, chan->flood_deop_time);
   else if (!strcmp(setting, "flood-nick"))
     simple_sprintf(s, "%d %d", chan->flood_nick_thr, chan->flood_nick_time);
+  else if (!strcmp(setting, "flood-size"))
+    simple_sprintf(s, "%d %d", chan->flood_size_thr, chan->flood_size_time);
   else if (!strcmp(setting, "aop-delay"))
     simple_sprintf(s, "%d %d", chan->aop_min, chan->aop_max);
   else if CHKFLAG_POS(CHAN_ENFORCEBANS, "enforcebans", chan->status)
@@ -1498,6 +1502,9 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
       } else if (!strcmp(item[i] + 6, "nick")) {
         pthr = &chan->flood_nick_thr;
         ptime = &chan->flood_nick_time;
+      } else if (!strcmp(item[i] + 6, "size")) {
+        pthr = &chan->flood_size_thr;
+        ptime = &chan->flood_size_time;
       } else {
         if (irp)
           Tcl_AppendResult(irp, "illegal channel flood type: ", item[i], NULL);
@@ -2067,6 +2074,8 @@ static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
     chan->flood_kick_time = gfld_kick_time;
     chan->flood_nick_thr = gfld_nick_thr;
     chan->flood_nick_time = gfld_nick_time;
+    chan->flood_size_thr = gfld_size_thr;
+    chan->flood_size_time = gfld_size_time;
     chan->stopnethack_mode = global_stopnethack_mode;
     chan->revenge_mode = global_revenge_mode;
     chan->ban_type = global_ban_type;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -177,7 +177,7 @@ static void do_mask(struct chanset_t *chan, masklist *m, char *mask, char mode)
  * and handles kick & deop as well.
  */
 static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
-                             struct chanset_t *chan, int which, char *victim)
+                             struct chanset_t *chan, int which, char *victim, int size)
 {
   char h[UHOSTLEN], ftype[12], *p;
   struct userrec *u;
@@ -232,6 +232,11 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
     lapse = chan->flood_nick_time;
     strcpy(ftype, "nick");
     break;
+  case FLOOD_SIZE:
+    thr = chan->flood_size_thr;
+    lapse = chan->flood_size_time;
+    strcpy(ftype, "pub");
+    break;
   case FLOOD_JOIN:
     thr = chan->flood_join_thr;
     lapse = chan->flood_join_time;
@@ -265,13 +270,19 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
     strncpy(chan->floodwho[which], p, 80);
     chan->floodwho[which][80] = 0;
     chan->floodtime[which] = now;
-    chan->floodnum[which] = 1;
+    if (which == FLOOD_SIZE)
+      chan->floodnum[which] = size;
+    else
+      chan->floodnum[which] = 1;
     return 0;
   }
   if (chan->floodtime[which] < now - lapse) {
     /* Flood timer expired, reset it */
     chan->floodtime[which] = now;
-    chan->floodnum[which] = 1;
+    if (which == FLOOD_SIZE)
+      chan->floodnum[which] = size;
+    else
+      chan->floodnum[which] = 1;
     return 0;
   }
   /* Deop'n the same person, sillyness ;) - so just ignore it */
@@ -281,7 +292,12 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
     else
       strcpy(chan->deopd, victim);
   }
-  chan->floodnum[which]++;
+
+  if (which == FLOOD_SIZE)
+    chan->floodnum[which]+=size;
+  else
+    chan->floodnum[which]++;
+
   if (chan->floodnum[which] >= thr) {   /* FLOOD */
     /* Reset counters */
     chan->floodnum[which] = 0;
@@ -296,6 +312,7 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
     case FLOOD_PRIVMSG:
     case FLOOD_NOTICE:
     case FLOOD_CTCP:
+    case FLOOD_SIZE:
       /* Flooding chan! either by public or notice */
       if (!chan_sentkick(m) &&
           (me_op(chan) || (me_halfop(chan) && !chan_hasop(m)))) {
@@ -1728,7 +1745,7 @@ static int gotjoin(char *from, char *chname)
     chan->status &= ~CHAN_STOP_CYCLE;
     strcpy(uhost, from);
     nick = splitnick(&uhost);
-    detect_chan_flood(nick, uhost, from, chan, FLOOD_JOIN, NULL);
+    detect_chan_flood(nick, uhost, from, chan, FLOOD_JOIN, NULL, 0);
 
     chan = findchan(chname);
     if (!chan) {
@@ -2060,7 +2077,7 @@ static int gotkick(char *from, char *origmsg)
     u = get_user_by_host(from);
     strcpy(uhost, from);
     whodid = splitnick(&uhost);
-    detect_chan_flood(whodid, uhost, from, chan, FLOOD_KICK, nick);
+    detect_chan_flood(whodid, uhost, from, chan, FLOOD_KICK, nick, 0);
 
     chan = findchan(chname);
     if (!chan)
@@ -2151,7 +2168,7 @@ static int gotnick(char *from, char *msg)
       /* Compose a nick!user@host for the new nick */
       sprintf(s1, "%s!%s", msg, uhost);
       strcpy(m->nick, msg);
-      detect_chan_flood(msg, uhost, from, chan, FLOOD_NICK, NULL);
+      detect_chan_flood(msg, uhost, from, chan, FLOOD_NICK, NULL, 0);
 
       if (!findchan_by_dname(chname)) {
         chan = oldchan;
@@ -2318,7 +2335,8 @@ static int gotmsg(char *from, char *msg)
       strcpy(ctcp, p1);
       strcpy(p1 - 1, p + 1);
       detect_chan_flood(nick, uhost, from, chan, strncmp(ctcp, "ACTION ", 7) ?
-                        FLOOD_CTCP : FLOOD_PRIVMSG, NULL);
+                        FLOOD_CTCP : FLOOD_PRIVMSG, NULL, 0);
+      detect_chan_flood(nick, uhost, from, chan, FLOOD_SIZE, NULL, strlen(msg));
 
       chan = findchan(realto);
       if (!chan)
@@ -2375,7 +2393,8 @@ static int gotmsg(char *from, char *msg)
     int result = 0;
 
     /* Check even if we're ignoring the host. (modified by Eule 17.7.99) */
-    detect_chan_flood(nick, uhost, from, chan, FLOOD_PRIVMSG, NULL);
+    detect_chan_flood(nick, uhost, from, chan, FLOOD_PRIVMSG, NULL, 0);
+    detect_chan_flood(nick, uhost, from, chan, FLOOD_SIZE, NULL, strlen(msg));
 
     chan = findchan(realto);
     if (!chan)
@@ -2439,7 +2458,8 @@ static int gotnotice(char *from, char *msg)
       p = strchr(msg, 1);
       detect_chan_flood(nick, uhost, from, chan,
                         strncmp(ctcp, "ACTION ", 7) ?
-                        FLOOD_CTCP : FLOOD_PRIVMSG, NULL);
+                        FLOOD_CTCP : FLOOD_PRIVMSG, NULL, 0);
+      detect_chan_flood(nick, uhost, from, chan, FLOOD_SIZE, NULL, strlen(msg));
 
       chan = findchan(realto);
       if (!chan)
@@ -2467,7 +2487,8 @@ static int gotnotice(char *from, char *msg)
   if (msg[0]) {
 
     /* Check even if we're ignoring the host. (modified by Eule 17.7.99) */
-    detect_chan_flood(nick, uhost, from, chan, FLOOD_NOTICE, NULL);
+    detect_chan_flood(nick, uhost, from, chan, FLOOD_NOTICE, NULL, 0);
+    detect_chan_flood(nick, uhost, from, chan, FLOOD_SIZE, NULL, strlen(msg));
 
     chan = findchan(realto);
     if (!chan)

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -69,7 +69,7 @@ static void recheck_channel(struct chanset_t *, int);
 static void set_key(struct chanset_t *, char *);
 static void maybe_revenge(struct chanset_t *, char *, char *, int);
 static int detect_chan_flood(char *, char *, char *, struct chanset_t *, int,
-                             char *);
+                             char *, int);
 static void newmask(masklist *, char *, char *);
 static char *quickban(struct chanset_t *, char *);
 static void got_op(struct chanset_t *chan, char *nick, char *from, char *who,

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -653,7 +653,7 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
 
   /* Check for mass deop */
   if (nick[0])
-    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who);
+    detect_chan_flood(nick, from, s1, chan, FLOOD_DEOP, who, 0);
 
   /* Having op hides your +v and +h status -- so now that someone's lost ops,
    * check to see if they have +v or +h


### PR DESCRIPTION
Patch by: remorse
One-line summary: Add byte-based flood option
Fixes: #242 

This is to track the floodsize branch. We might want to expand our "couplets" to be X:Y:A:B for X lines in Y seconds or A bytes in B lines (or similar), or make the size trigger its own flud bind (current patch calls pub). It is confusing for users to set flood-chan to 0:0 and still triggering a flood. Also, size limit isn't displayed in chaninfo AFAIK.
