### PR TITLE
Return more user-friendly message with incorrect vhost4/6 setting in config.

### DIFF
--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -205,8 +205,8 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0x647,Modekø er på
 0x648,Serverkø er på
 0x649,Hjælpekø er på
-# 0x64a - unused
-# 0x64b - unused
+0x64a,Vhost set in config can not be used to connect to this address 
+0x64b,Vhost set in config is not available on this machine
 0x64c,Behandler kanal
 0x64d,Kanal
 0x64e,Ønsker kanal

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -205,8 +205,8 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0x647,Mode queue is at
 0x648,Server queue is at
 0x649,Help queue is at
-# 0x64a - unused
-# 0x64b - unused
+0x64a,Vhost set in config can not be used to connect to this address
+0x64b,Vhost set in config is not available on this machine
 0x64c,Processing channel
 0x64d,Channel
 0x64e,Desiring channel

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -205,8 +205,8 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0x647,Moodi queue on nyt
 0x648,Serveri queue on nyt
 0x649,Auto queue on nyt
-# 0x64a - ei käytössä
-# 0x64b - ei käytössä
+0x64a,Vhost set in config can not be used to connect to this address 
+0x64b,Vhost set in config is not available on this machine
 0x64c,Tapahtuma kanava
 0x64d,Kanava
 0x64e,Halutaan kanava

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -206,8 +206,8 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x647,La file d'attente des modes est à
 0x648,La file d'attente des serveurs est à
 0x649,La file d'attente d'aide est à
-# 0x64a - unused
-# 0x64b - unused
+0x64a,Vhost set in config can not be used to connect to this address 
+0x64b,Vhost set in config is not available on this machine
 0x64c,Traitement du canal
 0x64d,Canal
 0x64e,Je désire le canal

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -206,8 +206,8 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x647,La file d'attente des modes est ‡
 0x648,La file d'attente des serveurs est ‡
 0x649,La file d'attente d'aide est ‡
-0x64a,Vhost set in config can not be used to connect to this address 
-0x64b,Vhost set in config is not available on this machine
+0x64a,Le vhost qu'est configur√© dans le fichier de configuration n'est pas capable de connecter √† l'addresse du serveur
+0x64b,Le vhost qu'est configur√© dans le fichier de configuration n'est pas disponsible en cette machine
 0x64c,Traitement du canal
 0x64d,Canal
 0x64e,Je dÈsire le canal

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -212,8 +212,8 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0x647,Mode-Queue ist bei
 0x648,Server-Queue ist bei
 0x649,Hilfe-Queue ist bei
-# 0x64a - unused
-# 0x64b - unused
+0x64a,Vhost set in config can not be used to connect to this address 
+0x64b,Vhost set in config is not available on this machine
 0x64c,Bearbeite Channel
 0x64d,Channel
 #need context

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -212,8 +212,8 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0x647,Mode-Queue ist bei
 0x648,Server-Queue ist bei
 0x649,Hilfe-Queue ist bei
-0x64a,Vhost set in config can not be used to connect to this address 
-0x64b,Vhost set in config is not available on this machine
+0x64a,Der Vhost, der in der Konfig eingestellt ist, kann nicht benutzt werden um zu dieser IP-Adresse zu verbinden
+0x64b,Der Vhost, der in der Konfig eingestellt ist, ist auf diesem Computer nicht verfÃ¼gbar
 0x64c,Bearbeite Channel
 0x64d,Channel
 #need context

--- a/src/lang.h
+++ b/src/lang.h
@@ -197,8 +197,8 @@
 #define IRC_MODEQUEUE           get_language(0x647)
 #define IRC_SERVERQUEUE         get_language(0x648)
 #define IRC_HELPQUEUE           get_language(0x649)
-/* was: IRC_BOTNOTONIRC         0x64a            */
-/* was: IRC_NOTACTIVECHAN       0x64b            */
+#define IRC_VHOSTWRONGNET	get_language(0x64a)
+#define IRC_VHOSTBADADDR	get_language(0x64b)
 #define IRC_PROCESSINGCHAN      get_language(0x64c)
 #define IRC_CHANNEL             get_language(0x64d)
 #define IRC_DESIRINGCHAN        get_language(0x64e)

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1290,8 +1290,16 @@ static void server_resolve_success(int servidx)
   setsnport(dcc[servidx].sockname, dcc[servidx].port);
   serv = open_telnet_raw(dcc[servidx].sock, &dcc[servidx].sockname);
   if (serv < 0) {
+    char *errstr = NULL;
+    if (errno == EINVAL) {
+      errstr = IRC_VHOSTWRONGNET;
+    } else if (errno == EADDRNOTAVAIL) {
+      errstr = IRC_VHOSTBADADDR;
+    } else {
+      errstr = strerror(errno);
+    }
     putlog(LOG_SERV, "*", "%s %s (%s)", IRC_FAILEDCONNECT, dcc[servidx].host,
-           strerror(errno));
+           errstr);
     check_tcl_event("fail-server");
     lostdcc(servidx);
     return;


### PR DESCRIPTION
Found by: Geo, thommey
Patch by: Cizzle
Fixes: #301 

One-line summary: Returns more user-friendly messages when vhost4, vhost6 or the deprecated my-ip or my-hostname are incorrectly set in config.

Additional description (if needed):
Instead of "Invalid argument" it will now reply "Vhost set in config can not be used to connect to this address".
Instead of "Cannot assign requested address" it will now reply "Vhost set in config is not available on this machine".
The danish, finnish, french and german language files will need an update.

Test cases demonstrating functionality (if applicable):
 - Set "vhost4" in config to "127.0.0.1" and try to connect to any public IRC server for the "Invalid argument" reply.
 - Set "vhost4" in config to "1.2.3.4" (or another address if this one would be valid on your machine) and try to connect to any public IRC server for the "Cannot assign requested address" reply.
