### PR TITLE
Allow parallel make for building eggdrop

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,42 +101,59 @@ egg_install_msg =  echo "" && \
 		   echo "Now run \"make install\" to install your bot." && \
 		   echo ""
 
-MAKE_MODEGG = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(MOD_CC)' 'LD=$(MOD_LD)' \
-'STRIP=$(MOD_STRIP)' 'RANLIB=$(RANLIB)' 'CFLGS=$(CFLGS)' \
-'TCLLIB=$(TCLLIB)' 'TCLINC=$(TCLINC)' \
-'XLIBS=$(XLIBS)' 'EGGEXEC=$(EGGEXEC)' 'EGGBUILD=(standard build)' 'MODOBJS='
+ls_exe =  echo "" && \
+          echo "Eggdrop successfully compiled:" && ls -l $(EGGEXEC) && \
+          echo ""
 
-MAKE_MODULES = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(SHLIB_CC)' 'LD=$(SHLIB_LD)' \
-'STRIP=$(SHLIB_STRIP)' 'CFLGS=$(CFLGS)' 'XLIBS=$(XLIBS)' \
-'TCLINC=$(TCLINC)' 'TCLLIB=$(TCLLIB)' \
-'MOD_EXT=$(MOD_EXT)' 'MODULE_XLIBS=$(MODULE_XLIBS)'
+ls_mods = $(ls_exe) && echo "" && \
+          echo "Modules successfully compiled:" && ls -l *.$(MOD_EXT) && \
+          echo ""
 
