### PR TITLE
Do not trigger CHON binds when returning from a control script.

### DIFF
--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -401,7 +401,7 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0xe16,DCC forbindelse lukket (%s!%s)
 0xe17,Fejlede indgående TELNET (%s)
 0xe18,Afviste %s/%d (ugyldig kilde port)
-# 0xe19 - unused / ubrugt
+0xe19,*** %s er vendt tilbage.\n 
 0xe1a,Afviste %s (ugyldigt hostname)
 0xe1b,Telnet forbindelse: %s/%d
 0xe1c,Ident fejlede for %s: %s

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -401,7 +401,7 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0xe16,DCC connection closed (%s!%s)
 0xe17,Failed TELNET incoming (%s)
 0xe18,Refused %s/%d (bad src port)
-# 0xe19 - unused
+0xe19,*** %s has returned.\n
 0xe1a,Refused %s (bad hostname)
 0xe1b,Telnet connection: %s/%d
 0xe1c,Ident failed for %s: %s

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -401,7 +401,7 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0xe16,DCC yhteys suljettu (%s!%s)
 0xe17,TELNET yhdistäminen epäonnistui (%s)
 0xe18,Evätään %s/%d (huono src portti)
-# 0xe19 - ei käytössä
+0xe19,*** %s on palannut.\n 
 0xe1a,Evätään %s (huono hostname)
 0xe1b,Telnet yhteys: %s/%d
 0xe1c,Ident epäonnistui %s: %s

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -402,7 +402,7 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe16,Connexion DCC fermée (%s!%s)
 0xe17,Echec de la tentative de TELNET en cours (%s)
 0xe18,Refus %s/%d (mauvais port source)
-# 0xe19 - unused
+0xe19,*** %s est de retour.\n 
 0xe1a,Refus %s (mauvais hostname)
 0xe1b,Connexion telnet: %s/%d
 0xe1c,Echec de l'ident pour %s: %s

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -410,7 +410,7 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe16,DCC-Verbindung geschlossen (%s!%s)
 0xe17,Einkommende TELNET-Verbindung fehlgeschlagen (%s)
 0xe18,Verbindung zu %s/%d zurueckgewiesen (falscher Quellport)
-# 0xe19 - unused
+0xe19,*** %s ist zurueckgekehrt.\n 
 0xe1a,Verbindung zu %s zurueckgewiesen (falscher hostname)
 0xe1b,Telnet-Verbindung: %s/%d
 0xe1c,Ident fehlgeschlagen fuer %s: %s

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -401,7 +401,7 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe16,Ligação DCC fechada (%s!%s)
 0xe17,Ligação de entrada TELNET falhada (%s)
 0xe18,Recusado %s/%d (porta src inválida)
-# 0xe19 - não utilizado
+0xe19,*** %s retornou.\n 
 0xe1a,Recusado %s (máscara inválida)
 0xe1b,Ligação Telnet: %s/%d
 0xe1c,Ident falhada para %s: %s

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1587,8 +1587,7 @@ int check_dcc_attrs(struct userrec *u, int oatr)
           dcc[i].status &= (~STAT_CHAT);
           dcc[i].type = &DCC_CHAT;
           if (dcc[i].u.chat->channel >= 0) {
-            chanout_but(-1, dcc[i].u.chat->channel,
-                        "*** %s has returned.\n", dcc[i].nick);
+            chanout_but(-1, dcc[i].u.chat->channel, DCC_RETURN, dcc[i].nick);
             if (dcc[i].u.chat->channel < GLOBAL_CHANS)
               botnet_send_join_idx(i, -1);
           }

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2086,13 +2086,12 @@ static void dcc_script(int idx, char *buf, int len)
     }
     if (dcc[idx].type == &DCC_CHAT) {
       if (dcc[idx].u.chat->channel >= 0) {
-        chanout_but(-1, dcc[idx].u.chat->channel, DCC_JOIN, dcc[idx].nick);
+        chanout_but(-1, dcc[idx].u.chat->channel, DCC_RETURN, dcc[idx].nick);
         if (dcc[idx].u.chat->channel < 10000)
           botnet_send_join_idx(idx, -1);
         check_tcl_chjn(botnetnick, dcc[idx].nick, dcc[idx].u.chat->channel,
                        geticon(idx), dcc[idx].sock, dcc[idx].host);
       }
-      check_tcl_chon(dcc[idx].nick, dcc[idx].sock);
     }
   }
 }

