### PR TITLE
Simplify sockgets line parsing

### DIFF
--- a/src/patch.h
+++ b/src/patch.h
@@ -39,12 +39,12 @@ patch("Git");                   /* Git version */
  *
  *
  */
-patch("1486095498");            /* current unixtime */
+patch("1486176263");            /* current unixtime */
 /*
  *
  *
  */
-patch("channelinit");
+patch("sockgets");
 /*
  *
  *


### PR DESCRIPTION
This simplifies the line parsing of sockets, and fixes the bug where s[strlen(s)-1] accesses invalid memory in case of an empty line (s = "\n" and it looks behind to find '\r').

Found by:
Patch by:
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