-MAKE_STATIC = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)' 'LD=$(LD)' \
-'STRIP=$(STRIP)' 'RANLIB=$(RANLIB)' 'CFLGS=$(CFLGS) -DSTATIC' \
-'TCLLIB=$(TCLLIB)' 'TCLINC=$(TCLINC)' \
-'XLIBS=$(XLIBS)' 'EGGEXEC=$(EGGEXEC)' 'EGGBUILD=(static version)' \
-'MODOBJS=mod/*.o'
+show_test_run = echo "" && \
+                echo "Test run of ./eggdrop -v:" && \
+                $(egg_test_run) && \
+                echo ""
 
-MAKE_DEBEGG = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(MOD_CC)' 'LD=$(MOD_LD)' \
-'STRIP=touch' 'RANLIB=$(RANLIB)' 'CFLGS=$(DEBCFLGS) $(CFLGS)' \
-'TCLLIB=$(TCLLIB)' 'TCLINC=$(TCLINC)' \
-'XLIBS=$(XLIBS)' 'EGGEXEC=$(EGGEXEC)' 'EGGBUILD=(debug version)' 'MODOBJS='
+# Equal for all build types
+SMAKE_GENERAL_ARGS = 'MAKE=$(MAKE)' 'RANLIB=$(RANLIB)' 'XLIBS=$(XLIBS)' \
+                     'TCLLIB=$(TCLLIB)' 'TCLINC=$(TCLINC)'
 
-MAKE_DEBMODULES = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(SHLIB_CC)' 'LD=$(SHLIB_LD)' \
-'XLIBS=$(XLIBS)' 'STRIP=touch' 'CFLGS=$(DEBCFLGS) $(CFLGS)' \
-'TCLINC=$(TCLINC)' 'TCLLIB=$(TCLLIB)' \
-'MOD_EXT=$(MOD_EXT)' 'MODULE_XLIBS=$(MODULE_XLIBS)'
+# Equal for each builds category (static, shlib, modules)
+SMAKE_BUILD_STATIC_ARGS = 'CC=$(CC)' 'LD=$(LD)' 'MODOBJS=mod/*.o' \
+                          'EGGEXEC=$(EGGEXEC)'
+SMAKE_BUILD_SHLIB_ARGS = 'CC=$(MOD_CC)' 'LD=$(MOD_LD)' 'MODOBJS=' \
+                         'EGGEXEC=$(EGGEXEC)'
+SMAKE_BUILD_MODULES_ARGS = 'CC=$(SHLIB_CC)' 'LD=$(SHLIB_LD)' \
+                           'MOD_EXT=$(MOD_EXT)' 'MODULE_XLIBS=$(MODULE_XLIBS)'
 
-MAKE_SDEBUG = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)' 'LD=$(LD)' \
-'STRIP=touch' 'RANLIB=$(RANLIB)' 'CFLGS=$(DEBCFLGS) $(CFLGS) -DSTATIC' \
-'TCLLIB=$(TCLLIB)' 'TCLINC=$(TCLINC)' 'XLIBS=$(XLIBS)' \
-'EGGEXEC=$(EGGEXEC)' 'EGGBUILD=(static debug version)' 'MODOBJS=mod/*.o'
+# Equal for each build type (standard, debug)
+SMAKE_NO_DEBUG_ARGS = 'STRIP=$(STRIP)'
+SMAKE_WITH_DEBUG_ARGS = 'STRIP=touch'
 
-MAKE_DEPEND = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)'
+# Combined
+MAKE_STATIC_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_STATIC_ARGS) \
+                   $(SMAKE_NO_DEBUG_ARGS) 'EGGBUILD=(static version)' \
+		   'CFLGS=$(CFLGS) -DSTATIC'
+MAKE_SDEBUG_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_STATIC_ARGS) \
+                   $(SMAKE_WITH_DEBUG_ARGS) 'EGGBUILD=(static debug version)' \
+		   'CFLGS=$(CFLGS) $(DEBCFLGS) -DSTATIC'
+MAKE_MODEGG_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_SHLIB_ARGS) \
+                   $(SMAKE_NO_DEBUG_ARGS) 'EGGBUILD=(standard build)' \
+		   'CFLGS=$(CFLGS)'
+MAKE_DEBEGG_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_SHLIB_ARGS) \
+                   $(SMAKE_WITH_DEBUG_ARGS) 'EGGBUILD=(debug build)' \
+		   'CFLGS=$(CFLGS) $(DEBCFLGS)'
+MAKE_MODULES_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_MODULES_ARGS) \
+		    $(SMAKE_NO_DEBUG_ARGS) 'CFLGS=$(CFLGS)'
+MAKE_DEBMOD_ARGS = $(SMAKE_GENERAL_ARGS) $(SMAKE_BUILD_MODULES_ARGS) \
+		   $(SMAKE_WITH_DEBUG_ARGS) 'CFLGS=$(CFLGS) $(DEBCFLGS)'
 
+# Special target types
 MAKE_CONFIG = $(MAKE) 'MAKE=$(MAKE)'
 
 MAKE_INSTALL = $(MAKE) 'MAKE=$(MAKE)' 'DEST=$(ABSDEST)'
+
+MAKE_DEPEND = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)'
 
 all: @DEFAULT_MAKE@
 
@@ -168,28 +185,28 @@ depend:
 	@cd src/compat && $(MAKE_DEPEND) depend
 
 config:
-	@$(modconf) modules-still-exist
-	@$(modconf) detect-modules
-	@$(modconf) update-depends
-	@$(modconf) Makefile
-	@cd src/mod && $(MAKE_CONFIG) config
-	@$(modconf) Makefile
-	@$(post_config)
+	@$(modconf) modules-still-exist && \
+	$(modconf) detect-modules && \
+	$(modconf) update-depends && \
+	$(modconf) Makefile && \
+	cd src/mod && $(MAKE_CONFIG) config && cd ../../ && \
+	$(modconf) Makefile && \
+	$(post_config)
 
 new-iconfig:
-	@$(modconf) modules-still-exist
-	@$(modconf) update-depends
-	@$(modconf) -n configure
-	@$(post_iconfig)
-	@$(post_config)
+	@$(modconf) modules-still-exist && \
+	$(modconf) update-depends && \
+	$(modconf) -n configure && \
+	$(post_iconfig) && \
+	$(post_config)
 
 iconfig:
-	@$(modconf) modules-still-exist
-	@$(modconf) detect-modules
-	@$(modconf) update-depends
-	@$(modconf) configure
-	@$(post_iconfig)
-	@$(post_config)
+	@$(modconf) modules-still-exist && \
+	$(modconf) detect-modules && \
+	$(modconf) update-depends && \
+	$(modconf) configure && \
+	$(post_iconfig) && \
+	$(post_config)
 
 clean-modconfig:
 	@rm -f .modules .known_modules
@@ -207,90 +224,7 @@ conftest:
 
 reconfig: clean-modconfig config
 
-eggdrop: modegg modules
-
-modegg: modtest
-	@rm -f src/mod/mod.xlibs
-	@cd src && $(MAKE_MODEGG) $(EGGEXEC)
-
-modules: modtest
-	@cd src/mod && $(MAKE_MODULES) modules
-	@echo ""
-	@echo "Test run of ./eggdrop -v:"
-	@$(egg_test_run)
-	@echo ""
-	@echo "Eggdrop successfully compiled:"
-	@ls -l $(EGGEXEC)
-	@echo ""
-	@echo "Modules successfully compiled:"
-	@ls -l *.$(MOD_EXT)
-	@$(egg_install_msg)
-
-static: eggtest
-	@echo ""
-	@echo "Making module objects for static linking..."
-	@echo ""
-	@rm -f src/mod/mod.xlibs
-	@cd src/mod && $(MAKE_STATIC) static
-	@echo ""
-	@echo "Making core eggdrop for static linking..."
-	@echo ""
-	@cd src && $(MAKE_STATIC) $(EGGEXEC)
-	@echo ""
-	@echo "Test run of ./eggdrop -v:"
-	@$(egg_test_run)
-	@echo ""
-	@echo "Eggdrop successfully compiled:"
-	@ls -l $(EGGEXEC)
-	@echo ""
-	@$(egg_install_msg)
-
-debug: debegg debmodules
-
-debegg: modtest
-	@cd src && $(MAKE_DEBEGG) $(EGGEXEC)
-
-debmodules: modtest
-	@cd src/mod && $(MAKE_DEBMODULES) modules
-	@echo ""
-	@echo "Test run of ./eggdrop -v:"
-	@$(egg_test_run)
-	@echo ""
-	@echo "Eggdrop successfully compiled:"
-	@ls -l $(EGGEXEC)
-	@echo ""
-	@echo "Modules successfully compiled:"
-	@ls -l *.$(MOD_EXT)
-	@$(egg_install_msg)
-
-sdebug: eggtest
-	@echo ""
-	@echo "Making module objects for static linking."
-	@echo ""
-	@rm -f src/mod/mod.xlibs
-	@cd src/mod && $(MAKE_SDEBUG) static
-	@echo ""
-	@echo "Making eggdrop core for static linking."
-	@echo ""
-	@cd src && $(MAKE_SDEBUG) $(EGGEXEC)
-	@echo ""
-	@echo "Test run of ./eggdrop -v:"
-	@$(egg_test_run)
-	@echo ""
-	@echo "Eggdrop successfully compiled:"
-	@ls -l $(EGGEXEC)
-	@echo ""
-	@$(egg_install_msg)
-
-eggtest: conftest
-	@if test -f EGGMOD.stamp; then \
-		echo "You're trying to do a STATIC build of eggdrop when you've";\
-		echo "already run 'make' for a module build.";\
-		echo "You must first type \"make clean\" before you can build";\
-		echo "a static version.";\
-		exit 1;\
-	fi
-	@echo "stamp" >EGGDROP.stamp
+# Modular builds
 
 modtest: conftest
 	@if [ -f EGGDROP.stamp ]; then \
@@ -299,8 +233,56 @@ modtest: conftest
 		echo "You must first type \"make clean\" before you can build";\
 		echo "a module version.";\
 		exit 1;\
-	fi
-	@echo "stamp" >EGGMOD.stamp
+	fi && \
+	echo "stamp" >EGGMOD.stamp
+
+eggdrop: modtest
+	@echo "" && echo "Making core eggdrop files..." && echo "" && \
+	rm -f src/mod/mod.xlibs && \
+	(cd src && $(MAKE) $(MAKE_MODEGG_ARGS) $(EGGEXEC)) && \
+	echo "" && echo "Making modules..." && echo "" && \
+	(cd src/mod && $(MAKE) $(MAKE_MODULES_ARGS) modules) && \
+	$(show_test_run) && $(ls_mods) && $(egg_install_msg)
+
+debug: modtest
+	@echo "" && echo "Making core eggdrop files..." && echo "" && \
+	rm -f src/mod/mod.xlibs && \
+	(cd src && $(MAKE) $(MAKE_DEBEGG_ARGS) $(EGGEXEC)) && \
+	echo "" && echo "Making modules..." && echo "" && \
+	(cd src/mod && $(MAKE) $(MAKE_DEBMOD_ARGS) modules) && \
+	$(show_test_run) && $(ls_mods) && $(egg_install_msg)
+
+# Static builds
+
+eggtest: conftest
+	@if test -f EGGMOD.stamp; then \
+		echo "You're trying to do a STATIC build of eggdrop when you've";\
+		echo "already run 'make' for a module build.";\
+		echo "You must first type \"make clean\" before you can build";\
+		echo "a static version.";\
+		exit 1;\
+	fi && \
+	echo "stamp" >EGGDROP.stamp
+
+static: eggtest
+	@echo "" && echo "Making module objects for static linking..." && \
+	echo "" && rm -f src/mod/mod.xlibs && \
+	(cd src/mod && $(MAKE) $(MAKE_STATIC_ARGS) static) && \
+	echo "" && echo "Making core eggdrop for static linking..." && \
+	echo "" && \
+	(cd src && $(MAKE) $(MAKE_STATIC_ARGS) $(EGGEXEC)) && \
+	$(show_test_run) && $(ls_exe) && $(egg_install_msg)
+
+sdebug: eggtest
+	@echo "" && echo "Making module objects for static linking..." && \
+	echo "" && rm -f src/mod/mod.xlibs && \
+	(cd src/mod && $(MAKE) $(MAKE_SDEBUG_ARGS) static) && \
+	echo "" && echo "Making core eggdrop for static linking..." && \
+	echo "" && \
+	(cd src && $(MAKE) $(MAKE_SDEBUG_ARGS) $(EGGEXEC)) && \
+	$(show_test_run) && $(ls_exe) && $(egg_install_msg)
+
+# Install
 
 sslcert:
 	@if test ! -d $(DEST); then \
@@ -308,14 +290,14 @@ sslcert:
 		echo "Please run \"make install\" first.";\
 		echo "If you have already run \"make install\" and used the DEST= option, please use it again here";\
 		exit 1;\
-	fi
-	@if test -f $(DEST)/eggdrop.key; then \
+	fi && \
+	if test -f $(DEST)/eggdrop.key; then \
 		cp $(DEST)/eggdrop.key $(DEST)/eggdrop.key~old; \
-	fi
-	@if test -f $(DEST)/eggdrop.crt; then \
+	fi && \
+	if test -f $(DEST)/eggdrop.crt; then \
 		cp $(DEST)/eggdrop.crt $(DEST)/eggdrop.crt~old; \
-	fi
-	@openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf; \
+	fi && \
+	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf; \
 
 install: ainstall
 
@@ -323,9 +305,9 @@ dinstall: eggdrop ainstall
 
 sinstall: static ainstall
 
-ainstall: install-start install-bin install-modules install-data \
-install-help install-language install-filesys install-doc \
-install-scripts install-end
+ainstall: install-start install-bin install-modules install-data install-text \
+install-help install-language install-filesys install-doc install-scripts \
+install-end
 
 install-start:
 	@if test ! -f $(EGGEXEC); then \
@@ -339,16 +321,16 @@ install-start:
 		echo "Default target: '@DEFAULT_MAKE@'."; \
 		echo ""; \
 		exit 1; \
-	fi
-	@if test "x$(DEST)" = "x"; then \
+	fi && \
+	if test "x$(DEST)" = "x"; then \
 		echo "You must specify a destination directory."; \
 		echo "Example:"; \
 		echo ""; \
 		echo "  make install DEST=\"/home/wcc/mybot\""; \
 		echo ""; \
 		exit 1; \
-	fi
-	@if test "$(DEST)" -ef .; then \
+	fi && \
+	if test "$(DEST)" -ef .; then \
 		echo "You are trying to install into the source directory."; \
 		echo "That will not work. Please specify a different"; \
 		echo "install directory with:"; \
@@ -356,13 +338,12 @@ install-start:
 		echo "make install DEST=\"/home/wcc/mybot\""; \
 		echo ""; \
 		exit 1; \
-	fi
-	@echo ""
-	@$(egg_test_run)
-	@echo ""
-	@echo "Installing in directory: '$(ABSDEST)'."
-	@echo ""
-	@if test ! -d $(DEST); then \
+	fi && \
+	echo "" && \
+	$(egg_test_run) && \
+	echo "" && echo "Installing in directory: '$(ABSDEST)'." && \
+	echo "" && \
+	if test ! -d $(DEST); then \
 		echo "Creating directory '$(DEST)'."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST) >/dev/null; \
 	fi
@@ -370,30 +351,30 @@ install-start:
 install-bin:
 	@if test -f $(DEST)/o$(EGGEXEC); then \
 		rm -f $(DEST)/o$(EGGEXEC); \
-	fi
-	@if test -h $(DEST)/$(EGGEXEC); then \
+	fi && \
+	if test -h $(DEST)/$(EGGEXEC); then \
 		echo "Removing symlink to archival eggdrop binary."; \
 		rm -f $(DEST)/$(EGGEXEC); \
-	fi
-	@if test -f $(DEST)/$(EGGEXEC); then \
+	fi && \
+	if test -f $(DEST)/$(EGGEXEC); then \
 		echo "Renaming old '$(EGGEXEC)' executable to 'o$(EGGEXEC)'."; \
 		mv -f $(DEST)/$(EGGEXEC) $(DEST)/o$(EGGEXEC); \
-	fi
-	@echo "Copying new '$(EGGEXEC)' executable and creating symlink."
-	@$(INSTALL_PROGRAM) $(EGGEXEC) $(DEST)/$(EGGEXEC)-$(EGGVERSION)
-	@(cd $(DEST) && $(LN_S) $(EGGEXEC)-$(EGGVERSION) $(EGGEXEC))
+	fi && \
+	echo "Copying new '$(EGGEXEC)' executable and creating symlink." && \
+	$(INSTALL_PROGRAM) $(EGGEXEC) $(DEST)/$(EGGEXEC)-$(EGGVERSION) && \
+	(cd $(DEST) && $(LN_S) $(EGGEXEC)-$(EGGVERSION) $(EGGEXEC))
 
 install-modules:
 	@if test -h $(DEST)/modules; then \
 		echo "Removing symlink to archival modules subdirectory."; \
 		rm -f $(DEST)/modules; \
-	fi
-	@if test -d $(DEST)/modules; then \
+	fi && \
+	if test -d $(DEST)/modules; then \
 		echo "Moving old modules into 'modules.old' subdirectory."; \
 		rm -rf $(DEST)/modules.old; \
 		mv -f $(DEST)/modules $(DEST)/modules.old; \
-	fi
-	@if test ! "x`echo *.$(MOD_EXT)`" = "x*.$(MOD_EXT)"; then \
+	fi && \
+	if test ! "x`echo *.$(MOD_EXT)`" = "x*.$(MOD_EXT)"; then \
 		if test ! -d $(DEST)/modules-$(EGGVERSION); then \
 			echo "Creating 'modules-$(EGGVERSION)' subdirectory and symlink."; \
 			$(top_srcdir)/misc/mkinstalldirs $(DEST)/modules-$(EGGVERSION) >/dev/null; \
@@ -416,21 +397,23 @@ install-data:
 		echo "Creating 'logs' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/logs >/dev/null; \
 		$(INSTALL_DATA) $(srcdir)/logs/CONTENTS $(DEST)/logs/; \
-	fi;
+	fi
+
+install-text:
 	@if test ! -d $(DEST)/text; then \
 		echo "Creating 'text' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/text >/dev/null; \
-	fi;
-	@if test ! -f $(DEST)/text/motd; then \
+	fi && \
+	if test ! -f $(DEST)/text/motd; then \
 		$(INSTALL_DATA) $(srcdir)/text/motd $(DEST)/text/; \
-	fi
-	@if test ! -f $(DEST)/text/banner; then \
+	fi && \
+	if test ! -f $(DEST)/text/banner; then \
 		$(INSTALL_DATA) $(srcdir)/text/banner $(DEST)/text/; \
 	fi
 
 install-help:
-	@echo "Copying help files."
-	@if test ! "x`echo $(srcdir)/help/*.help`" = "x$(srcdir)/help/*.help"; then \
+	@echo "Copying help files." && \
+	if test ! "x`echo $(srcdir)/help/*.help`" = "x$(srcdir)/help/*.help"; then \
 		if test ! -d $(DEST)/help; then \
 			echo "Creating 'help' subdirectory."; \
 			$(top_srcdir)/misc/mkinstalldirs $(DEST)/help >/dev/null; \
@@ -438,8 +421,8 @@ install-help:
 		for i in $(srcdir)/help/*.help; do \
 			$(INSTALL_DATA) $$i $(DEST)/help/; \
 		done; \
-	fi
-	@if test ! "x`echo $(srcdir)/help/msg/*.help`" = "x$(srcdir)/help/msg/*.help"; then \
+	fi && \
+	if test ! "x`echo $(srcdir)/help/msg/*.help`" = "x$(srcdir)/help/msg/*.help"; then \
 		if test ! -d $(DEST)/help/msg; then \
 			echo "Creating 'help/msg' subdirectory."; \
 			$(top_srcdir)/misc/mkinstalldirs $(DEST)/help/msg >/dev/null; \
@@ -447,8 +430,8 @@ install-help:
 		for i in $(srcdir)/help/msg/*.help; do \
 			$(INSTALL_DATA) $$i $(DEST)/help/msg/; \
 		done; \
-	fi
-	@if test ! "x`echo $(srcdir)/help/set/*.help`" = "x$(srcdir)/help/set/*.help"; then \
+	fi && \
+	if test ! "x`echo $(srcdir)/help/set/*.help`" = "x$(srcdir)/help/set/*.help"; then \
 		if test ! -d $(DEST)/help/set; then \
 			echo "Creating 'help/set' subdirectory."; \
 			$(top_srcdir)/misc/mkinstalldirs $(DEST)/help/set >/dev/null; \
@@ -456,12 +439,12 @@ install-help:
 		for i in $(srcdir)/help/set/*.help; do \
 			$(INSTALL_DATA) $$i $(DEST)/help/set/; \
 		done; \
-	fi
-	@cd src/mod/ && $(MAKE_INSTALL) install-help
+	fi && \
+	cd src/mod/ && $(MAKE_INSTALL) install-help
 
 install-language:
-	@echo "Copying language files."
-	@if test ! "x`echo $(srcdir)/language/*.lang`" = "x$(srcdir)/language/*.lang"; then \
+	@echo "Copying language files." && \
+	if test ! "x`echo $(srcdir)/language/*.lang`" = "x$(srcdir)/language/*.lang"; then \
 		if test ! -d $(DEST)/language; then \
 			echo "Creating 'language' subdirectory."; \
 			$(top_srcdir)/misc/mkinstalldirs $(DEST)/language >/dev/null; \
@@ -469,8 +452,8 @@ install-language:
 		for i in $(srcdir)/language/*.lang; do \
 			$(INSTALL_DATA) $$i $(DEST)/language/; \
 		done; \
-	fi
-	@cd src/mod && $(MAKE_INSTALL) install-language
+	fi && \
+	cd src/mod && $(MAKE_INSTALL) install-language
 
 install-filesys:
 	@if test ! -d $(DEST)/filesys; then \
@@ -480,24 +463,22 @@ install-filesys:
 	fi
 
 install-doc:
-	@$(INSTALL_DATA) $(srcdir)/README $(DEST)
-	@cd doc/ && $(MAKE_INSTALL) install
+	@$(INSTALL_DATA) $(srcdir)/README $(DEST) && \
+	cd doc/ && $(MAKE_INSTALL) install
 
 install-scripts:
 	@cd scripts/ && $(MAKE_INSTALL) install
 
 install-end:
-	@echo
-	@echo "Installation completed."
-	@echo ""
-	@echo "If you intend to use this bot as a botnet hub for other 1.8 bots using SSL,"
-	@echo "please run \"make sslcert\" now. If you installed eggdrop to a custom path"
-	@echo "during the make install process, use the same DEST= option here."
-	@echo ""
-	@echo "You MUST ensure that you edit/verify your configuration file."
-	@echo "An example configuration file, eggdrop.conf, is distributed with Eggdrop."
-	@echo ""
-	@echo "Remember to change directory to $(DEST) before you proceed."
-	@echo ""
+	@echo "" && echo "Installation completed." && echo "" && \
+	echo "If you intend to use this bot as a botnet hub for other 1.8 bots using SSL," && \
+	echo "please run \"make sslcert\" now. If you installed eggdrop to a custom path" && \
+	echo "during the make install process, use the same DEST= option here." && \
+	echo "" && \
+	echo "You MUST ensure that you edit/verify your configuration file." && \
+	echo "An example configuration file, eggdrop.conf, is distributed with Eggdrop." && \
+	echo "" && \
+	echo "Remember to change directory to $(DEST) before you proceed." && \
+	echo ""
 
 #safety hash

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -22,25 +22,35 @@ dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o \
 modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o \
 tls.o userent.o userrec.o users.o
 
-MAKE_GENERIC = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)' 'LD=$(LD)' \
-'STRIP=$(STRIP)' 'CFLGS=$(CFLGS)'
+MAKE_GENERIC_ARGS = 'MAKE=$(MAKE)' 'CC=$(CC)' 'LD=$(LD)' \
+                    'STRIP=$(STRIP)' 'CFLGS=$(CFLGS)'
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd .. && $(MAKE)
+	@echo "" && \
+	echo "Let's try this from the right directory..." && echo "" && \
+	cd .. && $(MAKE)
 
-../$(EGGEXEC): build_msg $(eggdrop_objs) compile_md5 compatibility
-	@echo "Linking eggdrop $(EGGBUILD)."
-	@echo ""
-	@touch mod/mod.xlibs
+linkstart:
+	@echo "" && echo "This may take a while. Go get some runts." && \
+	echo "" && \
+	echo "---------- Yeah! That's the compiling, now the linking! ----------" && \
+	echo "" && \
+	echo "Linking eggdrop $(EGGBUILD)." && \
+	echo "" && \
+	touch mod/mod.xlibs
+
+link:
 	$(LD) -o ../$(EGGEXEC) $(eggdrop_objs) $(MODOBJS) $(XLIBS) md5/md5c.o compat/*.o `cat mod/mod.xlibs`
-	$(STRIP) ../$(EGGEXEC)
-	@echo ""
-	@echo "Successful compile: $(EGGEXEC)"
-	@echo ""
+
+linkfinish:
+	@$(STRIP) ../$(EGGEXEC) && \
+	echo "" && \
+	echo "Successful compile: $(EGGEXEC)" && \
+	echo ""
+
+../$(EGGEXEC): $(eggdrop_objs) compile_md5 compatibility
+	$(MAKE) linkstart && $(MAKE) link && $(MAKE) linkfinish
 
 $(EGGEXEC): ../$(EGGEXEC)
 
@@ -50,29 +60,20 @@ depend:
 clean:
 	@rm -f .depend *.o *.a *~
 
-build_msg:
-	@echo ""
-	@echo "This may take a while. Go get some runts."
-	@echo ""
-
 main.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) \
-'-DCCFLAGS="$(CC) $(CFLAGS) $(CPPFLAGS)"' \
-'-DLDFLAGS="$(LD)"' \
-'-DSTRIPFLAGS="$(STRIP)"' -c $(srcdir)/main.c
+	'-DCCFLAGS="$(CC) $(CFLAGS) $(CPPFLAGS)"' \
+	'-DLDFLAGS="$(LD)"' \
+	'-DSTRIPFLAGS="$(STRIP)"' -c $(srcdir)/main.c
 
 compatibility:
-	@cd compat && $(MAKE_GENERIC) compat
-	@echo ""
-	@echo "---------- Yeah! That's the compiling, now the linking! ----------"
-	@echo ""
+	@cd compat && $(MAKE) $(MAKE_GENERIC_ARGS) compat
 
 compile_md5:
-	@cd md5 && $(MAKE_GENERIC) md5
+	@cd md5 && $(MAKE) $(MAKE_GENERIC_ARGS) md5
 
 eggdrop.h:
-	@echo "You do not have the eggdrop source!"
-	@exit 1
+	@echo "You do not have the eggdrop source!" && exit 1
 
 .SUFFIXES:
 .SUFFIXES: .c .h .o .a

--- a/src/mod/Makefile.in
+++ b/src/mod/Makefile.in
@@ -23,7 +23,7 @@ MOD_CPPFLAGS = @CPPFLAGS@
 XLIBS = @XLIBS@
 MOD_EXT = @MOD_EXT@
 
-# Note: The following three lines are automatically adjusted by
+# Note: The following lines are automatically adjusted by
 #       misc/modconfig. They have to be present here.
 mods =
 mod_objs =
@@ -42,14 +42,13 @@ MAKE_MODDEPEND = $(MAKE) 'MAKE=$(MAKE)' 'CC=$(CC)' \
 'CFLAGS=-I../../.. -I../../../src/mod -DMAKING_DEPEND -DHAVE_CONFIG_H -DMAKING_MODS'
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../.. && $(MAKE)
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../.. && $(MAKE)
 
 modules: $(mod_libs)
-	@echo ""
-	@echo "All modules compiled."
+	@echo "" && echo "All modules compiled."
 
 static: $(mod_objs)
 	@$(modconfig) static.h
@@ -121,8 +120,8 @@ distclean:
 install: install-help install-language
 
 install-help:
-	@echo "Copying module help files."
-	@if test ! -d $(DEST)/help; then \
+	@echo "Copying module help files." && \
+	if test ! -d $(DEST)/help; then \
 		echo "Creating 'help' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/help >/dev/null; \
 	fi; \
@@ -132,8 +131,8 @@ install-help:
 				$(INSTALL_DATA) $$h $(DEST)/help/; \
 			done; \
 		fi; \
-	done;
-	@if test ! -d $(DEST)/help/msg; then \
+	done; \
+	if test ! -d $(DEST)/help/msg; then \
 		echo "Creating 'help/msg' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/help/msg >/dev/null; \
 	fi; \
@@ -143,8 +142,8 @@ install-help:
 				$(INSTALL_DATA) $$h $(DEST)/help/msg/; \
 			done; \
 		fi; \
-	done;
-	@if test ! -d $(DEST)/help/set; then \
+	done; \
+	if test ! -d $(DEST)/help/set; then \
 		echo "Creating 'help/set' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/help/set >/dev/null; \
 	fi; \
@@ -157,8 +156,8 @@ install-help:
 	done;
 
 install-language:
-	@echo "Copying module language files."
-	@if test ! -d $(DEST)/language; then \
+	@echo "Copying module language files." && \
+	if test ! -d $(DEST)/language; then \
 		echo "Creating 'language' subdirectory."; \
 		$(top_srcdir)/misc/mkinstalldirs $(DEST)/language >/dev/null; \
 	fi; \

--- a/src/mod/assoc.mod/Makefile
+++ b/src/mod/assoc.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../assoc.o
 
 modules: ../../../assoc.$(MOD_EXT)
 
 ../assoc.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/assoc.c
-	@rm -f ../assoc.o
-	mv assoc.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/assoc.c && mv -f assoc.o ../
 
 ../../../assoc.$(MOD_EXT): ../assoc.o
-	$(LD) -o ../../../assoc.$(MOD_EXT) ../assoc.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../assoc.$(MOD_EXT)
+	$(LD) -o ../../../assoc.$(MOD_EXT) ../assoc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../assoc.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/assoc.c -MT ../assoc.o > .depend

--- a/src/mod/blowfish.mod/Makefile
+++ b/src/mod/blowfish.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../blowfish.o
 
 modules: ../../../blowfish.$(MOD_EXT)
 
 ../blowfish.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/blowfish.c
-	@rm -f ../blowfish.o
-	mv blowfish.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/blowfish.c && mv -f blowfish.o ../
 
 ../../../blowfish.$(MOD_EXT): ../blowfish.o
-	$(LD) -o ../../../blowfish.$(MOD_EXT) ../blowfish.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../blowfish.$(MOD_EXT)
+	$(LD) -o ../../../blowfish.$(MOD_EXT) ../blowfish.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../blowfish.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/blowfish.c -MT ../blowfish.o > .depend

--- a/src/mod/channels.mod/Makefile
+++ b/src/mod/channels.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../channels.o
 
 modules: ../../../channels.$(MOD_EXT)
 
 ../channels.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/channels.c
-	@rm -f ../channels.o
-	mv channels.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/channels.c && mv -f channels.o ../
 
 ../../../channels.$(MOD_EXT): ../channels.o
-	$(LD) -o ../../../channels.$(MOD_EXT) ../channels.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../channels.$(MOD_EXT)
+	$(LD) -o ../../../channels.$(MOD_EXT) ../channels.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../channels.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/channels.c -MT ../channels.o > .depend

--- a/src/mod/compress.mod/Makefile.in
+++ b/src/mod/compress.mod/Makefile.in
@@ -5,10 +5,10 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../compress.o
 	@echo "$(ZLIB)" >> ../mod.xlibs
@@ -16,13 +16,10 @@ static: ../compress.o
 modules: ../../../compress.$(MOD_EXT)
 
 ../compress.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/compress.c
-	rm -f ../compress.o
-	mv compress.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/compress.c && mv -f compress.o ../
 
 ../../../compress.$(MOD_EXT): ../compress.o
-	$(LD) -o ../../../compress.$(MOD_EXT) ../compress.o $(ZLIB) $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../compress.$(MOD_EXT)
+	$(LD) -o ../../../compress.$(MOD_EXT) ../compress.o $(ZLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../compress.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/compress.c -MT ../compress.o > .depend

--- a/src/mod/console.mod/Makefile
+++ b/src/mod/console.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../console.o
 
 modules: ../../../console.$(MOD_EXT)
 
 ../console.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/console.c
-	@rm -f ../console.o
-	mv console.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/console.c && mv -f console.o ../
 
 ../../../console.$(MOD_EXT): ../console.o
-	$(LD) -o ../../../console.$(MOD_EXT) ../console.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../console.$(MOD_EXT)
+	$(LD) -o ../../../console.$(MOD_EXT) ../console.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../console.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/console.c -MT ../console.o > .depend

--- a/src/mod/ctcp.mod/Makefile
+++ b/src/mod/ctcp.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../ctcp.o
 
 modules: ../../../ctcp.$(MOD_EXT)
 
 ../ctcp.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/ctcp.c
-	@rm -f ../ctcp.o
-	mv ctcp.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/ctcp.c && mv -f ctcp.o ../
 
 ../../../ctcp.$(MOD_EXT): ../ctcp.o
-	$(LD) -o ../../../ctcp.$(MOD_EXT) ../ctcp.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../ctcp.$(MOD_EXT)
+	$(LD) -o ../../../ctcp.$(MOD_EXT) ../ctcp.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../ctcp.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/ctcp.c -MT ../ctcp.o > .depend

--- a/src/mod/dns.mod/Makefile.in
+++ b/src/mod/dns.mod/Makefile.in
@@ -6,10 +6,10 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../dns.o
 	@echo "$(RESLIB)" >> ../mod.xlibs
@@ -17,13 +17,10 @@ static: ../dns.o
 modules: ../../../dns.$(MOD_EXT)
 
 ../dns.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(RESINCLUDE) -DMAKING_MODS -c $(srcdir)/dns.c
-	@rm -f ../dns.o
-	mv dns.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(RESINCLUDE) -DMAKING_MODS -c $(srcdir)/dns.c && mv -f dns.o ../
 
 ../../../dns.$(MOD_EXT): ../dns.o
-	$(LD) -o ../../../dns.$(MOD_EXT) ../dns.o $(RESLIB) $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../dns.$(MOD_EXT)
+	$(LD) -o ../../../dns.$(MOD_EXT) ../dns.o $(RESLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../dns.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/dns.c -MT ../dns.o > .depend

--- a/src/mod/filesys.mod/Makefile
+++ b/src/mod/filesys.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../filesys.o
 
 modules: ../../../filesys.$(MOD_EXT)
 
 ../filesys.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/filesys.c
-	@rm -f ../filesys.o
-	mv filesys.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/filesys.c && mv -f filesys.o ../
 
 ../../../filesys.$(MOD_EXT): ../filesys.o
-	$(LD) -o ../../../filesys.$(MOD_EXT) ../filesys.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../filesys.$(MOD_EXT)
+	$(LD) -o ../../../filesys.$(MOD_EXT) ../filesys.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../filesys.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/filesys.c -MT ../filesys.o > .depend

--- a/src/mod/irc.mod/Makefile
+++ b/src/mod/irc.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../irc.o
 
 modules: ../../../irc.$(MOD_EXT)
 
 ../irc.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c
-	@rm -f ../irc.o
-	mv irc.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c && mv -f irc.o ../
 
 ../../../irc.$(MOD_EXT): ../irc.o
-	$(LD) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../irc.$(MOD_EXT)
+	$(LD) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../irc.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/irc.c -MT ../irc.o > .depend

--- a/src/mod/notes.mod/Makefile
+++ b/src/mod/notes.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	@echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../notes.o
 
 modules: ../../../notes.$(MOD_EXT)
 
 ../notes.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/notes.c
-	@rm -f ../notes.o
-	mv notes.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/notes.c && mv -f notes.o ../
 
 ../../../notes.$(MOD_EXT): ../notes.o
-	$(LD) -o ../../../notes.$(MOD_EXT) ../notes.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../notes.$(MOD_EXT)
+	$(LD) -o ../../../notes.$(MOD_EXT) ../notes.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../notes.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/notes.c -MT ../notes.o > .depend

--- a/src/mod/seen.mod/Makefile
+++ b/src/mod/seen.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../seen.o
 
 modules: ../../../seen.$(MOD_EXT)
 
 ../seen.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/seen.c
-	@rm -f ../seen.o
-	mv seen.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/seen.c && mv -f seen.o ../
 
 ../../../seen.$(MOD_EXT): ../seen.o
-	$(LD) -o ../../../seen.$(MOD_EXT) ../seen.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../seen.$(MOD_EXT)
+	$(LD) -o ../../../seen.$(MOD_EXT) ../seen.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../seen.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/seen.c -MT ../seen.o > .depend

--- a/src/mod/server.mod/Makefile
+++ b/src/mod/server.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../server.o
 
 modules: ../../../server.$(MOD_EXT)
 
 ../server.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/server.c
-	@rm -f ../server.o
-	mv server.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/server.c && mv -f server.o ../
 
 ../../../server.$(MOD_EXT): ../server.o
-	$(LD) -o ../../../server.$(MOD_EXT) ../server.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../server.$(MOD_EXT)
+	$(LD) -o ../../../server.$(MOD_EXT) ../server.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../server.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/server.c -MT ../server.o > .depend

--- a/src/mod/share.mod/Makefile
+++ b/src/mod/share.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../share.o
 
 modules: ../../../share.$(MOD_EXT)
 
 ../share.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/share.c
-	@rm -f ../share.o
-	mv share.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/share.c && mv -f share.o ../
 
 ../../../share.$(MOD_EXT): ../share.o
-	$(LD) -o ../../../share.$(MOD_EXT) ../share.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../share.$(MOD_EXT)
+	$(LD) -o ../../../share.$(MOD_EXT) ../share.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../share.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/share.c -MT ../share.o > .depend

--- a/src/mod/transfer.mod/Makefile
+++ b/src/mod/transfer.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../transfer.o
 
 modules: ../../../transfer.$(MOD_EXT)
 
 ../transfer.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/transfer.c
-	@rm -f ../transfer.o
-	mv transfer.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/transfer.c && mv -f transfer.o ../
 
 ../../../transfer.$(MOD_EXT): ../transfer.o
-	$(LD) -o ../../../transfer.$(MOD_EXT) ../transfer.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../transfer.$(MOD_EXT)
+	$(LD) -o ../../../transfer.$(MOD_EXT) ../transfer.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../transfer.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/transfer.c -MT ../transfer.o > .depend

--- a/src/mod/uptime.mod/Makefile
+++ b/src/mod/uptime.mod/Makefile
@@ -3,23 +3,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../uptime.o
 
 modules: ../../../uptime.$(MOD_EXT)
 
 ../uptime.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/uptime.c
-	@rm -f ../uptime.o
-	mv uptime.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/uptime.c && mv -f uptime.o ../
 
 ../../../uptime.$(MOD_EXT): ../uptime.o
-	$(LD) -o ../../../uptime.$(MOD_EXT) ../uptime.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../uptime.$(MOD_EXT)
+	$(LD) -o ../../../uptime.$(MOD_EXT) ../uptime.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../uptime.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/uptime.c -MT ../uptime.o > .depend

--- a/src/mod/woobie.mod/Makefile
+++ b/src/mod/woobie.mod/Makefile
@@ -4,23 +4,20 @@ srcdir = .
 
 
 doofus:
-	@echo ""
-	@echo "Let's try this from the right directory..."
-	@echo ""
-	@cd ../../../ && make
+	@echo "" && \
+	echo "Let's try this from the right directory..." && \
+	echo "" && \
+	cd ../../../ && $(MAKE)
 
 static: ../woobie.o
 
 modules: ../../../woobie.$(MOD_EXT)
 
 ../woobie.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/woobie.c
-	@rm -f ../woobie.o
-	mv woobie.o ../
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/woobie.c && mv -f woobie.o ../
 
 ../../../woobie.$(MOD_EXT): ../woobie.o
-	$(LD) -o ../../../woobie.$(MOD_EXT) ../woobie.o $(XLIBS) $(MODULE_XLIBS)
-	$(STRIP) ../../../woobie.$(MOD_EXT)
+	$(LD) -o ../../../woobie.$(MOD_EXT) ../woobie.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../woobie.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/woobie.c -MT ../woobie.o > .depend


### PR DESCRIPTION
Allows "make -j 9" instead of "make" (cannot use -j with config or install) to make use of multiple processors. Only tested on GNU Make so far, needs testing on other make systems.