### PR TITLE
Fix addbot Tcl command

### DIFF
--- a/doc/sphinx_source/mainDocs/botnet.rst
+++ b/doc/sphinx_source/mainDocs/botnet.rst
@@ -1,5 +1,5 @@
 Botnet Sharing and Linking
-Last revised: June 29, 2016
+Last revised: Nov 09, 2017
 
 ==========================
 Botnet Sharing and Linking
@@ -121,10 +121,10 @@ Here is an example scenario:
 
       BotA is on lame.org listening on port 3333, and BotB is on irc.org
       listening on port 4444. First, you have to add each Bot to the other's
-      userfile. On BotA, you would type '.+bot BotB irc.org:4444'. If BotB is
+      userfile. On BotA, you would type '.+bot BotB irc.org 4444'. If BotB is
       on a common channel with BotA, BotB's hostmask is automatically added.
       Otherwise, you have to add the hostmask manually with the '.+host'
-      command. On BotB, you would type '.+bot BotA lame.org:3333'.
+      command. On BotB, you would type '.+bot BotA lame.org 3333'.
 
 At this point, you can link the two bots by typing '.link BotA' on BotB (or '.link BotB' on BotA). The bots will now give themselves random passwords which are *not* stored encrypted in the userfile. Note that you can link as many bots as you wish to your botnet.
 
@@ -213,7 +213,7 @@ Making bots share user records
 
   On Lamestbot::
 
-    .+bot Lameshare eggdrop.com:3333
+    .+bot Lameshare eggdrop.com 3333
 
   This command adds a user record to
   Lamestbot for Lameshare. Lameshare is running from eggdrop.com and is
@@ -233,7 +233,7 @@ Making bots share user records
 
   On Lameshare::
 
-    .+bot Lamestbot best.com:3333/5555
+    .+bot Lamestbot best.com 3333/5555
 
   Again this will add a user on
   Lameshare called Lamestbot with the domain of best.com. The bot has
@@ -258,7 +258,7 @@ Making bots share user records
 
   On Lamestbot::
 
-    .+bot beldin llama.com:3333
+    .+bot beldin llama.com 3333
 
     .botattr beldin s|s #eggdrop
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -322,7 +322,13 @@ adduser <handle> [hostmask]
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 addbot <handle> <address>
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-  Description: adds a new bot to the userlist with the handle and botaddress given (with no password and no flags)
+  Description: adds a new bot to the userlist with the handle and botaddress given (with no password and no flags). <address> format is one of:
+
+  - ipaddress:botport/userport
+  - ipaddress/botport/userport
+  - [ipv6address]:botport/userport
+
+  NOTE: The ipaddress:botport/userport format is depreciated and will be removed in a future version. It is recommended to use the other two formats.
 
   Returns: 1 if successful; 0 if the bot already exists
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -263,7 +263,7 @@ setuser <handle> <entry-type> [extra info]
   |         |   sets global LASTON time (leaving the place field empty)                             |
   |         |                                                                                       |
   |         | <unixtime> <channel>                                                                  |
-  |         |   sets a users LASTON time for a channel (if it is a valid channel)                   |
+  |         |   sets a user's LASTON time for a channel (if it is a valid channel)                  |
   +---------+---------------------------------------------------------------------------------------+
 
   Returns: nothing

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -208,7 +208,7 @@ getuser <handle> [entry-type] [extra info]
   +----------+-------------------------------------------------------------------------------------+
   | BOTFL    | returns the current bot-specific flags for the user (bot-only)                      |
   +----------+-------------------------------------------------------------------------------------+
-  | BOTADDR  | returns a list containing the bot's address, telnet port, and relay port (bot-only) |
+  | BOTADDR  | returns a list containing the bot's address, bot listen port, and user listen port  |
   +----------+-------------------------------------------------------------------------------------+
   | HOSTS    | returns a list of hosts for the user                                                |
   +----------+-------------------------------------------------------------------------------------+
@@ -240,7 +240,10 @@ setuser <handle> <entry-type> [extra info]
   Description: this is the counterpart of getuser. It lets you set the various values. Other then the ones listed below, the entry-types are the same as getuser's.
 
   +---------+---------------------------------------------------------------------------------------+
-  | PASS    | sets a users password (no third arg will clear it)                                    |
+  | PASS    | Sets a users password (no third arg will clear it)                                    |
+  +---------+---------------------------------------------------------------------------------------+
+  | BOTADDR | Sets address, listen port and, with an optional third argument, user listen port. No  |
+  |         | third argument sets bot bot and user to the second argument.                          |
   +---------+---------------------------------------------------------------------------------------+
   | HOSTS   | if used with no third arg, all hosts for the user will be cleared. Otherwise, *1*     |
   |         | hostmask is added :P                                                                  |

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -240,23 +240,30 @@ setuser <handle> <entry-type> [extra info]
   Description: this is the counterpart of getuser. It lets you set the various values. Other then the ones listed below, the entry-types are the same as getuser's.
 
   +---------+---------------------------------------------------------------------------------------+
