### PR TITLE
Completely reset channels upon server disconnect, fixes incorrect botonchan results.

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -359,7 +359,7 @@ static int got442(char *from, char *msg)
 
     putlog(LOG_MISC, chname, IRC_SERVNOTONCHAN, chname);
     if (me && me->funcs)
-      (me->funcs[CHANNEL_CLEAR]) (chan, 1);
+      (me->funcs[CHANNEL_CLEAR]) (chan, CHAN_RESETALL);
     chan->status &= ~CHAN_ACTIVE;
 
     key = chan->channel.key[0] ? chan->channel.key : chan->key_prot;
@@ -1018,7 +1018,7 @@ static void kill_server(int idx, void *x)
     struct chanset_t *chan;
 
     for (chan = chanset; chan; chan = chan->next)
-      (me->funcs[CHANNEL_CLEAR]) (chan, 1);
+      (me->funcs[CHANNEL_CLEAR]) (chan, CHAN_RESETALL);
   }
   /* A new server connection will be automatically initiated in
    * about 2 seconds. */


### PR DESCRIPTION
Found by: Cizzle
Patch by: Cizzle
Fixes: any command relying on channel data like "botonchan".

One-line summary: Fix channel data not being reset after certain disconnects and thus any command relying on this data, like "botonchan".

Additional description (if needed): This is especially a problem for invite-only channels where the bot normally asks for an invite to rejoin. Because "botonchan" still returns 1, it thinks it's on the channel and thus doesn't ask an invite. Moreover it keeps trying to message the channel, tries to invite other users and bots etc...

Test cases demonstrating functionality (if applicable):
1. Enable tcl on partyline
2. Have your bot join an invite-only channel.
3. Disable any network activity so it pings out, the following works best: ifconfig IFACE down
4. Wait til the bot says the server got stoned and tries another server, then re-enable the network: service networking restart (worked better than just "ifconfig IFACE up")
5. When the bot eventually is connected to an IRC server again, execute on partyline: .tcl botonchan #CHANNEL 
6. Issue ".tcl resetchan #CHANNEL" to have it figure out it's not actually on the channel
