### PR TITLE
Swap incorrect 'ssl-privatekey/certificate not loaded' error messages

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -140,10 +140,10 @@ int ssl_init()
   if (!tls_certfile[0]) {
     ssl_files_loaded = 0;
     if (tls_keyfile[0])
-      putlog(LOG_MISC, "*", "ERROR: TLS: ssl-privatekey not set, ignoring ssl-certificate.");
+      putlog(LOG_MISC, "*", "ERROR: TLS: ssl-certificate not set, ignoring ssl-privatekey.");
   } else if (!tls_keyfile[0]) {
     ssl_files_loaded = 0;
-    putlog(LOG_MISC, "*", "ERROR: TLS: ssl-certificate not set, ignoring ssl-privatekey.");
+    putlog(LOG_MISC, "*", "ERROR: TLS: ssl-privatekey not set, ignoring ssl-certificate.");
   } else {
     ssl_files_loaded = 1;
     /* Load our own certificate and private key. Mandatory for acting as


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #444 

One-line summary: Swap incorrect 'ssl-privatekey/certificate not loaded' error messages


Additional description (if needed):


Test cases demonstrating functionality (if applicable):

with #set ssl-certificate "eggdrop.crt"
```
[03:01:07] ERROR: TLS: ssl-certificate not set, ignoring ssl-privatekey.
```

with #set ssl-privatekey "eggdrop.key"
```
[03:00:46] ERROR: TLS: ssl-privatekey not set, ignoring ssl-certificate.
```