### PR TITLE
Several fixes for the autobotchk script

### DIFF
--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -66,16 +66,20 @@ exec tclsh$lastver "$0" ${1+"$@"}
 #              directory if being run from the scripts directory.
 #   15Apr2003: cleaned up a few things, fixed a few bugs, and made a little
 #              love! j/k
+#   13Dec2016: add possibility to use multiple confs; fixes for (botnet-)nick
+#              with len > handlen, for (botnet-)nicks with \[ \] and for
+#              $(botnet-)nick used in pidfile, userfile or (botnet-)nick
 #
 
 if {$argc == 0} {
-  puts "\nusage: $argv0 <eggdrop config> \[options\]"
+  puts "\nusage: $argv0 <eggdrop mainconfig> \[options\]"
   puts " -dir     (directory to run autobotchk in)"
   puts " -noemail (discard crontab e-mails)"
   puts " -5       (5 minute checks)"
   puts " -10      (10 minute checks)"
   puts " -15      (15 minute checks)"
   puts " -30      (30 minute checks)"
+  puts " <configfile2 ...> (other eggdrop config files sourced from mainconfig)"
   puts ""
   exit
 }
@@ -95,10 +99,12 @@ proc newsplit {text {split " "}} {
   return $tmp
 }
 
-puts "\nautobotchk 1.10, (C) 2003 Jeff Fisher (guppy@eggheads.org)"
+puts "\nautobotchk 1.11, (C) 2003 Jeff Fisher (guppy@eggheads.org)"
+puts "\n                 Extra fixes by Cizzle"
 puts "------------------------------------------------------------\n"
 
-set config [newsplit argv]
+set mainconf [newsplit argv]
+set confs [list $mainconf]
 set dir [pwd]
 set delay 10
 set email 1
