### PR TITLE
Checks bans when received through botnet with users on chans.

### DIFF
--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -819,6 +819,8 @@ static void share_pls_ban(int idx, char *par)
   time_t expire_time;
   char *ban, *tm, *from;
   int flags = 0;
+  module_entry *me;
+  struct chanset_t *chan = NULL;
 
   if (dcc[idx].status & STAT_SHARE) {
     shareout_but(NULL, idx, "+b %s\n", par);
@@ -838,6 +840,11 @@ static void share_pls_ban(int idx, char *par)
     u_addban(NULL, ban, from, par, expire_time, flags);
     putlog(LOG_CMDS, "*", "%s: global ban %s (%s:%s)", dcc[idx].nick, ban,
            from, par);
+    /* check ban against users in chans */
+    if ((me = module_find("irc", 0, 0)))
+      for (chan = chanset; chan != NULL; chan = chan->next)
+        if (channel_shared(chan))
+          (me->funcs[IRC_CHECK_THIS_BAN]) (chan, ban, flags & MASKREC_STICKY);
     noshare = 0;
   }
 }
@@ -848,6 +855,7 @@ static void share_pls_banchan(int idx, char *par)
   int flags = 0;
   struct chanset_t *chan;
   char *ban, *tm, *chname, *from;
+  module_entry *me;
 
   if (dcc[idx].status & STAT_SHARE) {
     ban = newsplit(&par);
@@ -876,6 +884,9 @@ static void share_pls_banchan(int idx, char *par)
       if (expire_time != 0L)
         expire_time += now;
       u_addban(chan, ban, from, par, expire_time, flags);
+      /* check ban against users in chan */
+      if ((me = module_find("irc", 0, 0)))
+        (me->funcs[IRC_CHECK_THIS_BAN]) (chan, ban, flags & MASKREC_STICKY);
       noshare = 0;
     }
   }


### PR DESCRIPTION
Found by: Boris Capitanu
Patch by: Cizzle
Fixes: #10 

One-line summary: When a ban is shared through the botnet, it is now immediatly used for users on shared channels.

