### PR TITLE
Fix autobotchk error when eggdrop returns an error.

### DIFF
--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -88,7 +88,7 @@ exec tclsh$lastver "$0" ${1+"$@"}
 #   13Dec2016: add possibility to use multiple confs; fixes for (botnet-)nick
 #              with len > handlen, for (botnet-)nicks with \[ \] and for
 #              $(botnet-)nick used in pidfile, userfile or (botnet-)nick
-#
+#   19Apr2017: Fix running this from a non-eggdrop dir.
 
 if {$argc == 0} {
   puts "\nusage: $argv0 <eggdrop mainconfig> \[options\] \[additional configs\]"
@@ -247,9 +247,7 @@ foreach config $confs {
   puts ""
   exit
  }
- if {[catch {exec "$dir/$binary" -v} execres]} {
-  puts "\nWARNING: eggdrop could not be executed properly, verify execution manually!\n"
- }
+ catch {exec "$dir/$binary" -v} execres
  if {![regexp {handlen=([0-9]+)} "$execres" -> handlen]} {
   puts "  Could not find handlen used, defaulting to 32."
   # len 32 means up to index 31

--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -247,7 +247,10 @@ foreach config $confs {
   puts ""
   exit
  }
- if {![regexp {handlen=([0-9]+)} "[exec "$dir/$binary" -v]" -> handlen]} {
+ if {[catch {exec "$dir/$binary" -v} execres]} {
+  puts "\nWARNING: eggdrop could not be executed properly, verify execution manually!\n"
+ }
+ if {![regexp {handlen=([0-9]+)} "$execres" -> handlen]} {
   puts "  Could not find handlen used, defaulting to 32."
   # len 32 means up to index 31
   set handlen 31


### PR DESCRIPTION
Found by: @Arkadietz
Patch by: Cizzle
Fixes: #367 

One-line summary: Shows a warning about an eggdrop error instead of malfunctioning when autobotchk is run.