-  | PASS    | Sets a users password (no third arg will clear it)                                    |
+  | Type    | Extra Info                                                                            |
+  +=========+=======================================================================================+
+  | PASS    | <password>                                                                            |
+  |         |   Password string (Empty value will clear the password)                               |
   +---------+---------------------------------------------------------------------------------------+
-  | BOTADDR | Sets address, listen port and, with an optional third argument, user listen port. No  |
-  |         | third argument sets bot bot and user to the second argument.                          |
+  | BOTADDR | <address> [bot listen port] [user listen port]                                        |
+  |         |   Sets address, bot listen port and user listen port. If no listen ports are          |
+  |         |   specified, only the bot address is updated. If only the bot listen port is          |
+  |         |   specified, both the bot and user listen ports are set to the bot listen port.       |
   +---------+---------------------------------------------------------------------------------------+
-  | HOSTS   | if used with no third arg, all hosts for the user will be cleared. Otherwise, *1*     |
-  |         | hostmask is added :P                                                                  |
+  | HOSTS   | [hostmask]                                                                            |
+  |         |   If no value is specified, all hosts for the user will be cleared. Otherwise, only   |
+  |         |   *1* hostmask is added :P                                                            |
   +---------+---------------------------------------------------------------------------------------+
   | LASTON  | This setting has 3 forms.                                                             |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime> <place>* sets global LASTON time                |
+  |         | <unixtime> <place>                                                                    |
+  |         |    sets global LASTON time                                                            |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime>* sets global LASTON time (leaving the place     |
-  |         |   field empty)                                                                        |
+  |         | <unixtime>                                                                            |
+  |         |   sets global LASTON time (leaving the place field empty)                             |
   |         |                                                                                       |
-  |         |   *setuser <handle> LASTON <unixtime> <channel>* sets a users LASTON time for a       |
-  |         |   channel (if it is a  valid channel)                                                 |
+  |         | <unixtime> <channel>                                                                  |
+  |         |   sets a users LASTON time for a channel (if it is a valid channel)                   |
   +---------+---------------------------------------------------------------------------------------+
 
   Returns: nothing

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -324,11 +324,9 @@ addbot <handle> <address>
 ^^^^^^^^^^^^^^^^^^^^^^^^^
   Description: adds a new bot to the userlist with the handle and botaddress given (with no password and no flags). <address> format is one of:
 
-  - ipaddress:botport/userport
   - ipaddress/botport/userport
