### PR TITLE
Fix misleading indentation warnings from gcc.

### DIFF
--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -88,7 +88,7 @@ static int tcl_logfile STDVAR
                  logs[i].chname, logs[i].filename);
         Tcl_AppendElement(interp, s);
       }
-      return TCL_OK;
+    return TCL_OK;
   }
 
   BADARGS(4, 4, " ?logModes channel logFile?");

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -310,12 +310,12 @@ static int tcl_addbot STDVAR
     userlist = adduser(userlist, argv[1], "none", "-", USER_BOT);
     bi = user_malloc(sizeof(struct bot_addr));
 #ifdef IPV6
-  if ((q = strchr(argv[2], '/'))) {
-    if (!q[1]) {
-      *q = 0;
-      q = 0;
-    }
-  } else
+    if ((q = strchr(argv[2], '/'))) {
+      if (!q[1]) {
+        *q = 0;
+        q = 0;
+      }
+    } else
 #endif
     q = strchr(argv[2], ':');
     if (!q) {

--- a/src/userent.c
+++ b/src/userent.c
@@ -551,7 +551,7 @@ static int botaddr_write_userfile(FILE *f, struct userrec *u,
       *q++ = ';';
     else
       *q++ = *p;
-    *q = 0;
+  *q = 0;
 #ifdef TLS
   if (fprintf(f, "--%s %s:%s%u/%s%u\n", e->type->name, addr,
       (bi->ssl & TLS_BOT) ? "+" : "", bi->telnet_port, (bi->ssl & TLS_RELAY) ?


### PR DESCRIPTION
Found by: Cizzle
Patch by: Cizzle
Fixes: 

One-line summary: Correct some warnings about misleading indentation.
