### PR TITLE
Change global-* to default-* in docs and conf, add default-* in src.

### DIFF
--- a/doc/html/coreDocs/channels.html
+++ b/doc/html/coreDocs/channels.html
@@ -394,23 +394,23 @@ setting channel modes without having ops.</dd>
 <p>The following settings are used as default values when you .+chan #chan or .tcl
 channel add #chan. Look in the section above for explanation of every option.</p>
 <blockquote>
-<div><p>set global-flood-chan 15:60</p>
-<p>set global-flood-deop 3:10</p>
-<p>set global-flood-kick 3:10</p>
-<p>set global-flood-join 5:60</p>
-<p>set global-flood-ctcp 3:60</p>
-<p>set global-flood-nick 5:60</p>
-<p>set global-aop-delay 5:30</p>
-<p>set global-idle-kick 0</p>
-<p>set global-chanmode &quot;nt&quot;</p>
-<p>set global-stopnethack-mode 0</p>
-<p>set global-revenge-mode 0</p>
-<p>set global-ban-type 3</p>
-<p>set global-ban-time 120</p>
-<p>set global-exempt-time 60</p>
-<p>set global-invite-time 60</p>
+<div><p>set default-flood-chan 15:60</p>
+<p>set default-flood-deop 3:10</p>
+<p>set default-flood-kick 3:10</p>
+<p>set default-flood-join 5:60</p>
+<p>set default-flood-ctcp 3:60</p>
+<p>set default-flood-nick 5:60</p>
+<p>set default-aop-delay 5:30</p>
+<p>set default-idle-kick 0</p>
+<p>set default-chanmode &quot;nt&quot;</p>
+<p>set default-stopnethack-mode 0</p>
+<p>set default-revenge-mode 0</p>
+<p>set default-ban-type 3</p>
+<p>set default-ban-time 120</p>
+<p>set default-exempt-time 60</p>
+<p>set default-invite-time 60</p>
 <dl class="docutils">