--- a/src/lang.h
+++ b/src/lang.h
@@ -462,7 +462,7 @@
 #define DCC_CLOSED              get_language(0xe16)
 #define DCC_FAILED              get_language(0xe17)
 #define DCC_BADSRC              get_language(0xe18)
-#define DCC_RETURN		get_language(0xe19)
+#define DCC_RETURN              get_language(0xe19)
 #define DCC_BADHOST             get_language(0xe1a)
 #define DCC_TELCONN             get_language(0xe1b)
 #define DCC_IDENTFAIL           get_language(0xe1c)

--- a/src/lang.h
+++ b/src/lang.h
@@ -462,7 +462,7 @@
 #define DCC_CLOSED              get_language(0xe16)
 #define DCC_FAILED              get_language(0xe17)
 #define DCC_BADSRC              get_language(0xe18)
-/* was: DCC_BADIP               0xe19            */
+#define DCC_RETURN		get_language(0xe19)
 #define DCC_BADHOST             get_language(0xe1a)
 #define DCC_TELCONN             get_language(0xe1b)
 #define DCC_IDENTFAIL           get_language(0xe1c)

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -261,8 +261,7 @@ static void dcc_files(int idx, char *buf, int i)
       dcc[idx].status &= (~STAT_CHAT);
       dcc[idx].type = &DCC_CHAT;
       if (dcc[idx].u.chat->channel >= 0) {
-        chanout_but(-1, dcc[idx].u.chat->channel,
-                    "*** %s has returned.\n", dcc[idx].nick);
+        chanout_but(-1, dcc[idx].u.chat->channel, DCC_RETURN, dcc[idx].nick);
         if (dcc[idx].u.chat->channel < GLOBAL_CHANS)
           botnet_send_join_idx(idx, -1);
       }
@@ -345,8 +344,7 @@ static int cmd_files(struct userrec *u, int idx, char *par)
         dcc[idx].type = &DCC_CHAT;
         putlog(LOG_FILES, "*", "File system broken.");
         if (dcc[idx].u.chat->channel >= 0) {
-          chanout_but(-1, dcc[idx].u.chat->channel,
-                      "*** %s has returned.\n", dcc[idx].nick);
+          chanout_but(-1, dcc[idx].u.chat->channel, DCC_RETURN, dcc[idx].nick);
           if (dcc[idx].u.chat->channel < GLOBAL_CHANS)
             botnet_send_join_idx(idx, -1);
         }


### PR DESCRIPTION
Found by: Tothwolf
Patch by: Cizzle
Fixes: #14 

One-line summary: When returning from a control proc (.tcl control <idx> <procname>) we no longer trigger CHON binds.

Additional description: It's also more clear now that we're returning from the script and the text has been made translatable. Other already existing usages of the text were replaced as well.

Test cases demonstrating functionality:
Source the following Tcl script:
```
bind chon -|- * chonproc
proc chonproc {hand idx} { putlog "We got: $hand and $idx" }
proc choncontrol {idx text} {
        putlog "Getting text from $idx: $text"
        if {$text eq "quit"} {
                putdcc $idx "Ending this nonsense!"
                return 1
        }
        return 0
}
```
Then have two partyline connections open of which you know which has what IDX (see .dccstat). Then on either one run (with IDX their idx):
```
.tcl control IDX choncontrol
test
quit
```