### PR TITLE
Fix matchattr for local flags

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -305,7 +305,41 @@ botattr <handle> [changes [channel]]
 matchattr <handle> <flags> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified user has the specified flags; 0 otherwise
+  Description: checks if the flags of the specified user match the flags provided. Default matching pattern uses the | (OR) convention. For example, specifying +mn for flags will check if the user has the m OR n flag.
+
++------------+-----------------------------------------------------------------+
+| Flag Mask  | Action                                                          |
++============+=================================================================+
+| +m         + Checks if the user has the m global flag                        |
++------------+-----------------------------------------------------------------+
+| +mn        | Checks if the user has the m or n global flag                   |
++------------+-----------------------------------------------------------------+
+| +mn&       | Checks if the user has the m and n global flag                  |
++------------+-----------------------------------------------------------------+
+| \|+o #foo  | Checks if the user has the o channel flag for #foo              |
++------------+-----------------------------------------------------------------+
+| &mn #foo   | Checks if the user has the m and n channel flag for #foo        |
++------------+-----------------------------------------------------------------+
+| +o|+n #foo | Checks if the user has the o global flag, or the n channel      |
+|            | flag for #foo                                                   |
++------------+-----------------------------------------------------------------+
+| +m&+v      | Checks if the user has the m global flag, and the v channel     |
+|            | flag for #foo                                                   |
++------------+-----------------------------------------------------------------+
+| -m         | Checks if the user does not have the m global flag              |
++------------+-----------------------------------------------------------------+
+| \|-n #foo  | Checks if the user does not have the n channel flag for #foo    |
++------------+-----------------------------------------------------------------+
+| +m|-n #foo | Checks if the user has the global m flag or does not have a     |
+|            | channel n flag for #foo                                         |
++------------+-----------------------------------------------------------------+
+| -n&-m #foo | Searches if the user does not have the global n flag and does   |
+|            | not have the channel m flag for #foo                            |
++------------+-----------------------------------------------------------------+
+| ||+b       | Searches if the user has the bot flag b                         |
++------------+-----------------------------------------------------------------+
+
+  Returns: 1 if the specified user has the flags matching the provided mask; 0 otherwise
 
   Module: core
 
@@ -1168,17 +1202,7 @@ onchansplit <nick> [channel]
 chanlist <channel> [flags][<&|>chanflags]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: flags are any global flags; the '&' or '|' denotes to look for channel specific flags, where '&' will return users having ALL chanflags and '|' returns users having ANY of the chanflags. Examples:
-
-  +--------+--------------------------------+
-  | n      | (Global Owner)                 |
-  +--------+--------------------------------+
-  | &n     |  (Channel Owner)               |
-  +--------+--------------------------------+
-  | o&m    |  (Global Op, Channel Master)   |
-  +--------+--------------------------------+
-
-  Now you can use even more complex matching of flags, including +&- flags and & or | ('and' or 'or') matching.
+  Description: flags are any global flags; the '&' or '|' denotes to look for channel specific flags, where '&' will return users having ALL chanflags and '|' returns users having ANY of the chanflags (See matchattr above for additional examples).
 
   Returns: Searching for flags optionally preceded with a '+' will return a list of nicknames that have all the flags listed. Searching for flags preceded with a '-' will return a list of nicknames that do not have have any of the flags (differently said, '-' will hide users that have all flags listed). If no flags are given, all of the nicknames on the channel are returned.
 