-<dt>set global-chanset {</dt>
+<dt>set default-chanset {</dt>
 <dd><div class="first last line-block">
 <div class="line">-autoop</div>
 <div class="line">-autovoice</div>

--- a/doc/html/mainDocs/tcl-commands.html
+++ b/doc/html/mainDocs/tcl-commands.html
@@ -355,7 +355,7 @@ Changes are of the form '+f', '-o', '+dk', '-o+d', etc. If changes are specified
 </div></blockquote>
 <p><strong>newban &lt;ban&gt; &lt;creator&gt; &lt;comment&gt; [lifetime] [options]</strong></p>
 <blockquote>
-<div><p>Description: adds a ban to the global ban list (which takes effect on all channels); creator is given credit for the ban in the ban list. lifetime is specified in minutes. If lifetime is not specified, global-ban-time (usually 60) is used. Setting the lifetime to 0 makes it a permanent ban.</p>
+<div><p>Description: adds a ban to the global ban list (which takes effect on all channels); creator is given credit for the ban in the ban list. lifetime is specified in minutes. If lifetime is not specified, default-ban-time (usually 120) is used. Setting the lifetime to 0 makes it a permanent ban.</p>
 <p>Options:</p>
 <table border="1" class="docutils">
 <colgroup>

--- a/doc/settings/mod.channels
+++ b/doc/settings/mod.channels
@@ -409,37 +409,37 @@ There are also some variables you can set in your config file:
   #chan or .tcl channel add #chan. Look in the section above for
   explanation of every option.
 
-    set global-flood-chan 15:60
+    set default-flood-chan 15:60
 
-    set global-flood-deop 3:10
+    set default-flood-deop 3:10
 
-    set global-flood-kick 3:10
+    set default-flood-kick 3:10
 
-    set global-flood-join 5:60
+    set default-flood-join 5:60
 
-    set global-flood-ctcp 3:60
+    set default-flood-ctcp 3:60
 
-    set global-flood-nick 5:60
+    set default-flood-nick 5:60
 
-    set global-aop-delay 5:30
+    set default-aop-delay 5:30
 
-    set global-idle-kick 0
+    set default-idle-kick 0
 
-    set global-chanmode "nt"
+    set default-chanmode "nt"
 
-    set global-stopnethack-mode 0
+    set default-stopnethack-mode 0
 
-    set global-revenge-mode 0
+    set default-revenge-mode 0
 
-    set global-ban-type 3
+    set default-ban-type 3
 
-    set global-ban-time 120
+    set default-ban-time 120
 
-    set global-exempt-time 60
+    set default-exempt-time 60
 
-    set global-invite-time 60
+    set default-invite-time 60
 
-    set global-chanset {
+    set default-chanset {
 
         -autoop
         -autovoice

--- a/doc/sphinx_source/coreDocs/channels.rst
+++ b/doc/sphinx_source/coreDocs/channels.rst
@@ -338,37 +338,37 @@ There are also some variables you can set in your config file:
     The following settings are used as default values when you .+chan #chan or .tcl
     channel add #chan. Look in the section above for explanation of every option.
 
-      set global-flood-chan 15:60
+      set default-flood-chan 15:60
 
-      set global-flood-deop 3:10
+      set default-flood-deop 3:10
 
-      set global-flood-kick 3:10
+      set default-flood-kick 3:10
 
-      set global-flood-join 5:60
+      set default-flood-join 5:60
 
-      set global-flood-ctcp 3:60
+      set default-flood-ctcp 3:60
 
-      set global-flood-nick 5:60
+      set default-flood-nick 5:60
 
-      set global-aop-delay 5:30
+      set default-aop-delay 5:30
 
-      set global-idle-kick 0
+      set default-idle-kick 0
 
-      set global-chanmode "nt"
+      set default-chanmode "nt"
 
-      set global-stopnethack-mode 0
+      set default-stopnethack-mode 0
 
-      set global-revenge-mode 0
+      set default-revenge-mode 0
 
-      set global-ban-type 3
+      set default-ban-type 3
 
-      set global-ban-time 120
+      set default-ban-time 120
 
-      set global-exempt-time 60
+      set default-exempt-time 60
 
-      set global-invite-time 60
+      set default-invite-time 60
 
-      set global-chanset {
+      set default-chanset {
         | -autoop         
         | -autovoice
         | -bitch          

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -337,7 +337,7 @@ User Record Manipulation Commands
 
 **newban <ban> <creator> <comment> [lifetime] [options]**
 
-  Description: adds a ban to the global ban list (which takes effect on all channels); creator is given credit for the ban in the ban list. lifetime is specified in minutes. If lifetime is not specified, global-ban-time (usually 60) is used. Setting the lifetime to 0 makes it a permanent ban.
+  Description: adds a ban to the global ban list (which takes effect on all channels); creator is given credit for the ban in the ban list. lifetime is specified in minutes. If lifetime is not specified, default-ban-time (usually 120) is used. Setting the lifetime to 0 makes it a permanent ban.
 
   Options:
 

--- a/doc/tcl-commands.doc
+++ b/doc/tcl-commands.doc
@@ -390,7 +390,7 @@ newban <ban> <creator> <comment> [lifetime] [options]
   Description: adds a ban to the global ban list (which takes effect on
   all channels); creator is given credit for the ban in the ban list.
   lifetime is specified in minutes. If lifetime is not specified,
-  global-ban-time (usually 60) is used. Setting the lifetime to 0 makes
+  default-ban-time (usually 60) is used. Setting the lifetime to 0 makes
   it a permanent ban.
 
   Options:

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -664,23 +664,23 @@ set allow-ps 0
 # The following settings are used as default values when you .+chan #chan or .tcl
 # channel add #chan. Look below for explanation of every option.
 
-set global-flood-chan 15:60
-set global-flood-deop 3:10
-set global-flood-kick 3:10
-set global-flood-join 5:60
-set global-flood-ctcp 3:60
-set global-flood-nick 5:60
-set global-aop-delay 5:30
-set global-idle-kick 0
-set global-chanmode "nt"
-set global-stopnethack-mode 0
-set global-revenge-mode 0
-set global-ban-type 3
-set global-ban-time 120
-set global-exempt-time 60
-set global-invite-time 60
+set default-flood-chan 15:60
+set default-flood-deop 3:10
+set default-flood-kick 3:10
+set default-flood-join 5:60
+set default-flood-ctcp 3:60
+set default-flood-nick 5:60
+set default-aop-delay 5:30
+set default-idle-kick 0
+set default-chanmode "nt"
+set default-stopnethack-mode 0
+set default-revenge-mode 0
+set default-ban-type 3
+set default-ban-time 120
+set default-exempt-time 60
+set default-invite-time 60
 
-set global-chanset {
+set default-chanset {
         -autoop         -autovoice
         -bitch          +cycle
         +dontkickops    +dynamicbans


### PR DESCRIPTION
Found by: thommey
Patch by: Cizzle
Fixes: #189 

One-line summary: Changes the global-* settings to default-* settings in docs and conf, adds the default-* settings in src with same functionality and keeps global-* in src for backward compatibility.
