### PR TITLE
Make T_A handler mirror the T_AAAA behaviour. Partial fix for #433.

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -914,12 +914,13 @@ void parserespacket(u_8bit_t *response, int len)
         ddebug0(RES_WRN "Ignoring response with unexpected query type \"A\".");
         return;
       }
-      rp->sockname.family = AF_INET;
 #ifndef IPV6
+      rp->sockname.family = AF_INET;
       break;
 #else
       if (rp->sockname.family == AF_INET6)
         ready = 1;
+      rp->sockname.family = AF_INET;
       break;
     case T_AAAA:
       if (!IS_A(rp)) {


### PR DESCRIPTION
It doesn't make sense to set `rp->sockname.family` to `AF_INET` and then immediately check if it equals `AF_INET6`. The condition will always be false.

This changes the behaviour of T_A to mirror the behaviour of T_AAAA.