### PR TITLE
Do not start if -n is missing from -c or -t cli flags

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -589,12 +589,10 @@ static void do_arg()
   } else if (cliflags & 1) {
     show_ver();
     exit(0);
-  } else if ((cliflags & 8) || (cliflags & 4)) {
-    if (!(cliflags & 16)) {
-      printf("\n%s\n", version);
-      printf("ERROR: The -n flag is required when using the -c or -t flags. Exiting...\n\n");
-      exit(1);
-    }
+  } else if (!(cliflags & 16) && ((cliflags & 8) || (cliflags & 4))) {
+    printf("\n%s\n", version);
+    printf("ERROR: The -n flag is required when using the -c or -t flags. Exiting...\n\n");
+    exit(1);
   } else if (argc > (optind + 1)) {
     printf("\n");
     printf("WARNING: More than one config file value detected\n");

--- a/src/main.c
+++ b/src/main.c
@@ -589,6 +589,12 @@ static void do_arg()
   } else if (cliflags & 1) {
     show_ver();
     exit(0);
+  } else if ((cliflags & 8) || (cliflags & 4)) {
+    if (!(cliflags & 16)) {
+      printf("\n%s\n", version);
+      printf("ERROR: The -n flag is required when using the -c or -t flags. Exiting...\n\n");
+      exit(1);
+    }
   } else if (argc > (optind + 1)) {
     printf("\n");
     printf("WARNING: More than one config file value detected\n");


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #391 

One-line summary:
Do not start if -n is missing from -c or -t cli flags

Additional description (if needed):
Check for -c or -t, if -n isn't there, exit and return 1.

Test cases demonstrating functionality (if applicable):
```
$ ./eggdrop -t

Eggdrop v1.8.1+altnick (C) 1997 Robey Pointer (C) 1999-2017 Eggheads
ERROR: The -n flag is required when using the -c or -t flags. Exiting...
```