### PR TITLE
Fix some more invalid options and use correct response.

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1514,12 +1514,12 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
       /* Check for valid X:Y, denying X, :Y, X: and X:Y:Z[:...] */
       if (p && item[i] != p && *(p+1) && !strchr(p+1, ':')) {
         *p++ = 0;
-        /* We don't care about strtol's return val, only what endptr holds */
-        if ((strtol(item[i], &endptr, 10), (*endptr))
-           || (strtol(p, &endptr, 10), (*endptr))) {
+        /* strtol's return val should not be negative and endptr be NULL */
+        if (strtol(item[i], &endptr, 10) < 0 || (*endptr)
+           || strtol(p, &endptr, 10) < 0 || (*endptr)) {
           *--p = ':';
           if (irp)
-            Tcl_AppendResult(irp, "values must be integers: ", item[i], NULL);
+            Tcl_AppendResult(irp, "values must be integers >= 0: ", item[i], NULL);
           return TCL_ERROR;
         } else {
           *pthr = atoi(item[i]);

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1511,8 +1511,8 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
         return TCL_ERROR;
       }
       p = strchr(item[i], ':');
-      /* Check for valid X:Y, denying X, :Y and X: */
-      if (p && item[i] != p && *(p+1)) {
+      /* Check for valid X:Y, denying X, :Y, X: and X:Y:Z[:...] */
+      if (p && item[i] != p && *(p+1) && !strchr(p+1, ':')) {
         *p++ = 0;
         /* We don't care about strtol's return val, only what endptr holds */
         if ((strtol(item[i], &endptr, 10), (*endptr))

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1511,11 +1511,12 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
         return TCL_ERROR;
       }
       p = strchr(item[i], ':');
-      if (p) {
+      /* Check for valid X:Y, denying X, :Y and X: */
+      if (p && item[i] != p && *(p+1)) {
         *p++ = 0;
-        if ((!strtol(item[i], &endptr, 10) && (*endptr))
-           || (!strtol(p, &endptr, 10) && (*endptr))
-           || !*p || !*item[i]) { // Block :X or X: inputs
+        /* We don't care about strtol's return val, only what endptr holds */
+        if ((strtol(item[i], &endptr, 10), (*endptr))
+           || (strtol(p, &endptr, 10), (*endptr))) {
           *--p = ':';
           if (irp)
             Tcl_AppendResult(irp, "values must be integers: ", item[i], NULL);
@@ -1526,7 +1527,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           *--p = ':';
         }
       } else {
-        if (!strtol(item[i], &endptr, 10) && !(*endptr)) {
+        if ((*item[i]) && !strtol(item[i], &endptr, 10) && !(*endptr)) {
           *pthr = 0;  // Shortcut for .chanset #chan flood-x 0 to activate 0:0
           *ptime = 0;
         } else {


### PR DESCRIPTION
Found by: @vanosg 
Patch by: Cizzle
Fixes: #406 

One-line summary: Fixes incorrect output like "4a:5b", "3:4:5" etc being allowed. Also uses the correct error message.