### PR TITLE
Update mod.channels source and docs to have same defaults as eggdrop.conf

### DIFF
--- a/doc/settings/mod.channels
+++ b/doc/settings/mod.channels
@@ -365,11 +365,17 @@ There are also some variables you can set in your config file:
 
     set global-flood-nick 5:60
 
-    set global-chanmode "nt-likm"
+    set global-aop-delay 5:30
+
+    set global-idle-kick 0
+
+    set global-chanmode "nt"
 
     set global-stopnethack-mode 0
 
     set global-revenge-mode 0
+
+    set global-ban-type 3
 
     set global-ban-time 120
 
@@ -401,8 +407,8 @@ There are also some variables you can set in your config file:
         +userbans  
         +userexempts  
         +userinvites  
-        +protecthalfops  
-        +autohalfop  
+        -protecthalfops  
+        -autohalfop  
         -static
 
     }

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -939,7 +939,7 @@ char *channels_start(Function *global_funcs)
 {
   global = global_funcs;
 
-  gfld_chan_thr = 10;
+  gfld_chan_thr = 15;
   gfld_chan_time = 60;
   gfld_deop_thr = 3;
   gfld_deop_time = 10;
@@ -947,8 +947,10 @@ char *channels_start(Function *global_funcs)
   gfld_kick_time = 10;
   gfld_join_thr = 5;
   gfld_join_time = 60;
-  gfld_ctcp_thr = 5;
+  gfld_ctcp_thr = 3;
   gfld_ctcp_time = 60;
+  gfld_nick_thr = 5;
+  gfld_nick_time = 60;
   global_idle_kick = 0;
   global_aop_min = 5;
   global_aop_max = 30;
@@ -974,7 +976,7 @@ char *channels_start(Function *global_funcs)
          "-bitch "
          "+greet "
          "+protectops "
-         "+statuslog "
+         "-statuslog "
          "-revenge "
          "-secret "
          "-autovoice "


### PR DESCRIPTION
Found by: vanosg
Patch by: Cizzle
Fixes: #243 

One-line summary: Updates source and docs of the channels module to have all settings at same value as eggdrop.conf

Additional description: The "help-path" setting as mentioned in #243 did not need a sync, default in source was same as conf.
