### PR TITLE
Add new bot share cmd to request userflags for a new channel.

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -2108,6 +2108,9 @@ static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
     egg_list_append((struct list_type **) &chanset, (struct list_type *) chan);
     /* Channel name is stored in xtra field for sharebot stuff */
     join = 1;
+    /* Request user chanflags from other bots */
+    shareout(NULL, "nc %s\n", chan->dname);
+
   }
   /* If chan_hack is set, we're loading the userfile. Ignore errors while
    * reading userfile and just return TCL_OK. This is for compatability

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -529,6 +529,42 @@ static void share_killuser(int idx, char *par)
   }
 }
 
+/*
+ * "s nc <chan>"
+ * Received when another bot adds a chan.
+ * We (re)send the "s a <user> <flags> <chan>" for this specific chan if
+ * this chan is known to us and <user> has <flags> for this chan
+ */
+static void share_newchan(int idx, char *par)
+{
+  struct userrec *u;
+  struct chanset_t *ch;
+
+  if ((dcc[idx].status & STAT_SHARE) && !private_user) {
+
+    /* Do we have chan as well and do we share it? */
+    if ((ch = findchan_by_dname(par)) && channel_shared(ch)) {
+
+      /* Go over users and check if it has flags for that chan */
+      for (u = userlist; u->next; u = u->next) {
+        struct flag_record fr = { FR_CHAN, 0, 0, 0, 0, 0 };
+        char buffer[100];
+
+        get_user_flagrec(u, &fr, par);
+
+        if (fr.chan) {
+          /* send flags to bot requesting */
+          build_flags(buffer, &fr, NULL);
+          dprintf(idx, "s a %s %s %s\n", u->handle, buffer, par);
+        }
+      }
+    }
+
+    /* Log, don't shareout to other bots */
+    putlog(LOG_CMDS, "*", "%s: newchan %s", dcc[idx].nick, par);
+  }
+}
+
 static void share_pls_host(int idx, char *par)
 {
   char *hand;
@@ -1296,6 +1332,7 @@ static botcmd_t C_share[] = {
   {"h",        (IntFunc) share_chhand},
   {"k",        (IntFunc) share_killuser},
   {"n",        (IntFunc) share_newuser},
+  {"nc",       (IntFunc) share_newchan},
   {"r!",       (IntFunc) share_resync},
   {"r?",       (IntFunc) share_resyncq},
   {"rn",       (IntFunc) share_resync_no},

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -547,15 +547,18 @@ static void share_newchan(int idx, char *par)
 
       /* Go over users and check if it has flags for that chan */
       for (u = userlist; u->next; u = u->next) {
-        struct flag_record fr = { FR_CHAN, 0, 0, 0, 0, 0 };
-        char buffer[100];
+        /* Only for shared users */
+        if (!(u->flags & USER_UNSHARED)) {
+          struct flag_record fr = { FR_CHAN, 0, 0, 0, 0, 0 };
+          char buffer[100];
 
-        get_user_flagrec(u, &fr, par);
+          get_user_flagrec(u, &fr, par);
 
-        if (fr.chan) {
-          /* send flags to bot requesting */
-          build_flags(buffer, &fr, NULL);
-          dprintf(idx, "s a %s %s %s\n", u->handle, buffer, par);
+          if (fr.chan) {
+            /* send flags to bot requesting */
+            build_flags(buffer, &fr, NULL);
+            dprintf(idx, "s a %s %s %s\n", u->handle, buffer, par);
+          }
         }
       }
     }

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.2"
-#define EGG_NUMVER 1080201
-#define EGG_PATCH "bansanity"
+#define EGG_NUMVER 1080205
+#define EGG_PATCH "newchanflags"


### PR DESCRIPTION
Found by: BarkerJr
Patch by: Cizzle
Fixes: #11 

One-line summary: When a linked bot (leaf or hub) adds a new channel, it announces this to the other linked bots upon which they send any chan specific flags for any shared user.

Test cases demonstrating functionality:
1. On one bot:
`.+chan #newchan`
`.chatrr SharedUser |+d #newchan`
2. On other bot:
`.+chan #newchan`