### PR TITLE
Only show warning to convert old userfile for actual old userfiles.

### DIFF
--- a/src/users.c
+++ b/src/users.c
@@ -693,10 +693,10 @@ int readuserfile(char *file, struct userrec **ret)
   /* read opening comment */
   s = buf;
   if (fgets(s, 180, f) != NULL) {
-    if (s[1] < '4') {
+    if (s[0] == '#' && s[1] < '4' && s[1] >= '0' && s[2] == 'v') {
       fatal(USERF_OLDFMT, 0);
     }
-    if (s[1] > '4')
+    if (s[0] != '#' || s[1] > '4' || s[2] != 'v')
       fatal(USERF_INVALID, 0);
   }
   /* don't check for feof after fgets, skips last line if it has no \n (ie on windows) */


### PR DESCRIPTION
Found by: Many, many, many people
Patch by: Cizzle
Fixes: 

One-line summary: Will now show a warning (a fatal one) that the userfile is invalid instead of the almost always incorrect suggestion to weed out the old userfile.

Additional description (if needed): Eggdrop v4 userfiles date back to around mid 1997 so v3 or even older ones are probably not around anymore. Corrupt (v4) userfiles however still trigger this warning.
