### PR TITLE
Remove leftover unused BOT_BOT botflag b.

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1943,9 +1943,6 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
     pls.match = user.match;
     break_down_flags(chg, &pls, &mns);
     /* No-one can change these flags on-the-fly */
-    pls.global &=~BOT_BOT;
-    mns.global &=~BOT_BOT;
-
     if (chan && glob_owner(user)) {
       pls.chan &= BOT_SHARE;
       mns.chan &= BOT_SHARE;

--- a/src/flags.h
+++ b/src/flags.h
@@ -88,7 +88,7 @@ struct flag_record {
 
 /* Flags specifically for bots */
 #define BOT_ALT        0x00000001 /* a  auto-link here if all hubs fail */
-#define BOT_BOT        0x00000002 /* b  sanity bot flag                 */
+#define BOT_B          0x00000002 /* b  unused                          */
 #define BOT_C          0x00000004 /* c  unused                          */
 #define BOT_D          0x00000008 /* d  unused                          */
 #define BOT_E          0x00000010 /* e  unused                          */


### PR DESCRIPTION
There is only userflag 'b' to indicate a bot, which is internally USER_BOT. Internally there also exists BOT_BOT as supposedly botflag 'b', but this is not really used anywhere.