### PR TITLE
Fix out-of-bounds read error

### DIFF
--- a/doc/Changes1.8
+++ b/doc/Changes1.8
@@ -4,6 +4,9 @@ Eggdrop Changes (since version 1.8.0)
 
 1.8.0:
 
+  - Fix out-of-bounds read error
+    Patch by: thommey, Geo / Found by: Robby
+
   - Clear channel modes on disconnect
     Patch by: Geo / Found by: thommey
 
@@ -19,7 +22,7 @@ Eggdrop Changes (since version 1.8.0)
     Patch by: thommey / Found by: Geo
     
   - Fix formatting bug in 618ecbf9, MISC_LOGREPEAT contains a format specifier.
-    Found by: Robby / Patch by: thommey
+    Patch by: thommey / Found by: Robby
 
   - Increase memory table size for memory debugging by factor 10.
     Found by: Kiril, various / Patch by: thommey

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -273,8 +273,8 @@ static inline u_32bit_t getipbash(IP ip)
 #ifdef IPV6
 static unsigned long getip6bash(struct in6_addr *ip6) {
   u_32bit_t x, y;
-  egg_memcpy(&x, &ip6->s6_addr     , sizeof x);
-  egg_memcpy(&y, &ip6->s6_addr + 12, sizeof y);
+  egg_memcpy(&x, ip6->s6_addr     , sizeof x);
+  egg_memcpy(&y, ip6->s6_addr + 12, sizeof y);
   x ^= y;
   return (unsigned long) BASH_MODULO(x);
 }


### PR DESCRIPTION
Found by: Robby
Patch by: thommey, Geo
Fixes: #200

One-line summary:
Fix out-of-bounds read error

Additional description (if needed):
The famous SCHAT crash! 

Test cases demonstrating functionality (if applicable):

Patch by: thommey, Geo / Found by: Robby
