### PR TITLE
Bug/uninit channel

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1934,7 +1934,7 @@ static void init_channel(struct chanset_t *chan, int reset)
       nfree(chan->channel.member); 
     }
     chan->channel.members = 0;
-    chan->channel.member = nmalloc(sizeof(memberlist));
+    chan->channel.member = nmalloc(sizeof *chan->channel.member);
     /* Since we don't have channel_malloc, manually bzero */
     egg_bzero(chan->channel.member, sizeof *chan->channel.member);
     chan->channel.member->nick[0] = 0;

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1935,6 +1935,8 @@ static void init_channel(struct chanset_t *chan, int reset)
     }
     chan->channel.members = 0;
     chan->channel.member = nmalloc(sizeof(memberlist));
+    /* Since we don't have channel_malloc, manually bzero */
+    egg_bzero(chan->channel.member, sizeof *chan->channel.member);
     chan->channel.member->nick[0] = 0;
     chan->channel.member->next = NULL;
   }

--- a/src/patch.h
+++ b/src/patch.h
@@ -39,12 +39,12 @@ patch("Git");                   /* Git version */
  *
  *
  */
-patch("1485620062");            /* current unixtime */
+patch("1486095498");            /* current unixtime */
 /*
  *
  *
  */
-patch("detectssl");
+patch("channelinit");
 /*
  *
  *


### PR DESCRIPTION
Found by: Geo
Patch by: thommey
Fixes: #326 

One-line summary:
Zero memory after nmalloc() to initialize memberlist

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
valgrind doesn't detect uninitialized conditional jump