### PR TITLE
More errorchecking for +bot, chaddr and tcl addbot.

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -799,6 +799,12 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
   port2 = newsplit(&par);
   port = strtok(port2, "/");
   relay = strtok(NULL, "/");
+
+  if (strtok(NULL, "/")) {
+    dprintf(idx, "You've supplied more than 2 ports, make up your mind.\n");
+    return;
+  }
+
   host = newsplit(&par);
 
   if (strlen(handle) > HANDLEN)
@@ -1149,6 +1155,11 @@ static void cmd_chaddr(struct userrec *u, int idx, char *par)
   port2 = newsplit(&par);
   port = strtok(port2, "/");
   relay = strtok(NULL, "/");
+
+  if (strtok(NULL, "/")) {
+    dprintf(idx, "You've supplied more than 2 ports, make up your mind.\n");
+    return;
+  }
 
   if (addr[0]) {
 #ifndef IPV6

--- a/src/proto.h
+++ b/src/proto.h
@@ -119,6 +119,7 @@ float getcputime();
 /* cmds.c */
 int check_dcc_attrs(struct userrec *, int);
 int check_dcc_chanattrs(struct userrec *, char *, int, int);
+int check_int_range(char *value, int min, int max);
 int stripmodes(char *);
 char *stripmasktype(int);
 

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -373,7 +373,7 @@ static int tcl_addbot STDVAR
         return TCL_OK;
       }
       /* check_int_range returns 0 if p is NULL */
-      if (!check_int_range(p, 0, 65536)) {
+      if (p && !check_int_range(p, 0, 65536)) {
         Tcl_AppendResult(irp, "0", NULL);
         return TCL_OK;
       }
@@ -407,8 +407,8 @@ static int tcl_addbot STDVAR
       } else {
         bi->relay_port = atoi(p);
 #ifdef TLS
-      if (*p == '+')
-        bi->ssl |= TLS_RELAY;
+        if (*p == '+')
+          bi->ssl |= TLS_RELAY;
 #endif
       }
     }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -385,15 +385,27 @@ static int tcl_addbot STDVAR
 #ifdef TLS
     bi->ssl = 0;
 #endif
+
+    /* Max addr len is 60 ? (see cmd_pls_bot in cmds.c) */
+    if ((count = strlen(argv[2])) > 60) {
+      count = 60;
+      argv[2][count] = 0;
+    }
+    /* Trim IPv6 []s out if present */
+    if (braced) {
+      --count;
+      argv[2][count] = 0;
+      memmove(argv[2], argv[2] + 1, count);
+    }
+
     if (!q) {
-      bi->address = user_malloc(strlen(argv[2]) + 1);
+      bi->address = user_malloc(count + 1);
       strcpy(bi->address, argv[2]);
       bi->telnet_port = 3333;
       bi->relay_port = 3333;
     } else {
-      bi->address = user_malloc(q - argv[2]);
-      strncpy(bi->address, argv[2], q - argv[2] - 1);
-      bi->address[q - argv[2] - 1] = 0;
+      bi->address = user_malloc(count + 1);
+      strcpy(bi->address, argv[2]);
       bi->telnet_port = atoi(q);
 #ifdef TLS
       if (*q == '+')


### PR DESCRIPTION
Adds errorcheck for more than 2 ports being supplied to `+bot` and `chaddr` and synchronizes errorchecking of Tcl `addbot` with the `+bot` command; it was missing range, amount and ssl checking and ignored usage of ssl ports.