### PR TITLE
Always have +o console flag for new -nt runs.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1234,7 +1234,7 @@ int main(int arg_c, char **arg_v)
     getvhost(&dcc[term_z].sockname, AF_INET);
     dcc[term_z].sock = STDOUT;
     dcc[term_z].timeval = now;
-    dcc[term_z].u.chat->con_flags = conmask;
+    dcc[term_z].u.chat->con_flags = conmask | EGG_BG_CONMASK;
     dcc[term_z].u.chat->strip_flags = STRIP_ALL;
     dcc[term_z].status = STAT_ECHO;
     strcpy(dcc[term_z].nick, EGG_BG_HANDLE);

--- a/src/main.h
+++ b/src/main.h
@@ -143,6 +143,8 @@ extern struct dcc_table DCC_CHAT, DCC_BOT, DCC_LOST, DCC_SCRIPT, DCC_BOT_NEW,
 
 /* Handle for the user that's used when starting eggdrop with -tn */
 #define EGG_BG_HANDLE "-HQ"
+/* Default recommended flags for this user, use | as splitter */
+#define EGG_BG_CONMASK LOG_MISC /* "o" */
 
 /* Stringify macros */
 #define EGG_MACRO_STR(x) EGG_STR(x)


### PR DESCRIPTION
Found by: @thommey 
Patch by: Cizzle
Fixes: #428 

One-line summary: Appends +o to the console flags of the -HQ user when starting eggdrop with -nt.

Additional description: This mode can simply be removed during the run.
