### PR TITLE
Use new ASN1_STRING_get0_data fucntion when available.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -31,6 +31,9 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#  define ASN1_STRING_data ASN1_STRING_get0_data
+#endif
 
 extern int tls_vfydcc;
 extern struct dcc_t *dcc;


### PR DESCRIPTION
Found by: @vanosg
Patch by: Cizzle
Fixes: #324 

One-line summary: Fixes the warnings about the deprecated ASN1_STRING_data() function when using OpenSSL 1.1.0+

Adding a (configure-generated) define in config.h (which is included via main.h) generates a "conflicting type" error when compiling and is thus not usable.

Might be preferable to do the define the other way around and use the newer name in the code for future readings?