### PR TITLE
Bug/botaddrdocs

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -263,7 +263,7 @@ setuser <handle> <entry-type> [extra info]
   |         |   sets global LASTON time (leaving the place field empty)                             |
   |         |                                                                                       |
   |         | <unixtime> <channel>                                                                  |
-  |         |   sets a users LASTON time for a channel (if it is a valid channel)                   |
+  |         |   sets a user's LASTON time for a channel (if it is a valid channel)                  |
   +---------+---------------------------------------------------------------------------------------+
 
   Returns: nothing

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -208,7 +208,7 @@ getuser <handle> [entry-type] [extra info]
   +----------+-------------------------------------------------------------------------------------+
   | BOTFL    | returns the current bot-specific flags for the user (bot-only)                      |
   +----------+-------------------------------------------------------------------------------------+
-  | BOTADDR  | returns a list containing the bot's address, telnet port, and relay port (bot-only) |
+  | BOTADDR  | returns a list containing the bot's address, bot listen port, and user listen port  |
   +----------+-------------------------------------------------------------------------------------+
   | HOSTS    | returns a list of hosts for the user                                                |
   +----------+-------------------------------------------------------------------------------------+
@@ -240,7 +240,10 @@ setuser <handle> <entry-type> [extra info]
   Description: this is the counterpart of getuser. It lets you set the various values. Other then the ones listed below, the entry-types are the same as getuser's.
 
   +---------+---------------------------------------------------------------------------------------+
-  | PASS    | sets a users password (no third arg will clear it)                                    |
+  | PASS    | Sets a users password (no third arg will clear it)                                    |
+  +---------+---------------------------------------------------------------------------------------+
+  | BOTADDR | Sets address, listen port and, with an optional third argument, user listen port. No  |
+  |         | third argument sets bot bot and user to the second argument.                          |
   +---------+---------------------------------------------------------------------------------------+
   | HOSTS   | if used with no third arg, all hosts for the user will be cleared. Otherwise, *1*     |
   |         | hostmask is added :P                                                                  |

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -240,23 +240,30 @@ setuser <handle> <entry-type> [extra info]
   Description: this is the counterpart of getuser. It lets you set the various values. Other then the ones listed below, the entry-types are the same as getuser's.
 
   +---------+---------------------------------------------------------------------------------------+
-  | PASS    | Sets a users password (no third arg will clear it)                                    |
+  | Type    | Extra Info                                                                            |
+  +=========+=======================================================================================+
+  | PASS    | <password>                                                                            |
+  |         |   Password string (Empty value will clear the password)                               |
   +---------+---------------------------------------------------------------------------------------+
-  | BOTADDR | Sets address, listen port and, with an optional third argument, user listen port. No  |
-  |         | third argument sets bot bot and user to the second argument.                          |
+  | BOTADDR | <address> [bot listen port] [user listen port]                                        |
+  |         |   Sets address, bot listen port and user listen port. If no listen ports are          |
+  |         |   specified, only the bot address is updated. If only the bot listen port is          |
+  |         |   specified, both the bot and user listen ports are set to the bot listen port.       |
   +---------+---------------------------------------------------------------------------------------+
-  | HOSTS   | if used with no third arg, all hosts for the user will be cleared. Otherwise, *1*     |
-  |         | hostmask is added :P                                                                  |
+  | HOSTS   | [hostmask]                                                                            |
+  |         |   If no value is specified, all hosts for the user will be cleared. Otherwise, only   |
+  |         |   *1* hostmask is added :P                                                            |
   +---------+---------------------------------------------------------------------------------------+
   | LASTON  | This setting has 3 forms.                                                             |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime> <place>* sets global LASTON time                |
