### PR TITLE
Fix some oob (and an iob) for a few config settings.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -120,7 +120,7 @@ int term_z = 0;         /* Foreground: use the terminal as a partyline?  */
 int use_stderr = 1;     /* Send stuff to stderr instead of logfiles?     */
 
 char configfile[121] = "eggdrop.conf";  /* Default config file name */
-char pid_file[120];                     /* Name of the pid file     */
+char pid_file[121];                     /* Name of the pid file     */
 char helpdir[121] = "help/";            /* Directory of help files  */
 char textdir[121] = "text/";            /* Directory for text files */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -53,7 +53,7 @@ extern time_t now;
 extern Tcl_Interp *interp;
 
 char logfile_suffix[21] = ".%d%b%Y";    /* Format of logfile suffix */
-char log_ts[32] = "[%H:%M:%S]"; /* Timestamp format for logfile entries */
+char log_ts[33] = "[%H:%M:%S]"; /* Timestamp format for logfile entries */
 
 int shtime = 1;                 /* Display the time with console output */
 log_t *logs = 0;                /* Logfiles */

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -29,7 +29,7 @@
 
 static Function *global = NULL;
 
-static char chanfile[121], glob_chanmode[64];
+static char chanfile[121], glob_chanmode[65];
 static char *lastdeletedmask;
 
 static struct udef_struct *udef;

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -61,7 +61,7 @@ static time_t lastpingcheck;    /* set when i unidle myself, cleared when
 static time_t server_online;    /* server connection time */
 static time_t server_cycle_wait;        /* seconds to wait before
                                          * re-beginning the server list */
-static char botrealname[121];   /* realname of bot */
+static char botrealname[81];    /* realname of bot */
 static int server_timeout;      /* server timeout for connecting */
 static struct server_list *serverlist;  /* old-style queue, still used by
                                          * server list */

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -48,7 +48,7 @@ static Function *global = NULL, *transfer_funcs = NULL, *channels_funcs = NULL;
 
 static int private_global = 0;
 static int private_user = 0;
-static char private_globals[50];
+static char private_globals[51];
 static int allow_resync = 0;
 static struct flag_record fr = { 0, 0, 0, 0, 0, 0 };
 static int resync_time = 900;

--- a/src/net.c
+++ b/src/net.c
@@ -69,7 +69,7 @@ int pref_af = 0;              /* Prefer IPv6 over IPv4?                       */
 #endif
 char firewall[121] = "";      /* Socks server for firewall.                   */
 int firewallport = 1080;      /* Default port of socks 4/5 firewalls.         */
-char botuser[21] = "eggdrop"; /* Username of the user running the bot.        */
+char botuser[11] = "eggdrop"; /* Username of the user running the bot.        */
 int dcc_sanitycheck = 0;      /* Do some sanity checking on dcc connections.  */
 
 sock_list *socklist = NULL;   /* Enough to be safe.                           */


### PR DESCRIPTION
Found by: Cizzle
Patch by: Cizzle
Fixes: 

One-line summary: The default-chanmode and private-globals settings could defunct the bot when holding too many chars.