@@ -108,16 +114,16 @@ set binary "eggdrop"
 
 while {[set opt [newsplit argv]] != ""} {
   switch -- $opt {
-   "-time" -
-   "-1" { set delay 1 }
-   "-5" { set delay 5 }
-   "-10" { set delay 10 } 
-   "-15" { set delay 15 }
-   "-20" { set delay 20 }
-   "-30" { set delay 30 }
-   "-nomail" -
-   "-noemail" {set email 0}
-   "-dir" {
+    "-time" -
+    "-1" { set delay 1 }
+    "-5" { set delay 5 }
+    "-10" { set delay 10 }
+    "-15" { set delay 15 }
+    "-20" { set delay 20 }
+    "-30" { set delay 30 }
+    "-nomail" -
+    "-noemail" {set email 0}
+    "-dir" {
       set dir [newsplit argv]
       if {[string match -* $dir]} {
         puts "*** ERROR: you did not supply a directory name"
@@ -129,6 +135,10 @@ while {[set opt [newsplit argv]] != ""} {
         puts ""
         exit
       }
+    }
+    default {
+      # Treat as extra config file
+      if {[file isfile $opt] && [file readable $opt]} { lappend confs $opt }
     }
   }
 }
@@ -158,53 +168,51 @@ if {![file exists $dir/help] || ![file isdirectory $dir/help]} {
   exit
 }
 
-puts -nonewline "Opening '$config' for processing ... "
+foreach config $confs {
+  puts -nonewline "Opening '$config' for processing ... "
 
-if {[catch {open $dir/$config r} fd]} {
-  puts "error:"
-  puts "  $fd\n"
-  exit
-} else {
-  puts "done"
-}
-
-set count 0
-puts -nonewline "Scanning the config file "
-
-while {![eof $fd]} {
-  incr count
-  if {$count == 100} {
-    puts -nonewline "."
-    set count 0
+  if {[catch {open $dir/$config r} fd]} {
+    puts "error:"
+    puts "  $fd\n"
+    exit
+  } else {
+    puts "done"
   }
-  set line [gets $fd]
-  if {[set blarg [newsplit line]] != "set"} {
-    continue
-  }
-  switch -- [set opt [newsplit line]] {
-    "pidfile" -
-    "nick" -
-    "userfile" -
-    "botnet-nick" {
-      set $opt [string trim [newsplit line] " \""]
+
+  set count 0
+  puts -nonewline "Scanning the config file "
+
+  while {![eof $fd]} {
+    incr count
+    if {$count == 100} {
+      puts -nonewline "."
+      set count 0
+    }
+    set line [gets $fd]
+    if {[set blarg [newsplit line]] != "set"} {
+      continue
+    }
+    switch -- [set opt [newsplit line]] {
+      "pidfile" -
+      "nick" -
+      "userfile" -
+      "botnet-nick" {
+        set $opt [string trim [newsplit line] " \""]
+      }
     }
   }
-}
-close $fd
+  close $fd
 
-if {$count != 0} {
-  puts -nonewline "."
-}
+  if {$count != 0} {
+    puts -nonewline "."
+  }
 
-puts " done"
+  puts " done"
+}
 
  if {![info exists {botnet-nick}] && [info exists nick]} {
   puts "  Defaulting \$botnet-nick to \"$nick\""
   set botnet-nick $nick
- }
- if {![info exists pidfile]} {
-  puts "  Defaulting \$pidfile to \"pid.${botnet-nick}\""
-  set pidfile "pid.${botnet-nick}"
  }
  if {![info exists {botnet-nick}] || ![info exists userfile]} {
   puts "  *** ERROR: could not find either \$userfile or \$botnet-nick"
@@ -213,6 +221,14 @@ puts " done"
   puts ""
   exit
  }
+ set handlen [expr [string range "[exec $dir/$binary -v]" end-1 end] - 1]
+ set nick [string range [subst $nick] 0 $handlen]
+ set botnet-nick [string range [subst ${botnet-nick}] 0 $handlen]
+ if {![info exists pidfile]} {
+  puts "  Defaulting \$pidfile to \"pid.${botnet-nick}\""
+  set pidfile "pid.${botnet-nick}"
+ }
+ set pidfile [subst $pidfile]
  if {[catch {open $dir/${botnet-nick}.botchk w} fd]} {
   puts "  *** ERROR: unable to open '${botnet-nick}.botchk' for writing"
   puts ""
@@ -222,15 +238,16 @@ puts " done"
 #
 # ${botnet-nick}.botchk (generated on [clock format [clock seconds] -format "%B %d, %Y @ %I:%M%p"])
 #
-# Generated by AutoBotchk 1.10
+# Generated by AutoBotchk 1.11
 # Copyright (C) 1999, 2000, 2001, 2002, 2003 Jeff Fisher <guppy@eggheads.org>
+# Extra fixes by Cizzle
 #
 
 # change this to the directory you run your bot from:
 botdir=\"$dir\"
 
 # change this to the name of your bot's script in that directory:
-botscript=\"$binary $config\"
+botscript=\"$binary $mainconf\"
 
 # change this to the nickname of your bot (capitalization COUNTS)
 botname=\"${botnet-nick}\"
@@ -318,12 +335,13 @@ exit 0
   exit
  }
  puts -nonewline "Scanning crontab entries ... "
- 
+
 set tmp ".autobotchk[clock clicks].[pid]"
+set cronbotchk [string map {\\ \\\\ \[ \\\[ \] \\\]} "${botnet-nick}.botchk"]
 if {$email} {
-  set line "$minutes \* \* \* \* $dir/${botnet-nick}.botchk"
+  set line "$minutes \* \* \* \* $dir/${cronbotchk}"
 } {
-  set line "$minutes \* \* \* \* $dir/${botnet-nick}.botchk >\/dev\/null 2>&1"
+  set line "$minutes \* \* \* \* $dir/${cronbotchk} >\/dev\/null 2>&1"
 }
 
 if {[catch {exec crontab -l > $tmp} error ]} {
@@ -338,11 +356,12 @@ if {[catch {exec crontab -l > $tmp} error ]} {
   }
 }
 
+set cronbotchk [string map {\\ \\\\ \[ \\\[ \] \\\]} "${cronbotchk}"]
 set fd [open $tmp r]
 while {![eof $fd]} {
   set z [gets $fd]
-  if {[string match "*$dir/${botnet-nick}.botchk*" $z] ||
-      [string match "*$dir//${botnet-nick}.botchk*" $z]} {
+  if {[string match "*$dir/${cronbotchk}*" $z] ||
+      [string match "*$dir//${cronbotchk}*" $z]} {
     puts "found an existing entry, we're done now"
     puts ""
     exit


### PR DESCRIPTION
Found by: Cizzle and StephenS
Patch by: Cizzle
Fixes #239 

One-line summary: Several fixes for the autobotchk script.

Additional description:
 - adds possibilty for multiple confs if settings are split
 - fixes nick or botnet-nick with \\[ \\] in creating botchk file not findable by cron
 - fixes multiple cron entries added when \\[ \\] is in filename
 - fixes cases where botnet-nick="$nick" or pidfile="pid.${botnet-nick}" or any  of the other vars nick, userfile, pidfile and botnet-nick having one of the other vars in conf
 - fixes cases where botnet-nick or nick has handlen > defined handlen and pidfile uses this botnet-nick or nick

Test cases demonstrating functionality (if applicable):
 - put "set userfile" in another.conf, put "source another.conf" in your main bot.conf and then try running autobotchk
 - use $nick in botnet-nick, $botnet-nick in nick or any of those two in userfile and/or pidfile, run autobotchk and then run the generated *.botchk (in case of pidfile need to run it twice)
 - use \\[ \\] in botnet-nick (or nick if not set), run autobotchk and then wait for the cronjob to kick in (and fail) and you get mail
 - use \\[ \\] in botnet-nick (or nick if not set) and run autobotchk multiple times an then check crontab
 - use a botnet-nick (or nick if not set) longer than default handlen and set no pidfile or use $botnet-nick or $nick in pidfile, run autobotchk and then the generated *.botchk twice