### PR TITLE
Clear channel modes on disconnect

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,17 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0:
 
+  - Clear channel modes on disconnect
+    Patch by: Geo / Found by: thommey
+
+    nuke_server() calls reset_chan_info(), which clears channel modes and
+    then re-requests them, which is the point of the function. However,
+    because the server connection has already been killed, chan->status
+    is set to CHAN_ASKEDBANS and thus doesn't re-request the banlist from
+    the server when it finally does rejoin. By setting to clear_chan, the
+    list is just cleared and the banlist properly requested from the IRC
+    server on join.
+
   - Ensure our Makefile works with both BSD make and GNU make.
     Patch by: thommey / Found by: Geo
     

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -386,7 +386,7 @@ static void nuke_server(char *reason)
     for (chan = chanset; chan; chan = chan->next) {
       if (channel_active(chan))
         if ((me = module_find("irc", 1, 3)) != NULL)
-          (me->funcs[IRC_RESET_CHAN_INFO]) (chan, CHAN_RESETALL);
+          (me->funcs[CHANNEL_CLEAR]) (chan, CHAN_RESETALL);
     }
 
     disconnect_server(servidx);


### PR DESCRIPTION
Found by: thommey
Patch by: Geo, thommey
Fixes: #278 

One-line summary: 
Clear channel modes on disconnect

Additional description (if needed):

nuke_server() calls reset_chan_info(), which clears channel modes and then re-requests them,
which is the point of the function. However, because the server connection has already been
killed, chan->status is set to CHAN_ASKEDBANS and thus doesn't re-request the banlist from
the server when it finally does rejoin. By setting to clear_chan, the list is just cleared
and the banlist properly requested from the IRC server on join.

Test cases demonstrating functionality (if applicable):

```
_<bot joins channel>_
*** .bans
Global bans:
Channel bans for #foober:  (* = not placed by bot)
(There are no bans, permanent or otherwise.)

*** .jump
_<Add ban to channel while bot not present>_
_<bot rejoins>_

*** .bans #foober
Global bans:
Channel bans for #foober:  (* = not placed by bot)
* [  1] *!sdf@foo.com (user!user@foo.com) (active 00:48)

*** .jump
_<while bot is disconnected>_ 

*** .bans #foober
Global bans:
Channel bans for #foober:  (* = not placed by bot)
(There are no bans, permanent or otherwise.)
_<bot rejoins>_

*** .bans #foober
Global bans:
Channel bans for #foober:  (* = not placed by bot)
* [  1] *!sdf@foo.com (user!user@foo.com) (active 00:09)
```

So, in sum:
Bot joins, no bans. 
Bot jumps, ban added to channel while gone
Ban is added to bot upon reconnect. 
Bot jumps, ban is cleared from bot
Bot rejoins, ban is readded to bot. 
