### PR TITLE
Add error message if server list contains only SSL servers and TLS is disabled

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -100,7 +100,7 @@ static int tls_vfyserver;       /* Certificate validation mode for servrs  */
 #endif
 
 #ifndef TLS
-char sslserver = 0;
+static char sslserver = 0;
 #endif
 
 static p_tcl_bind_list H_wall, H_raw, H_notc, H_msgm, H_msg, H_flud, H_ctcr,
@@ -972,7 +972,7 @@ static void add_server(const char *ss)
     putlog(LOG_MISC, "*", "ERROR: Attempted to add SSL-enabled server, but \
 Eggdrop was not compiled with SSL libraries. Skipping...");
     sslserver = 1;
-  return;
+    return;
   }
 #endif
 

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -99,6 +99,10 @@ static int use_ssl;		/* Use SSL for the next server connection? */
 static int tls_vfyserver;       /* Certificate validation mode for servrs  */
 #endif
 
+#ifndef TLS
+char sslserver = 0;
+#endif
+
 static p_tcl_bind_list H_wall, H_raw, H_notc, H_msgm, H_msg, H_flud, H_ctcr,
                        H_ctcp, H_out;
 
@@ -967,6 +971,7 @@ static void add_server(const char *ss)
   if (port[0] == '+') {
     putlog(LOG_MISC, "*", "ERROR: Attempted to add SSL-enabled server, but \
 Eggdrop was not compiled with SSL libraries. Skipping...");
+    sslserver = 1;
   return;
   }
 #endif
@@ -1681,8 +1686,15 @@ static void server_postrehash()
   strncpyz(botname, origbotname, NICKLEN);
   if (!botname[0])
     fatal("NO BOT NAME.", 0);
-  if (serverlist == NULL)
-    fatal("NO SERVER.", 0);
+  if ((serverlist == NULL)
+#ifndef TLS
+  && (sslserver)) {
+    fatal("NO NON-SSL SERVERS ADDED (TLS IS DISABLED).", 0);
+  } else if (serverlist == NULL
+#endif
+  ) {
+    fatal("NO SERVERS ADDED.", 0);
+  }
   if (oldnick[0] && !rfc_casecmp(oldnick, botname) &&
       !rfc_casecmp(oldnick, get_altbotnick())) {
     /* Change botname back, don't be premature. */

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.1"
-#define EGG_NUMVER 1080103
-#define EGG_PATCH "safechannelsreload"
+#define EGG_NUMVER 1080104
+#define EGG_PATCH "sslserverlist"


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #348 

One-line summary:
Add error message if server list contains only SSL servers and TLS is disabled

Additional description (if needed):


Test cases demonstrating functionality (if applicable):

With only SSL servers and --disable-tls:
```
<cut>
[04:58:13] Module loaded: blowfish        
[04:58:13] * NO NON-SSL SERVER (TLS DISABLED).
```
With non-SSL servers and --disable-tls
```
<cut>
[04:58:46] Module loaded: blowfish        
[04:58:46] Writing channel file...
[04:58:46] Userfile loaded, unpacking...
[04:58:46] === scooby: 0 channels, 130 users.
Launched into the background  (pid: 57598)
```