### PR TITLE
Bug/x compile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -75,11 +75,10 @@ MODULE_XLIBS = @MODULE_XLIBS@
 
 modconf = $(top_srcdir)/misc/modconfig --top_srcdir=$(top_srcdir)
 
-ifeq ($(EGG_CROSS_COMPILING),no)
-egg_test_run = EGG_LANGDIR=$(top_srcdir)/language ./$(EGGEXEC) -v
-else
-egg_test_run = echo "This build is a cross-compilation, skipping test run..."
-endif
+egg_test_run = if [ '$(EGG_CROSS_COMPILING)' = 'no' ]; \
+               	then EGG_LANGDIR=$(top_srcdir)/language ./$(EGGEXEC) -v; \
+               	else echo 'This build is a cross-compilation, skipping test run...'; \
+               fi
 
 post_config  =  echo "" && \
 		echo "You can now compile the bot, using \"make\"." && \

--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,12 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0:
 
+  - Update x-compile Makefile changes to POSIX compliance. Fixes #273
+    Patch by: Geo
+
+    Allows bsd 'make' to be used on BSD systems (gmake not needed). Fixes
+    bug introduced in e3321ccf46da7950995f7003b83e1b4a8e9eef81
+
   - Tcl various OS linking, cross-compilation issues. Fixes #250, #251
     Patch by: thommey / Found by: eelcohuininga, thommey
 


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #273 

One-line summary:
Update x-compile Makefile changes to POSIX compliance. Fixes #273

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
