### PR TITLE
Bug/patchwarn

### DIFF
--- a/misc/releaseprep
+++ b/misc/releaseprep
@@ -86,6 +86,8 @@ fix_patch_h() {
 		cat src/patch.h | sed 's/^patch.*Git.*Git version \*\//patch("PRE-RELEASE");           \/* RC version *\//g' > src/patch.h_
 	else
 		cat src/patch.h | sed 's/^patch.*/\/* PATCH GOES HERE *\//g' > src/patch.h_
+		mv src/patch.h_ src/patch.h
+		cat src/patch.h | sed -e '0,/^\/\* PATCH GOES HERE \*\//s//patch("");/' > src/patch.h_
 	fi
 	mv src/patch.h_ src/patch.h
 }

--- a/src/main.c
+++ b/src/main.c
@@ -733,7 +733,8 @@ static void patch(const char *str)
 
   if (!p)
     p = &egg_version[strlen(egg_version)];
-  sprintf(p, "+%s", str);
+  if (str[0])
+    sprintf(p, "+%s", str);
   egg_numver++;
   sprintf(&egg_xtra[strlen(egg_xtra)], " %s", str);
 }

--- a/src/patch.h
+++ b/src/patch.h
@@ -39,12 +39,12 @@ patch("Git");                   /* Git version */
  *
  *
  */
-patch("1483083216");            /* current unixtime */
+patch("1483331766");            /* current unixtime */
 /*
  *
  *
  */
-patch("docfilter");
+patch("patchwarn");
 /*
  *
  *


### PR DESCRIPTION
Found by: thommey
Patch by: Geo
Fixes: #303 

One-line summary: Change releaseprep patch version string to "" for stable release.


Additional description (if needed):


Test cases demonstrating functionality (if applicable):

No compile error, and correct version string produced
```
$ ./eggdrop -v
Eggdrop v1.8.0 (C) 1997 Robey Pointer (C) 2010-2016 Eggheads
```