### PR TITLE
Remove []s from IPv6 address if present

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1220,6 +1220,11 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
 #endif
   }
 
+/* Trim IPv6 []s out if present */
+  if (addr[0] == '[') {
+    addr[strlen(addr)-1] = 0;
+    memmove(addr, addr + 1, strlen(addr));
+  }
   bi = user_malloc(sizeof(struct bot_addr));
   bi->address = user_malloc(strlen(addr) + 1);
   strcpy(bi->address, addr);

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -869,6 +869,11 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   if (strlen(addr) > 60)
     addr[60] = 0;
 
+/* Trim IPv6 []s out if present */
+  if (addr[0] == '[') {
+    addr[strlen(addr)-1] = 0;
+    memmove(addr, addr + 1, strlen(addr));
+  }
   userlist = adduser(userlist, handle, "none", "-", USER_BOT);
   u1 = get_user_by_handle(userlist, handle);
   bi = user_malloc(sizeof(struct bot_addr));
@@ -904,11 +909,6 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     putlog(LOG_CMDS, "*", "#%s# +bot %s %s%s%s%s%s %s%s", dcc[idx].nick, handle,
            addr, port ? " " : "", port ? port : "", relay ? " " : "",
            relay ? relay : "", host[0] ? " " : "", host);
-/* Trim IPv6 []s out for display purposes */
-    if (addr[0] == '[') {
-      addr[strlen(addr)-1] = 0;
-      memmove(addr, addr + 1, strlen(addr));
-    }
 #ifdef TLS
     dprintf(idx, "Added bot '%s' with address [%s]:%s%d/%s%d and %s%s%s.\n",
             handle, addr, (bi->ssl & TLS_BOT) ? "+" : "", bi->telnet_port,


### PR DESCRIPTION
Found by: Geo
Patch by: Geo
Fixes: NA

One-line summary:
.+bot allows []s around an IPv6 address, this remove them prior to Eggdrop doing any processing on the address.

Additional description (if needed):
This also sanitizes the value so that things like ```.tcl getuser testbot botaddr``` will return the actual IP without []s around it, since this value was previously written to the userfile with the []s included.

Test cases demonstrating functionality (if applicable):
```
.+bot testbot [fd15:4ba5:5a2b:1008:c5c6:bbd0:483e:4492] 4444/5555
[05:53:28] #-HQ# +bot testbot fd15:4ba5:5a2b:1008:c5c6:bbd0:483e:4492 4444 5555 
Added bot 'testbot' with address [fd15:4ba5:5a2b:1008:c5c6:bbd0:483e:4492]:4444/5555 and no hostmask.
.whois testbot
[05:53:31] #-HQ# whois testbot
HANDLE                           PASS NOTES FLAGS           LAST
testbot                          no       0 b               never (nowhere)
  ADDRESS: fd15:4ba5:5a2b:1008:c5c6:bbd0:483e:4492
     users: 5555, bots: 4444
```
As opposed to the previous entry looking like this:
```
.whois testbot
[05:49:35] #Freeder# whois testbot
HANDLE                           PASS NOTES FLAGS           LAST
testbot                          no       0 b               never (nowhere)
  ADDRESS: [fd15:4ba5:5a2b:1008:c5c6:bbd0:483e:4492]
     users: 5555, bots: 4444
```