-  - [ipv6address]:botport/userport
-
-  NOTE: The ipaddress:botport/userport format is depreciated and will be removed in a future version. It is recommended to use the other two formats.
+  - ipv4address:botport/userport    [DEPRECATED]
+  - [ipv6address]:botport/userport  [DEPRECATED]
 
   Returns: 1 if successful; 0 if the bot already exists
 

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -310,12 +310,6 @@ static int tcl_addbot STDVAR
       get_user_by_handle(userlist, argv[1]))
     Tcl_AppendResult(irp, "0", NULL);
   else {
-    userlist = adduser(userlist, argv[1], "none", "-", USER_BOT);
-    bi = user_malloc(sizeof(struct bot_addr));
-#ifdef TLS
-    bi->ssl = 0;
-#endif
-#ifdef IPV6
     for (i=0; argv[2][i]; i++) {
       if (argv[2][i] == ':') {
         count++;
@@ -328,14 +322,17 @@ static int tcl_addbot STDVAR
     if (count > 1) {
       ipv6 = 1;
     }
+    if ((!ipv6 && braced)
+#ifndef IPV6
+        || (ipv6)
 #endif
-    if (!ipv6 && braced) {
+      ) {
       Tcl_AppendResult(irp, "0", NULL);
       return TCL_OK;
     }
 /* Check that the char following the / is not null */
     if ((q = strrchr(argv[2], '/'))) {
-      if (!q[1]) {  // this needs to move
+      if (!q[1]) {
         *q = 0;
         q = 0;
       }
@@ -344,12 +341,16 @@ static int tcl_addbot STDVAR
       if (!(q = strchr(argv[2], ':'))) {
         q = strchr(argv[2], '/');
       }
-    // if ipv6
     } else if (braced && (colon > braced)) {
       q = strrchr(argv[2], ':');
     } else {
       q = strchr(argv[2], '/');
     }
+    userlist = adduser(userlist, argv[1], "none", "-", USER_BOT);
+    bi = user_malloc(sizeof(struct bot_addr));
+#ifdef TLS
+    bi->ssl = 0;
+#endif
     if (!q) {
       bi->address = user_malloc(strlen(argv[2]) + 1);
       strcpy(bi->address, argv[2]);

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -329,18 +329,26 @@ static int tcl_addbot STDVAR
       ipv6 = 1;
     }
 #endif
+    if (!ipv6 && braced) {
+      Tcl_AppendResult(irp, "0", NULL);
+      return TCL_OK;
+    }
 /* Check that the char following the / is not null */
-    if ((q = strchr(argv[2], '/'))) {
-      if (!q[1]) {
+    if ((q = strrchr(argv[2], '/'))) {
+      if (!q[1]) {  // this needs to move
         *q = 0;
         q = 0;
       }
     }
     if (!ipv6) {
-      q = strchr(argv[2], ':');
-    }
-    if (braced && (colon > braced)) {
+      if (!(q = strchr(argv[2], ':'))) {
+        q = strchr(argv[2], '/');
+      }
+    // if ipv6
+    } else if (braced && (colon > braced)) {
       q = strrchr(argv[2], ':');
+    } else {
+      q = strchr(argv[2], '/');
     }
     if (!q) {
       bi->address = user_malloc(strlen(argv[2]) + 1);

--- a/src/userent.c
+++ b/src/userent.c
@@ -680,26 +680,29 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
       nfree(bi->address);
     bi->address = user_malloc(strlen(argv[3]) + 1);
     strcpy(bi->address, argv[3]);
-    if (argc > 4)
+    if (argc > 4) {
 #ifdef TLS
-    {
-      if (*argv[4] == '+')
+      /* If no user port set, use bot port for both entries */
+      if (*argv[4] == '+') {
         bi->ssl |= TLS_BOT;
-      bi->telnet_port = atoi(argv[4]);
-    }
-#else
-      bi->telnet_port = atoi(argv[4]);
+        if (argc == 5) {
+          bi->ssl |= TLS_RELAY;
+        }
+      }
 #endif
-    if (argc > 5)
+      bi->telnet_port = atoi(argv[4]); 
+      if (argc == 5) {
+        bi->relay_port = atoi(argv[4]);
+      }
+    }
+    if (argc > 5) {
 #ifdef TLS
-    {
-      if (*argv[5] == '+')
+      if (*argv[5] == '+') {
         bi->ssl |= TLS_RELAY;
+      }
+#endif
       bi->relay_port = atoi(argv[5]);
     }
-#else
-      bi->relay_port = atoi(argv[5]);
-#endif
     if (!bi->telnet_port)
       bi->telnet_port = 3333;
     if (!bi->relay_port)

--- a/src/userent.c
+++ b/src/userent.c
@@ -687,10 +687,15 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
         bi->ssl |= TLS_BOT;
         if (argc == 5) {
           bi->ssl |= TLS_RELAY;
+        } 
+      } else {
+        bi->ssl &= ~TLS_BOT;
+        if (argc == 5) {
+          bi->ssl &= ~TLS_RELAY;
         }
       }
 #endif
-      bi->telnet_port = atoi(argv[4]); 
+      bi->telnet_port = atoi(argv[4]);
       if (argc == 5) {
         bi->relay_port = atoi(argv[4]);
       }
@@ -699,6 +704,8 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
 #ifdef TLS
       if (*argv[5] == '+') {
         bi->ssl |= TLS_RELAY;
+      } else {
+        bi->ssl &= ~TLS_RELAY;
       }
 #endif
       bi->relay_port = atoi(argv[5]);

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.2"
-#define EGG_NUMVER 1080207
-#define EGG_PATCH "sslfatal"
+#define EGG_NUMVER 1080208
+#define EGG_PATCH "addbot"


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: #470

One-line summary:
Fix addbot Tcl command

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.tcl addbot foo 1.1.1.1/3333/4444
Tcl: 1
.whois foo
[07:03:40] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 1.1.1.1
     users: 4444, bots: 3333
```
```
.tcl addbot foo 1.1.1.1:4444/5555
Tcl: 1
.whois foo
[07:04:21] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: 1.1.1.1
     users: 5555, bots: 4444
```
```
.tcl addbot foo \[fe80::20c:29ff:fea7:5864\]:4444
Tcl: 1
.whois foo
[07:04:56] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 b               never (nowhere)
  ADDRESS: [fe80::20c:29ff:fea7:5864]
     users: 4444, bots: 4444
```
See Jenkins tests for full combinatorial.