### PR TITLE
Check if current nick matches altnick mask before switching, after a rehash

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1213,7 +1213,7 @@ static char *get_altbotnick(void)
 {
   /* A random-number nick? */
   if (strchr(altnick, '?')) {
-    if (!raltnick[0]) {
+    if (!raltnick[0] && !wild_match(altnick, botname)) {
       strncpyz(raltnick, altnick, NICKLEN);
       rand_nick(raltnick);
     }

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.1"
-#define EGG_NUMVER 1080106
-#define EGG_PATCH "cliflags"
+#define EGG_NUMVER 1080107
+#define EGG_PATCH "altnick"


### PR DESCRIPTION
Found by: thommey
Patch by: Geo
Fixes: #366 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