+  |         | <unixtime> <place>                                                                    |
+  |         |    sets global LASTON time                                                            |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime>* sets global LASTON time (leaving the place     |
-  |         |   field empty)                                                                        |
+  |         | <unixtime>                                                                            |
+  |         |   sets global LASTON time (leaving the place field empty)                             |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime> <channel>* sets a users LASTON time for a       |
-  |         |   channel (if it is a  valid channel)                                                 |
+  |         | <unixtime> <channel>                                                                  |
+  |         |   sets a users LASTON time for a channel (if it is a valid channel)                   |
   +---------+---------------------------------------------------------------------------------------+
 
   Returns: nothing

--- a/src/userent.c
+++ b/src/userent.c
@@ -680,26 +680,29 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
       nfree(bi->address);
     bi->address = user_malloc(strlen(argv[3]) + 1);
     strcpy(bi->address, argv[3]);
-    if (argc > 4)
+    if (argc > 4) {
 #ifdef TLS
-    {
-      if (*argv[4] == '+')
+      /* If no user port set, use bot port for both entries */
+      if (*argv[4] == '+') {
         bi->ssl |= TLS_BOT;
-      bi->telnet_port = atoi(argv[4]);
-    }
-#else
-      bi->telnet_port = atoi(argv[4]);
+        if (argc == 5) {
+          bi->ssl |= TLS_RELAY;
+        }
+      }
 #endif
-    if (argc > 5)
+      bi->telnet_port = atoi(argv[4]); 
+      if (argc == 5) {
+        bi->relay_port = atoi(argv[4]);
+      }
+    }
+    if (argc > 5) {
 #ifdef TLS
-    {
-      if (*argv[5] == '+')
+      if (*argv[5] == '+') {
         bi->ssl |= TLS_RELAY;
+      }
+#endif
       bi->relay_port = atoi(argv[5]);
     }
-#else
-      bi->relay_port = atoi(argv[5]);
-#endif
     if (!bi->telnet_port)
       bi->telnet_port = 3333;
     if (!bi->relay_port)

--- a/src/userent.c
+++ b/src/userent.c
@@ -687,10 +687,15 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
         bi->ssl |= TLS_BOT;
         if (argc == 5) {
           bi->ssl |= TLS_RELAY;
+        } 
+      } else {
+        bi->ssl &= ~TLS_BOT;
+        if (argc == 5) {
+          bi->ssl &= ~TLS_RELAY;
         }
       }
 #endif
-      bi->telnet_port = atoi(argv[4]); 
+      bi->telnet_port = atoi(argv[4]);
       if (argc == 5) {
         bi->relay_port = atoi(argv[4]);
       }
@@ -699,6 +704,8 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
 #ifdef TLS
       if (*argv[5] == '+') {
         bi->ssl |= TLS_RELAY;
+      } else {
+        bi->ssl &= ~TLS_RELAY;
       }
 #endif
       bi->relay_port = atoi(argv[5]);


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #459 

One-line summary:
Fix tcl setuser botaddr field docs and functionality

Additional description (if needed):

* Update docs to match actual setuser botaddr functionality
* Standardize setuser botaddr syntax with chaddr (.chaddr syntax changes both user and bot port if only one port is specified. .tcl setuser botaddr syntax changed only the bot port if one port was entered. This patch standardize to the chaddr behavior)
* Fixed other bug where ssl ports were not able to be reverted to non-SSL ports via setuser botaddr

Test cases demonstrating functionality (if applicable):
```
.whois foo
[23:11:44] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 2.2.2.2
     users: 4444, bots: 4444

.tcl setuser foo botaddr 2.2.2.2 5555
Tcl: 

.whois foo
[23:12:03] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 2.2.2.2
     users: 5555, bots: 5555

.tcl setuser foo botaddr 2.2.2.2 6666 +7777
Tcl: 

.whois foo
[23:12:17] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 2.2.2.2
     users: +7777, bots: 6666

.tcl setuser foo botaddr 2.2.2.2 6666 7777
Tcl: 

.whois foo
[23:17:28] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 2.2.2.2
     users: 7777, bots: 6666
```