### PR TITLE
Use tmpfile for receiving userfile when copy-to-tmp is enabled.

### DIFF
--- a/doc/sphinx_source/coreDocs/transfer.rst
+++ b/doc/sphinx_source/coreDocs/transfer.rst
@@ -29,9 +29,10 @@ There are also some variables you can set in your config file:
 
   set copy-to-tmp 1
     Enable this setting if you want to copy files to a temporary location
-    before sending them. This might be useful for file stability, but if your
-    directories are NFS mounted, it's a pain. Setting this to 1 is not
-    advised for big files or if you're low on disk space.
+    before sending or receiving them. This might be useful for file
+    stability, but if your directories are NFS mounted, it's a pain.
+    Setting this to 1 is not advised for big files or if you're low on
+    disk space.
 
   set xfer-timeout 30
     Set here the time (in seconds) to wait before an inactive transfer

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1312,9 +1312,9 @@ set max-dloads 3
 set dcc-block 0
 
 # Enable this setting if you want to copy files to a temporary location before
-# sending them. This might be useful for file stability, but if your
-# directories are NFS mounted, it's a pain. Setting this to 1 is not advised
-# for big files or if you're low on disk space.
+# sending or receiving them. This might be useful for file stability, but if
+# your directories are NFS mounted, it's a pain. Setting this to 1 is not
+# advised for big files or if you're low on disk space.
 set copy-to-tmp 1
 
 # Set here the time (in seconds) to wait before an inactive transfer times out.

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1180,7 +1180,10 @@ static void share_ufsend(int idx, char *par)
     putlog(LOG_MISC, "*", "NO MORE DCC CONNECTIONS -- can't grab userfile");
     dprintf(idx, "s e I can't open a DCC to you; I'm full.\n");
     zapfbot(idx);
-  } else if (!(f = fopen(s, "wb"))) {
+  } else if (copy_to_tmp && !(f = tmpfile())) {
+    putlog(LOG_MISC, "*", "CAN'T WRITE TEMPORARY USERFILE DOWNLOAD FILE!");
+    zapfbot(idx);
+  } else if (!copy_to_tmp && !(f = fopen(s, "wb"))) {
     putlog(LOG_MISC, "*", "CAN'T WRITE USERFILE DOWNLOAD FILE!");
     zapfbot(idx);
   } else {

--- a/src/mod/transfer.mod/help/set/transfer.help
+++ b/src/mod/transfer.mod/help/set/transfer.help
@@ -18,12 +18,11 @@
    improve the speed of file transfers, and is recommended.
 %{help=set copy-to-tmp}%{+n}
 ###  %bset copy-to-tmp%b <0/1>
-   This specifies whether or not files will be copied into your /tmp
-   directory before they are sent to users who download them from the
-   filesystem. Turning this on protects ongoing transfers from being
-   affected by people moving files around in the file system, but if
-   you're short of disk space or using a slow disk such as an NFS
-   system, you should probably turn this off.
+   Enable this setting if you want to copy files to a temporary location
+   before sending or receiving them. This might be useful for file
+   stability, but if your directories are NFS mounted, it's a pain.
+   Setting this to 1 is not advised for big files or if you're low on
+   disk space.
 %{help=set xfer-timeout}%{+n}
 ###  %bset xfer-timeout%b <#>
    This is the number of seconds to wait before a dcc send or get is


### PR DESCRIPTION
Found by: OUTsider, simple, Geo, ...
Patch by: Cizzle
Fixes: #490 

One-line summary: The userfile being received is now properly being sent to a tmpfile first if copy-to-tmp is set.