### PR TITLE
Bug/tlsaddrcheck

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -745,7 +745,7 @@ static void cmd_console(struct userrec *u, int idx, char *par)
 static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 {
   char *handle, *addr, *port, *relay, *relay2, *host;
-  char saddr[sizeof(struct in_addr)];
+  struct in_addr saddr;
   struct userrec *u1;
   struct bot_addr *bi;
   int i, found = 0;
@@ -1092,7 +1092,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #endif
   int i, found = 0, telnet_port = 3333, relay_port = 3333;
   char *handle, *addr, *port, *relay, *relay2;
-  char saddr[sizeof(struct in_addr)];
+  struct in_addr saddr;
   struct bot_addr *bi;
   struct userrec *u1;
 
@@ -1132,7 +1132,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
   if (relay) {
     relay2 = relay;
-    // Convert to just the port number string for error checking
+    /* Convert to just the port number string for error checking */
     relay2++;
     if (*relay2 == '+') {
       relay2++;
@@ -1148,7 +1148,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     return;
   }
 
-// Check if user forgot address field
+/* Check if user forgot address field */
   for (i=0; i < strlen(addr); i++) {
     if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
       found=1;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1157,7 +1157,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 
 
 #ifndef TLS  
-  if ((*port == '+') || ((relay && relay[1] == '+'))) {
+  if ((port && *port == '+') || ((relay && relay[1] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled "
       "(this Eggdrop was compiled without TLS support)\n");
     return;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -745,6 +745,7 @@ static void cmd_console(struct userrec *u, int idx, char *par)
 static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 {
   char *handle, *addr, *port, *relay, *relay2, *host;
+  char saddr[sizeof(struct in_addr)];
   struct userrec *u1;
   struct bot_addr *bi;
   int i, found = 0;
@@ -773,6 +774,18 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     dprintf(idx, "You can't start a botnick with '%c'.\n", handle[0]);
     return;
   }
+
+#ifndef IPV6
+  if (!inet_pton(AF_INET, addr, saddr)) {
+    for (i = 0; addr[i]; i++) {
+      if (addr[i] == ':') {
+        dprintf(idx, "Invalid IP address format (this Eggdrop "
+          "was not compiled with IPv6 support).\n");
+        return;
+      }
+    }
+  }
+#endif
 
 #ifndef TLS
   if ((*port == '+') || (relay && (relay[1] == '+'))) {
@@ -1081,6 +1094,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #endif
   int i, found = 0, telnet_port = 3333, relay_port = 3333;
   char *handle, *addr, *port, *relay, *relay2;
+  char saddr[sizeof(struct in_addr)];
   struct bot_addr *bi;
   struct userrec *u1;
 
@@ -1093,6 +1107,18 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   addr = newsplit(&par);
   port = newsplit(&par);
   relay = strchr(port, '/');
+
+#ifndef IPV6
+  if (!inet_pton(AF_INET, addr, saddr)) {
+    for (i = 0; addr[i]; i++) {
+      if (addr[i] == ':') {
+        dprintf(idx, "Invalid IP address format (this Eggdrop "
+          "was not compiled with IPv6 support).\n");
+        return;
+      }
+    }
+  }
+#endif
 
 #ifndef TLS  
   if ((*port == '+') || ((relay && relay[1] == '+'))) {

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1158,7 +1158,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
 #endif
 
-  if (port) {
+  if (port && port[0]) {
     if (!check_int_range(port, 0, 65536)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -780,7 +780,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     for (i = 0; addr[i]; i++) {
       if (addr[i] == ':') {
         dprintf(idx, "Invalid IP address format (this Eggdrop "
-          "was not compiled with IPv6 support).\n");
+          "was compiled without IPv6 support).\n");
         return;
       }
     }
@@ -1113,7 +1113,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     for (i = 0; addr[i]; i++) {
       if (addr[i] == ':') {
         dprintf(idx, "Invalid IP address format (this Eggdrop "
-          "was not compiled with IPv6 support).\n");
+          "was compiled without IPv6 support).\n");
         return;
       }
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -887,7 +887,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 #endif
     } else  {
 #ifdef TLS
-      if (relay[1] == '+')
+      if (relay[0] == '+')
         bi->ssl |= TLS_RELAY;
 #endif
       bi->relay_port = atoi(relay);

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -810,6 +810,10 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
         found=1;
         break;
       }
+      if (*addr == '+') {
+        dprintf(idx, "Bot address may not start with a +.\n");
+        return;
+      }
     }
     if (!found) {
       dprintf(idx, "Invalid host address.\n");
@@ -817,10 +821,6 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
               "[host]\n");
       return;
     }
-  }
-  if (*addr == '+') {
-    dprintf(idx, "Bot address may not start with a +.\n");
-    return;
   }
 
 #ifndef TLS
@@ -841,11 +841,6 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
-  }
-
-  if (*addr == '+') {
-    dprintf(idx, "Bot address may not start with a +.\n");
-    return;
   }
 
   if (strlen(addr) > 60)
@@ -1142,6 +1137,10 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
         found=1;
         break;
       }
+      if (*addr == '+') {
+        dprintf(idx, "Bot address may not start with a +.\n");
+        return;
+      }
     }
     if (!found) {
       dprintf(idx, "Invalid host address.\n");
@@ -1150,11 +1149,6 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
       return;
     }
   }
-  if (*addr == '+') {
-    dprintf(idx, "Bot address may not start with a +.\n");
-    return;
-  }
-
 
 #ifndef TLS  
   if ((port && *port == '+') || ((relay && relay[1] == '+'))) {
@@ -1209,7 +1203,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     bi->ssl = use_ssl;
   } else {
     bi->ssl = 0;
-    if (*port == '+')
+    if (port && *port == '+')
       bi->ssl |= TLS_BOT;
     bi->telnet_port = atoi(port);
     if (!relay) {

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -758,6 +758,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   addr = newsplit(&par);
   port = newsplit(&par);
   host = newsplit(&par);
+  relay = strchr(port, '/');
 
   if (strlen(handle) > HANDLEN)
     handle[HANDLEN] = 0;
@@ -771,6 +772,13 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     dprintf(idx, "You can't start a botnick with '%c'.\n", handle[0]);
     return;
   }
+
+#ifndef TLS
+  if ((*port == '+') || (relay[1] == '+')) {
+    dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+    return;
+  }
+#endif
 
   if (strlen(addr) > 60)
     addr[60] = 0;
@@ -790,13 +798,6 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
       bi->ssl |= TLS_BOT;
 #endif
     bi->telnet_port = atoi(port);
-    relay = strchr(port, '/');
-#ifndef TLS
-    if ((*port == '+') || (relay[1] == '+')) {
-      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
-      return;
-    }
-#endif
     if (!relay) {
       bi->relay_port = bi->telnet_port;
 #ifdef TLS
@@ -1052,6 +1053,15 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
   addr = newsplit(&par);
   port = newsplit(&par);
+  relay = strchr(port, '/');
+
+#ifndef TLS  
+  if ((*port == '+') || (relay[1] == '+')) {
+    dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+    return;
+  }
+#endif
+
   if (strlen(addr) > UHOSTMAX)
     addr[UHOSTMAX] = 0;
   u1 = get_user_by_handle(userlist, handle);
@@ -1087,7 +1097,6 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     if (*port == '+')
       bi->ssl |= TLS_BOT;
     bi->telnet_port = atoi(port);
-    relay = strchr(port, '/');
     if (!relay) {
       bi->relay_port = bi->telnet_port;
       bi->ssl *= TLS_BOT + TLS_RELAY;
@@ -1098,11 +1107,6 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #else
   } else {
     bi->telnet_port = atoi(port);
-    relay = strchr(port, '/');
-    if ((*port == '+') || (relay[1] == '+')) {
-      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
-      return;
-    }
     if (!relay)
       bi->relay_port = bi->telnet_port;
     else {

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1226,7 +1226,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
   set_user(&USERENTRY_BOTADDR, u1, bi);
   putlog(LOG_CMDS, "*", "#%s# chaddr %s %s%s%s", dcc[idx].nick, handle,
-         addr, *port ? " " : "", port);
+         addr, port ? " " : "", port);
   dprintf(idx, "Changed bot's address.\n");
 }
 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -791,6 +791,12 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 #endif
     bi->telnet_port = atoi(port);
     relay = strchr(port, '/');
+#ifndef TLS
+    if ((*port == '+') || (*relay == '/')) {
+      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+      return;
+    }
+#endif
     if (!relay) {
       bi->relay_port = bi->telnet_port;
 #ifdef TLS
@@ -1057,9 +1063,6 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     dprintf(idx, "You can't change a share bot's address.\n");
     return;
   }
-  putlog(LOG_CMDS, "*", "#%s# chaddr %s %s%s%s", dcc[idx].nick, handle,
-         addr, *port ? " " : "", port);
-  dprintf(idx, "Changed bot's address.\n");
 
   bi = (struct bot_addr *) get_user(&USERENTRY_BOTADDR, u1);
   if (bi) {
@@ -1096,6 +1099,10 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   } else {
     bi->telnet_port = atoi(port);
     relay = strchr(port, '/');
+    if ((*port == '+') || (*relay == '+')) {
+      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+      return;
+    }
     if (!relay)
       bi->relay_port = bi->telnet_port;
     else {
@@ -1105,6 +1112,9 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     }
   }
   set_user(&USERENTRY_BOTADDR, u1, bi);
+  putlog(LOG_CMDS, "*", "#%s# chaddr %s %s%s%s", dcc[idx].nick, handle,
+         addr, *port ? " " : "", port);
+  dprintf(idx, "Changed bot's address.\n");
 }
 
 static void cmd_comment(struct userrec *u, int idx, char *par)

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -774,7 +774,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   }
 
 #ifndef TLS
-  if ((*port == '+') || (relay[1] == '+')) {
+  if ((*port == '+') || (relay && (relay[1] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
     return;
   }
@@ -1056,7 +1056,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   relay = strchr(port, '/');
 
 #ifndef TLS  
-  if ((*port == '+') || (relay[1] == '+')) {
+  if ((*port == '+') || ((relay && relay[1] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
     return;
   }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -794,11 +794,9 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     return;
   }
 #endif
-  if (port) {
-    if ((atoi(port) < 1) || (atoi(port) > 65535)) {
-      dprintf(idx, "Ports must be integers between 1 and 65535.\n");
-      return;
-    }
+  if ((atoi(port) < 1) || (atoi(port) > 65535)) {
+    dprintf(idx, "Ports must be integers between 1 and 65535.\n");
+    return;
   }
   if (relay) {
     relay2 = relay;
@@ -1128,11 +1126,9 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
 #endif
 
-  if (port) {
-    if ((atoi(port) < 1) || (atoi(port) > 65535)) {
-      dprintf(idx, "Ports must be integers between 1 and 65535.\n");
-      return;
-    }
+  if ((atoi(port) < 1) || (atoi(port) > 65535)) {
+    dprintf(idx, "Ports must be integers between 1 and 65535.\n");
+    return;
   }
   if (relay) {
     relay2 = relay;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1196,14 +1196,14 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   bi->address = user_malloc(strlen(addr) + 1);
   strcpy(bi->address, addr);
 
-  if (!port[0]) {
+  if (!port) {
     bi->telnet_port = telnet_port;
     bi->relay_port = relay_port;
 #ifdef TLS
     bi->ssl = use_ssl;
   } else {
     bi->ssl = 0;
-    if (port && *port == '+')
+    if (*port == '+')
       bi->ssl |= TLS_BOT;
     bi->telnet_port = atoi(port);
     if (!relay) {

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -800,7 +800,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   }
   if (relay) {
     relay2 = relay;
-    // Convert to just the port number string for error checking
+    /* Convert to just the port number string for error checking */
     relay2++;
     if (*relay2 == '+') {
       relay2++;
@@ -816,9 +816,9 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     return;
   }
 
-// Check if user forgot address field
+ /* Check if user forgot address field */
   for (i=0; i < strlen(addr); i++) {
-    if (!isdigit(addr[i]) && (addr[i] != '/')) {
+    if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
       found=1;
       break;
     }
@@ -1150,7 +1150,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 
 // Check if user forgot address field
   for (i=0; i < strlen(addr); i++) {
-    if (!isdigit(addr[i]) && (addr[i] != '/')) {
+    if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
       found=1;
       break;
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -792,7 +792,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     bi->telnet_port = atoi(port);
     relay = strchr(port, '/');
 #ifndef TLS
-    if ((*port == '+') || (*relay == '/')) {
+    if ((*port == '+') || (relay[1] == '+')) {
       dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
       return;
     }
@@ -1099,14 +1099,14 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   } else {
     bi->telnet_port = atoi(port);
     relay = strchr(port, '/');
+    if ((*port == '+') || (relay[1] == '+')) {
+      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+      return;
+    }
     if (!relay)
       bi->relay_port = bi->telnet_port;
     else {
       relay++;
-      if ((*port == '+') || (*relay == '+')) {
-        dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
-        return;
-      }
 #endif
       bi->relay_port = atoi(relay);
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -795,7 +795,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   }
 #endif
   if (port) {
-    if ((atoi(port) < 1) && (atoi(port) > 65535)) {
+    if ((atoi(port) < 1) || (atoi(port) > 65535)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
@@ -807,7 +807,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     if (*relay2 == '+') {
       relay2++;
     }
-    if ((atoi(relay2) < 1) && (atoi(relay2) > 65535)) {
+    if ((atoi(relay2) < 1) || (atoi(relay2) > 65535)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
@@ -1129,7 +1129,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #endif
 
   if (port) {
-    if ((atoi(port) < 1) && (atoi(port) > 65535)) {
+    if ((atoi(port) < 1) || (atoi(port) > 65535)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
@@ -1141,7 +1141,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     if (*relay2 == '+') {
       relay2++;
     }
-    if ((atoi(relay2) < 1) && (atoi(relay2) > 65535)) {
+    if ((atoi(relay2) < 1) || (atoi(relay2) > 65535)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -776,7 +776,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 
 #ifndef TLS
   if ((*port == '+') || (relay && (relay[1] == '+'))) {
-    dprintf(idx, "Ports prefixed with '+' are not enabled"
+    dprintf(idx, "Ports prefixed with '+' are not enabled "
       "(this Eggdrop was compiled without TLS support).\n");
     return;
   }
@@ -1096,8 +1096,8 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 
 #ifndef TLS  
   if ((*port == '+') || ((relay && relay[1] == '+'))) {
-    dprintf(idx, "Ports prefixed with '+' are not enabled \
-(this Eggdrop was compiled without TLS support)\n");
+    dprintf(idx, "Ports prefixed with '+' are not enabled "
+      "(this Eggdrop was compiled without TLS support)\n");
     return;
   }
 #endif

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1099,14 +1099,14 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   } else {
     bi->telnet_port = atoi(port);
     relay = strchr(port, '/');
-    if ((*port == '+') || (*relay == '+')) {
-      dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
-      return;
-    }
     if (!relay)
       bi->relay_port = bi->telnet_port;
     else {
       relay++;
+      if ((*port == '+') || (*relay == '+')) {
+        dprintf(idx, "Ports prefixed with '+' are not enabled (this Eggdrop was compiled without TLS support)\n");
+        return;
+      }
 #endif
       bi->relay_port = atoi(relay);
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -796,8 +796,8 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 
 #ifndef TLS
   if ((*port == '+') || (relay && (relay[1] == '+'))) {
-    dprintf(idx, "Ports prefixed with '+' are not enabled \
-(this Eggdrop was compiled without TLS support).\n");
+    dprintf(idx, "Ports prefixed with '+' are not enabled
+      (this Eggdrop was compiled without TLS support).\n");
     return;
   }
 #endif

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -767,6 +767,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   char *handle, *addr, *port, *relay, *host;
   struct userrec *u1;
   struct bot_addr *bi;
+  int i, found = 0;
 
   if (!par[0]) {
     dprintf(idx, "Usage: +bot <handle> [address [telnet-port[/relay-port]]] "
@@ -796,21 +797,40 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 #ifndef TLS
   if ((*port == '+') || (relay && (relay[1] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled \
-(this Eggdrop was compiled without TLS support)\n");
+(this Eggdrop was compiled without TLS support).\n");
     return;
   }
 #endif
   if (port) {
     if (!check_port(port)) {
-      dprintf(idx, "Ports must be integers between 1 and 65535\n");
+      dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
   }
   if (relay) {
     if (!check_port(relay)) {
-      dprintf(idx, "Ports must be integers between 1 and 65535\n");
+      dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }
+  }
+
+  if (*addr == '+') {
+    dprintf(idx, "Bot address may not start with a +.\n");
+    return;
+  }
+
+// Check if user forgot address field
+  for (i=0; i < strlen(addr); i++) {
+    if (!isdigit(addr[i]) && (addr[i] != '/')) {
+      found=1;
+      break;
+    }
+  }
+  if (!found) {
+    dprintf(idx, "Invalid host address.\n");
+    dprintf(idx, "Usage: +bot <handle> [address [telnet-port[/relay-port]]] "
+            "[host]\n");
+    return;
   }
 
   if (strlen(addr) > 60)
@@ -1073,7 +1093,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #ifdef TLS
   int use_ssl = 0;
 #endif
-  int telnet_port = 3333, relay_port = 3333;
+  int i, found = 0, telnet_port = 3333, relay_port = 3333;
   char *handle, *addr, *port, *relay;
   struct bot_addr *bi;
   struct userrec *u1;
@@ -1095,6 +1115,25 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     return;
   }
 #endif
+
+  if (*addr == '+') {
+    dprintf(idx, "Bot address may not start with a +.\n");
+    return;
+  }
+
+// Check if user forgot address field
+  for (i=0; i < strlen(addr); i++) {
+    if (!isdigit(addr[i]) && (addr[i] != '/')) {
+      found=1;
+      break;
+    }
+  }
+  if (!found) {
+    dprintf(idx, "Invalid host address.\n");
+    dprintf(idx, "Usage: chaddr <botname> <address> "
+            "[telnet-port[/relay-port]]>\n");
+    return;
+  }
 
   if (strlen(addr) > UHOSTMAX)
     addr[UHOSTMAX] = 0;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -805,7 +805,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     }
 #endif
  /* Check if user forgot address field */
-    for (i=0; i < strlen(addr); i++) {
+    for (i=0; i < addr[i]; i++) {
       if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
         found=1;
         break;
@@ -817,6 +817,10 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
               "[host]\n");
       return;
     }
+  }
+  if (*addr == '+') {
+    dprintf(idx, "Bot address may not start with a +.\n");
+    return;
   }
 
 #ifndef TLS
@@ -833,11 +837,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     }
   }
   if (relay) {
-    relay2 = relay;
-    if (*relay == '+') {
-      relay2++;
-    }
-    if (!check_int_range(relay2, 0, 65536)) {
+    if (!check_int_range(relay, 0, 65536)) {
       dprintf(idx, "Ports must be integers between 1 and 65535.\n");
       return;
     }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -761,12 +761,12 @@ static void cmd_resetconsole(struct userrec *u, int idx, char *par)
   do_console(u, idx, par, 1);
 }
 
-/* Check if a string is a valid integer and lies between
- * two given integers. Returns 1 if true, 0 if not.
+/* Check if a string is a valid integer and lies non-inclusive
+ * between two given integers. Returns 1 if true, 0 if not.
  */
-char check_int_range(char *value, int min, int max) {
+int check_int_range(char *value, int min, int max) {
   char **endptr = NULL;
-  int intvalue;
+  long intvalue;
 
   if (value) {
     intvalue = strtol(value, endptr, 10);
@@ -824,14 +824,14 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     }
 #endif
  /* Check if user forgot address field */
+    if (*addr == '+') {
+      dprintf(idx, "Bot address may not start with a +.\n");
+      return;
+    }
     for (i=0; i < addr[i]; i++) {
       if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
         found=1;
         break;
-      }
-      if (*addr == '+') {
-        dprintf(idx, "Bot address may not start with a +.\n");
-        return;
       }
     }
     if (!found) {
@@ -843,7 +843,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   }
 
 #ifndef TLS
-  if ((port && *port == '+') || (relay && (relay[1] == '+'))) {
+  if ((port && *port == '+') || (relay && (relay[0] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled "
       "(this Eggdrop was compiled without TLS support).\n");
     return;
@@ -1151,14 +1151,14 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
     }
 #endif
 /* Check if user forgot address field */
+    if (*addr == '+') {
+      dprintf(idx, "Bot address may not start with a +.\n");
+      return;
+    }
     for (i=0; i < strlen(addr); i++) {
       if (!isdigit((unsigned char) addr[i]) && (addr[i] != '/')) {
         found=1;
         break;
-      }
-      if (*addr == '+') {
-        dprintf(idx, "Bot address may not start with a +.\n");
-        return;
       }
     }
     if (!found) {
@@ -1170,7 +1170,7 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   }
 
 #ifndef TLS  
-  if ((port && *port == '+') || ((relay && relay[1] == '+'))) {
+  if ((port && *port == '+') || ((relay && relay[0] == '+'))) {
     dprintf(idx, "Ports prefixed with '+' are not enabled "
       "(this Eggdrop was compiled without TLS support)\n");
     return;


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: NA

One-line summary:
Various error-checks against +bot/chaddr functions

Additional description (if needed):
Prevents IPv6 addresses from being added when no IPv6 support
Prevents + ports from being added when no TLS support
Prevents out of range ports
Checks for missing address field

Test cases demonstrating functionality (if applicable):