--- a/src/flags.c
+++ b/src/flags.c
@@ -488,7 +488,7 @@ static int bot2str(char *string, int bot)
 {
   char x = 'a', *old = string;
 
-  while (x < 'v') {
+  while (x <= 'z') {
     if (bot & 1)
       *string++ = x;
     x++;

--- a/src/flags.h
+++ b/src/flags.h
@@ -46,16 +46,16 @@ struct flag_record {
  *   unused letters: is
  *
  * botflags:
- *   0123456789ab????ghi??l???p?rs???????
- *   unused letters: cdefjkmnoqtuvwxyz
+ *   a?????ghi??l???p?rs???????0123456789
+ *   unused letters: bcdefjkmnoqtuvwxyz
  *
  * chanflags:
- *   a??defg???klmno?qr??uv??yz + user defined A-Z
- *   unused letters: bchijpstwx
+ *   a??defg???klmno?qr???vw?yz + user defined A-Z
+ *   unused letters: bchijpstuw
  */
-#define USER_VALID 0x03fbfeff   /* Sum of all USER_ flags */
-#define CHAN_VALID 0x03777c79   /* Sum of all CHAN_ flags */
-#define BOT_VALID  0x7fe689C1   /* Sum of all BOT_  flags */
+#define USER_VALID 0x003fbfeff   /* Sum of all valid USER_ flags */
+#define CHAN_VALID 0x003637c79   /* Sum of all valid CHAN_ flags */
+#define BOT_VALID  0xffc0689C1   /* Sum of all valid BOT_  flags */
 
 
 #define USER_AUTOOP        0x00000001 /* a  auto-op                               */
@@ -113,16 +113,16 @@ struct flag_record {
 #define BOT_X          0x00800000 /* x  unused                          */
 #define BOT_Y          0x01000000 /* y  unused                          */
 #define BOT_Z          0x02000000 /* z  unused                          */
-#define BOT_FLAG0      0x00200000 /* 0  user-defined flag #0            */
-#define BOT_FLAG1      0x00400000 /* 1  user-defined flag #1            */
-#define BOT_FLAG2      0x00800000 /* 2  user-defined flag #2            */
-#define BOT_FLAG3      0x01000000 /* 3  user-defined flag #3            */
-#define BOT_FLAG4      0x02000000 /* 4  user-defined flag #4            */
-#define BOT_FLAG5      0x04000000 /* 5  user-defined flag #5            */
-#define BOT_FLAG6      0x08000000 /* 6  user-defined flag #6            */
-#define BOT_FLAG7      0x10000000 /* 7  user-defined flag #7            */
-#define BOT_FLAG8      0x20000000 /* 8  user-defined flag #8            */
-#define BOT_FLAG9      0x40000000 /* 9  user-defined flag #9            */
+#define BOT_FLAG0      0x04000000 /* 0  user-defined flag #0            */
+#define BOT_FLAG1      0x08000000 /* 1  user-defined flag #1            */
+#define BOT_FLAG2      0x10000000 /* 2  user-defined flag #2            */
+#define BOT_FLAG3      0x20000000 /* 3  user-defined flag #3            */
+#define BOT_FLAG4      0x40000000 /* 4  user-defined flag #4            */
+#define BOT_FLAG5      0x80000000 /* 5  user-defined flag #5            */
+#define BOT_FLAG6      0x100000000 /* 6  user-defined flag #6            */
+#define BOT_FLAG7      0x200000000 /* 7  user-defined flag #7            */
+#define BOT_FLAG8      0x400000000 /* 8  user-defined flag #8            */
+#define BOT_FLAG9      0x800000000 /* 9  user-defined flag #9            */
 #define BOT_SHARE      (BOT_AGGRESSIVE|BOT_PASSIVE)
 
 

--- a/src/flags.h
+++ b/src/flags.h
@@ -46,7 +46,7 @@ struct flag_record {
  *   unused letters: is
  *
  * botflags:
- *   a?????ghi??l???p?rs???????0123456789
+ *   a?????ghi??l???p?rs??0123456789?????
  *   unused letters: bcdefjkmnoqtuvwxyz
  *
  * chanflags:
@@ -55,7 +55,7 @@ struct flag_record {
  */
 #define USER_VALID 0x003fbfeff   /* Sum of all valid USER_ flags */
 #define CHAN_VALID 0x003637c79   /* Sum of all valid CHAN_ flags */
-#define BOT_VALID  0xffc0689C1   /* Sum of all valid BOT_  flags */
+#define BOT_VALID  0x07fe689C1   /* Sum of all valid BOT_  flags */
 
 
 #define USER_AUTOOP        0x00000001 /* a  auto-op                               */
@@ -108,21 +108,21 @@ struct flag_record {
 #define BOT_AGGRESSIVE 0x00040000 /* s  bot shares user files           */
 #define BOT_T          0x00080000 /* t  unused                          */
 #define BOT_U          0x00100000 /* u  unused                          */
-#define BOT_V          0x00200000 /* v  unused                          */
-#define BOT_W          0x00400000 /* w  unused                          */
-#define BOT_X          0x00800000 /* x  unused                          */
-#define BOT_Y          0x01000000 /* y  unused                          */
-#define BOT_Z          0x02000000 /* z  unused                          */
-#define BOT_FLAG0      0x04000000 /* 0  user-defined flag #0            */
-#define BOT_FLAG1      0x08000000 /* 1  user-defined flag #1            */
-#define BOT_FLAG2      0x10000000 /* 2  user-defined flag #2            */
-#define BOT_FLAG3      0x20000000 /* 3  user-defined flag #3            */
-#define BOT_FLAG4      0x40000000 /* 4  user-defined flag #4            */
-#define BOT_FLAG5      0x80000000 /* 5  user-defined flag #5            */
-#define BOT_FLAG6      0x100000000 /* 6  user-defined flag #6            */
-#define BOT_FLAG7      0x200000000 /* 7  user-defined flag #7            */
-#define BOT_FLAG8      0x400000000 /* 8  user-defined flag #8            */
-#define BOT_FLAG9      0x800000000 /* 9  user-defined flag #9            */
+#define BOT_V          0x80000000 /* v  unused                          */
+#define BOT_W          0x100000000 /* w  unused                          */
+#define BOT_X          0x200000000 /* x  unused                          */
+#define BOT_Y          0x400000000 /* y  unused                          */
+#define BOT_Z          0x800000000 /* z  unused                          */
+#define BOT_FLAG0      0x00200000 /* 0  user-defined flag #0            */
+#define BOT_FLAG1      0x00400000 /* 1  user-defined flag #1            */
+#define BOT_FLAG2      0x00800000 /* 2  user-defined flag #2            */
+#define BOT_FLAG3      0x01000000 /* 3  user-defined flag #3            */
+#define BOT_FLAG4      0x02000000 /* 4  user-defined flag #4            */
+#define BOT_FLAG5      0x04000000 /* 5  user-defined flag #5            */
+#define BOT_FLAG6      0x08000000 /* 6  user-defined flag #6            */
+#define BOT_FLAG7      0x10000000 /* 7  user-defined flag #7            */
+#define BOT_FLAG8      0x20000000 /* 8  user-defined flag #8            */
+#define BOT_FLAG9      0x40000000 /* 9  user-defined flag #9            */
 #define BOT_SHARE      (BOT_AGGRESSIVE|BOT_PASSIVE)
 
 

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -253,20 +253,17 @@ static int tcl_matchattr STDVAR
     get_user_flagrec(u, &user, argv[3]);
     plus.match = user.match;
     break_down_flags(argv[2], &plus, &minus);
-    if (!minus.global && !minus.udef_global && !minus.chan && !minus.udef_chan
-        && !minus.bot) {
-      if (!plus.global && !plus.udef_global && !plus.chan && !plus.udef_chan
-          && !plus.bot) {
-        Tcl_AppendResult(irp, "0", NULL);
-        return TCL_OK;
+    if (minus.global || minus.udef_global || minus.chan || minus.udef_chan
+        || minus.bot || plus.global || plus.udef_global || plus.chan
+        || plus.udef_chan || plus.bot) {
+      if (flagrec_eq(&plus, &user)) {
+          ok = 1;
+      } else {
+        minus.match = plus.match ^ (FR_AND | FR_OR);
+        if (!flagrec_eq(&minus, &user)) {
+          ok = 1;
+        }
       }
-    }
-    if (flagrec_eq(&plus, &user)) {
-      ok = 1;
-    } else {
-      minus.match = plus.match ^ (FR_AND | FR_OR);
-      if (!flagrec_eq(&minus, &user))
-        ok = 1;
     }
   }
   Tcl_AppendResult(irp, ok ? "1" : "0", NULL);

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -259,7 +259,7 @@ static int tcl_matchattr STDVAR
       nom = 1;
       if (!plus.global && !plus.udef_global && !plus.chan &&
           !plus.udef_chan && !plus.bot) {
-        Tcl_AppendResult(irp, "Unknown flag specified for matching", NULL); 
+        Tcl_AppendResult(irp, "Unknown flag specified for matching", NULL);
         return TCL_ERROR;
       }
     }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -244,7 +244,7 @@ static int tcl_matchattr STDVAR
 {
   struct userrec *u;
   struct flag_record plus = {0}, minus = {0}, user = {0};
-  int ok = 0, nom = 0, nop = 0;
+  int ok = 0, nom = 0;
 
   BADARGS(3, 4, " handle flags ?channel?");
 
@@ -267,11 +267,6 @@ static int tcl_matchattr STDVAR
       if (nom || !flagrec_eq(&minus, &user)) {
         ok = 1;
       }
-//    if (!nop && flagrec_eq(&plus, &user)) {
-//      ok = 1;
-//    }
-//    if (!nom && !flagrec_eq(&minus, &user)) {
-//        ok = 1;
     }
   }
   Tcl_AppendResult(irp, ok ? "1" : "0", NULL);

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -252,16 +252,12 @@ static int tcl_matchattr STDVAR
     user.match = FR_GLOBAL | (argc == 4 ? FR_CHAN : 0) | FR_BOT;
     get_user_flagrec(u, &user, argv[3]);
     plus.match = user.match;
+    minus.match = plus.match ^ (FR_AND | FR_OR);
     break_down_flags(argv[2], &plus, &minus);
-    f = (minus.global || minus.udef_global || minus.chan || minus.udef_chan ||
-         minus.bot);
+    f = (!minus.global || !minus.udef_global || !minus.chan || !minus.udef_chan         || !minus.bot);
     if (flagrec_eq(&plus, &user)) {
-      if (!f)
+      if (f || !flagrec_eq(&minus, &user)) {
         ok = 1;
-      else {
-        minus.match = plus.match ^ (FR_AND | FR_OR);
-        if (!flagrec_eq(&minus, &user))
-          ok = 1;
       }
     }
   }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -259,8 +259,8 @@ static int tcl_matchattr STDVAR
       nom = 1;
       if (!plus.global && !plus.udef_global && !plus.chan &&
           !plus.udef_chan && !plus.bot) {
-        Tcl_AppendResult(irp, "0 Unknown flag specified for matching", NULL); 
-        return TCL_OK;
+        Tcl_AppendResult(irp, "Unknown flag specified for matching", NULL); 
+        return TCL_ERROR;
       }
     }
     if (flagrec_eq(&plus, &user)) {

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -244,7 +244,7 @@ static int tcl_matchattr STDVAR
 {
   struct userrec *u;
   struct flag_record plus, minus, user;
-  int ok = 0, f;
+  int ok = 0;
 
   BADARGS(3, 4, " handle flags ?channel?");
 
@@ -253,16 +253,20 @@ static int tcl_matchattr STDVAR
     get_user_flagrec(u, &user, argv[3]);
     plus.match = user.match;
     break_down_flags(argv[2], &plus, &minus);
-    f = (minus.global || minus.udef_global || minus.chan || minus.udef_chan ||
-         minus.bot);
-    if (flagrec_eq(&plus, &user)) {
-      if (!f)
-        ok = 1;
-      else {
-        minus.match = plus.match ^ (FR_AND | FR_OR);
-        if (!flagrec_eq(&minus, &user))
-          ok = 1;
+    if (!minus.global && !minus.udef_global && !minus.chan && !minus.udef_chan
+        && !minus.bot) {
+      if (!plus.global && !plus.udef_global && !plus.chan && !plus.udef_chan
+          && !plus.bot) {
+        Tcl_AppendResult(irp, "0", NULL);
+        return TCL_OK;
       }
+    }
+    if (flagrec_eq(&plus, &user)) {
+      ok = 1;
+    } else {
+      minus.match = plus.match ^ (FR_AND | FR_OR);
+      if (!flagrec_eq(&minus, &user))
+        ok = 1;
     }
   }
   Tcl_AppendResult(irp, ok ? "1" : "0", NULL);

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -243,8 +243,8 @@ static int tcl_botattr STDVAR
 static int tcl_matchattr STDVAR
 {
   struct userrec *u;
-  struct flag_record plus, minus, user;
-  int ok = 0, f;
+  struct flag_record plus = {0}, minus = {0}, user = {0};
+  int ok = 0, nom = 0, nop = 0;
 
   BADARGS(3, 4, " handle flags ?channel?");
 
@@ -252,13 +252,26 @@ static int tcl_matchattr STDVAR
     user.match = FR_GLOBAL | (argc == 4 ? FR_CHAN : 0) | FR_BOT;
     get_user_flagrec(u, &user, argv[3]);
     plus.match = user.match;
-    minus.match = plus.match ^ (FR_AND | FR_OR);
     break_down_flags(argv[2], &plus, &minus);
-    f = (!minus.global || !minus.udef_global || !minus.chan || !minus.udef_chan         || !minus.bot);
+    minus.match = plus.match ^ (FR_AND | FR_OR);
+    if (!minus.global && !minus.udef_global && !minus.chan &&
+        !minus.udef_chan && !minus.bot) {
+      nom = 1;
+      if (!plus.global && !plus.udef_global && !plus.chan &&
+          !plus.udef_chan && !plus.bot) {
+        Tcl_AppendResult(irp, "0 Unknown flag specified for matching", NULL); 
+        return TCL_OK;
+      }
+    }
     if (flagrec_eq(&plus, &user)) {
-      if (f || !flagrec_eq(&minus, &user)) {
+      if (nom || !flagrec_eq(&minus, &user)) {
         ok = 1;
       }
+//    if (!nop && flagrec_eq(&plus, &user)) {
+//      ok = 1;
+//    }
+//    if (!nom && !flagrec_eq(&minus, &user)) {
+//        ok = 1;
     }
   }
   Tcl_AppendResult(irp, ok ? "1" : "0", NULL);


### PR DESCRIPTION
Found by: maimizuno
Patch by: Geo
Fixes: #419 

One-line summary:
Tcl matchattr command incorrectly returned true when checking against an invalid channel flag. This 
patch checks first checks if the channel flag is invalid and, if it is, returns false.

Test cases demonstrating functionality (if applicable):
```
[03:57:25] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 -               never (nowhere)
                         #foober            -               never

.tcl foreach a [split $alpha] { putlog "${a}:GLOBAL([matchattr foo $a]):LOCAL:&([matchattr foo &$a #foober])):LOCAL:|([matchattr foo |$a #foober])" }
[03:56:58] a:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] b:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] c:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] d:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] e:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] f:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] g:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] h:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] i:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] j:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] k:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] m:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] n:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] o:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] p:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] q:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] r:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] s:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] t:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] u:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] v:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] w:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] x:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] y:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:56:58] z:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)

[03:58:04] #-HQ# whois foo
HANDLE                           PASS NOTES FLAGS           LAST
foo                              no       0 aefghjlmnoptuvwxyz never (nowhere)
                         #foober            -               never

.tcl foreach a [split $alpha] { putlog "${a}:GLOBAL([matchattr foo $a]):LOCAL:&([matchattr foo &$a #foober])):LOCAL:|([matchattr foo |$a #foober])" }
[03:58:20] a:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] b:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] c:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] d:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] e:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] f:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] g:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] h:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] i:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] j:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] k:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] m:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] n:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] o:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] p:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] q:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] r:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] s:GLOBAL(0):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] t:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] u:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] v:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] w:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] x:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] y:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)
[03:58:20] z:GLOBAL(1):LOCAL:&(0)):LOCAL:|(0)


```
