### PR TITLE
Have full access when starting bot with -tn.

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -863,6 +863,8 @@ static void cmd_chhandle(struct userrec *u, int idx, char *par)
     atr2 = u2 ? u2->flags : 0;
     if ((atr & USER_BOTMAST) && !(atr & USER_MASTER) && !(atr2 & USER_BOT))
       dprintf(idx, "You can't change handles for non-bots.\n");
+    else if (!egg_strcasecmp(hand, EGG_BG_HANDLE))
+      dprintf(idx, "You can't change the handle of a temporary user.\n");
     else if ((bot_flags(u2) & BOT_SHARE) && !(atr & USER_OWNER))
       dprintf(idx, "You can't change share bot's nick.\n");
     else if ((atr2 & USER_OWNER) && !(atr & USER_OWNER) &&
@@ -900,6 +902,8 @@ static void cmd_handle(struct userrec *u, int idx, char *par)
     dprintf(idx,
             "Bizarre quantum forces prevent handle from starting with '%c'.\n",
             newhandle[0]);
+  else if (!egg_strcasecmp(u->handle, EGG_BG_HANDLE))
+    dprintf(idx, "You can't change the handle of this temporary user.\n");
   else if (get_user_by_handle(userlist, newhandle) &&
            egg_strcasecmp(dcc[idx].nick, newhandle))
     dprintf(idx, "Somebody is already using %s.\n", newhandle);

--- a/src/main.c
+++ b/src/main.c
@@ -1190,7 +1190,7 @@ int main(int arg_c, char **arg_v)
     dcc[n].u.chat->con_flags = conmask;
     dcc[n].u.chat->strip_flags = STRIP_ALL;
     dcc[n].status = STAT_ECHO;
-    strcpy(dcc[n].nick, "HQ");
+    strcpy(dcc[n].nick, EGG_BG_HANDLE);
     strcpy(dcc[n].host, "llama@console");
     /* HACK: Workaround not to pass literal "HQ" as a non-const arg */
     dcc[n].user = get_user_by_handle(userlist, dcc[n].nick);
@@ -1199,6 +1199,14 @@ int main(int arg_c, char **arg_v)
       userlist = adduser(userlist, dcc[n].nick, "none", "-", USER_PARTY);
       dcc[n].user = get_user_by_handle(userlist, dcc[n].nick);
     }
+    /* Give all useful flags: efjlmnoptuvx */
+    dcc[n].user->flags = USER_EXEMPT | USER_FRIEND | USER_JANITOR |
+                         USER_HALFOP | USER_MASTER | USER_OWNER | USER_OP |
+                         USER_PARTY | USER_BOTMAST | USER_UNSHARED |
+                         USER_VOICE | USER_XFER;
+    /* Add to permowner list if there's place */
+    if (strlen(owner) + 4 < sizeof owner)
+      strcat(owner, " " EGG_BG_HANDLE);
     setsock(STDOUT, 0);          /* Entry in net table */
     dprintf(n, "\n### ENTERING DCC CHAT SIMULATION ###\n");
     dprintf(n, "You can use the .su command to log into your Eggdrop account.\n\n");

--- a/src/main.c
+++ b/src/main.c
@@ -1205,7 +1205,7 @@ int main(int arg_c, char **arg_v)
                          USER_PARTY | USER_BOTMAST | USER_UNSHARED |
                          USER_VOICE | USER_XFER;
     /* Add to permowner list if there's place */
-    if (strlen(owner) + 4 < sizeof owner)
+    if (strlen(owner) + sizeof EGG_BG_HANDLE < sizeof owner)
       strcat(owner, " " EGG_BG_HANDLE);
     setsock(STDOUT, 0);          /* Entry in net table */
     dprintf(n, "\n### ENTERING DCC CHAT SIMULATION ###\n");

--- a/src/main.h
+++ b/src/main.h
@@ -141,4 +141,7 @@ extern struct dcc_table DCC_CHAT, DCC_BOT, DCC_LOST, DCC_SCRIPT, DCC_BOT_NEW,
 #  define O_NONBLOCK 00000004 /* POSIX non-blocking I/O */
 #endif /* BORGCUBES */
 
+/* Handle for the user that's used when starting eggdrop with -tn */
+#define EGG_BG_HANDLE "-HQ"
+
 #endif /* _EGG_MAIN_H */

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -572,8 +572,9 @@ void write_userfile(int idx)
   strncpyz(s1, ctime(&tt), sizeof s1);
   fprintf(f, "#4v: %s -- %s -- written %s", ver, botnetnick, s1);
   ok = 1;
+  /* Add all users except the -tn user */
   for (u = userlist; u && ok; u = u->next)
-    if (!write_user(u, f, idx))
+    if (egg_strcasecmp(u->handle, EGG_BG_HANDLE) && !write_user(u, f, idx))
       ok = 0;
   if (!ok || !write_ignores(f, -1) || fflush(f)) {
     putlog(LOG_MISC, "*", "%s (%s)", USERF_ERRWRITE, strerror(ferror(f)));
@@ -593,6 +594,9 @@ int change_handle(struct userrec *u, char *newh)
   char s[HANDLEN + 1];
 
   if (!u)
+    return 0;
+  /* Don't allow the -tn handle to be changed */
+  if (!egg_strcasecmp(u->handle, EGG_BG_HANDLE))
     return 0;
   /* Nothing that will confuse the userfile */
   if (!newh[1] && strchr(BADHANDCHARS, newh[0]))


### PR DESCRIPTION
Found by: thommey
Patch by: Cizzle
Fixes: #173 

One-line summary: Make terminal user an invalid one, give permowner (and all others) access and disable it's handle being changed and it's userrecord being saved in the userfile.

Additional description: The temporary user used is now called "-HQ", where the starting dash makes it an invalid real user. It is given full bot access and is made permowner.
There's only 2 things that won't work:
- Changing the handle (via .handle, .chhandle, .tcl chhandle, ...)
- Saving the user in the userfile (via .save, the hourly save, ...)

Sharing this user is also turned off but this can be lifted by removing the 'u' userflag. Not recommended of course.