### PR TITLE
Clarify chanlist Tcl command documentation

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1176,7 +1176,9 @@ chanlist <channel> [flags[&chanflags]]
 
   Now you can use even more complex matching of flags, including +&- flags and & or | ('and' or 'or') matching.
 
-  Returns: list of nicknames currently on the bot's channel that have all of the flags specified;. If no flags are given, all of the nicknames are returned. Please note that if you're executing chanlist after a part or sign bind, the gone user will still be listed, so you can check for wasop, isop, etc.
+  Returns: Searching for flags preceded with a '+' will return a list of nicknames that have all the flags listed. Searching for flags preceded with a '-' will return a list of nicknames that do not have have any of the flags (differently said, '-' will hide users that have all flags listed). If no flags are given, all of the nicknames on the channel are returned.
+
+  Please note that if you're executing chanlist after a part or sign bind, the gone user will still be listed, so you can check for wasop, isop, etc.
 
   Module: irc
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1161,10 +1161,10 @@ onchansplit <nick> [channel]
   Module: irc
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-chanlist <channel> [flags[&chanflags]]
+chanlist <channel> [flags][<&|>chanflags]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: flags are any global flags; the '&' denotes to look for channel specific flags. Examples:
+  Description: flags are any global flags; the '&' or '|' denotes to look for channel specific flags, where '&' will return users having ALL chanflags and '|' returns users having ANY of the chanflags. Examples:
 
   +--------+--------------------------------+
   | n      | (Global Owner)                 |
@@ -1176,7 +1176,7 @@ chanlist <channel> [flags[&chanflags]]
 
   Now you can use even more complex matching of flags, including +&- flags and & or | ('and' or 'or') matching.
 
-  Returns: Searching for flags preceded with a '+' will return a list of nicknames that have all the flags listed. Searching for flags preceded with a '-' will return a list of nicknames that do not have have any of the flags (differently said, '-' will hide users that have all flags listed). If no flags are given, all of the nicknames on the channel are returned.
+  Returns: Searching for flags optionally preceded with a '+' will return a list of nicknames that have all the flags listed. Searching for flags preceded with a '-' will return a list of nicknames that do not have have any of the flags (differently said, '-' will hide users that have all flags listed). If no flags are given, all of the nicknames on the channel are returned.
 
   Please note that if you're executing chanlist after a part or sign bind, the gone user will still be listed, so you can check for wasop, isop, etc.
 


### PR DESCRIPTION
Found by: Robby
Patch by: Cizzle
Fixes: #78 

One-line summary:
Clarify docs regarding chanlist and how the +,-,&, and | descriptors affect its usage. 