### PR TITLE
Initialize SSL field when adding a new bot

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -872,6 +872,7 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   userlist = adduser(userlist, handle, "none", "-", USER_BOT);
   u1 = get_user_by_handle(userlist, handle);
   bi = user_malloc(sizeof(struct bot_addr));
+  bi->ssl = 0;
   bi->address = user_malloc(strlen(addr) + 1);
   strcpy(bi->address, addr);
 

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -309,6 +309,7 @@ static int tcl_addbot STDVAR
   else {
     userlist = adduser(userlist, argv[1], "none", "-", USER_BOT);
     bi = user_malloc(sizeof(struct bot_addr));
+    bi->ssl = 0;
 #ifdef IPV6
     if ((q = strchr(argv[2], '/'))) {
       if (!q[1]) {


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: NA

One-line summary:
Initialize SSL field when adding a new bot

Additional description (if needed):
bi->ssl was not initialized when adding a new bot, resulting in incorrect status of the SSL port depending on the random value inside that field if the user had not explicitly set the port to SSL. 

Test cases demonstrating functionality (if applicable):
