### PR TITLE
Stop link to rejected bot before opening socket

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -996,6 +996,10 @@ int botlink(char *linker, int idx, char *nick)
   } else if (in_chain(nick) && (idx != -3)) {
     if (idx >= 0)
       dprintf(idx, "%s\n", BOT_ALREADYLINKED);
+  } else if (bot_flags(u) & BOT_REJECT) {
+    if (idx >= 0) {
+      dprintf(idx, "%s %s\n", BOT_REJECTING, nick);
+    }
   } else {
     for (i = 0; i < dcc_total; i++)
       if ((dcc[i].user == u) &&

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.2"
-#define EGG_NUMVER 1080205
-#define EGG_PATCH "newchanflags"
+#define EGG_NUMVER 1080206
+#define EGG_PATCH "rejectlink"


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #463 

One-line summary:
Stop link to rejected bot before opening socket

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
[01:39:49] #-HQ# link ztestbot
Rejecting bot ztestbot
```