### PR TITLE
Ensure Makefile works with both BSDand GNU make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,7 +10,12 @@ VPATH = @srcdir@
 @SET_MAKE@
 prefix = @prefix@
 DEST = @DEST@
-override DEST := $(abspath $(DEST))
+# GNU Make < 3.82 ignores these != statements, they are for bsd make and gnu make >= 3.82
+DEST_PARENT != readlink `dirname $(DEST)`
+DEST_DIR != basename $(DEST)
+ABSDEST != echo $(DEST_PARENT)/$(DEST_DIR)
+# GNU Make
+ABSDEST ?= $(abspath $(DEST))
 EGGEXEC = @EGGEXEC@
 EGG_CROSS_COMPILING = @EGG_CROSS_COMPILING@
 EGGVERSION = @EGGVERSION@
@@ -128,7 +133,7 @@ MAKE_DEPEND = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)'
 
 MAKE_CONFIG = $(MAKE) 'MAKE=$(MAKE)'
 
-MAKE_INSTALL = $(MAKE) 'MAKE=$(MAKE)' 'DEST=$(DEST)'
+MAKE_INSTALL = $(MAKE) 'MAKE=$(MAKE)' 'DEST=$(ABSDEST)'
 
 all: @DEFAULT_MAKE@
 
@@ -352,7 +357,7 @@ install-start:
 	@echo ""
 	@$(egg_test_run)
 	@echo ""
-	@echo "Installing in directory: '$(DEST)'."
+	@echo "Installing in directory: '$(ABSDEST)'."
 	@echo ""
 	@if test ! -d $(DEST); then \
 		echo "Creating directory '$(DEST)'."; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -11,7 +11,7 @@ VPATH = @srcdir@
 prefix = @prefix@
 DEST = @DEST@
 # GNU Make < 3.82 ignores these != statements, they are for bsd make and gnu make >= 3.82
-DEST_PARENT != readlink `dirname $(DEST)`
+DEST_PARENT != readlink -f `dirname $(DEST)`
 DEST_DIR != basename $(DEST)
 ABSDEST != echo $(DEST_PARENT)/$(DEST_DIR)
 # GNU Make

--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0:
 
+  - Ensure our Makefile works with both BSD make and GNU make.
+    Patch by: thommey
+    
   - Fix formatting bug in 618ecbf9, MISC_LOGREPEAT contains a format specifier.
     Found by: Robby / Patch by: thommey
 

--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -5,7 +5,7 @@ Eggdrop Changes (since version 1.8.0)
 1.8.0:
 
   - Ensure our Makefile works with both BSD make and GNU make.
-    Patch by: thommey
+    Patch by: thommey / Found by: Geo
     
   - Fix formatting bug in 618ecbf9, MISC_LOGREPEAT contains a format specifier.
     Found by: Robby / Patch by: thommey


### PR DESCRIPTION
Found by: Geo
Patch by: thommey
Fixes: #272 

One-line summary:
Remove GNU-specific code from Makefile

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
