### PR TITLE
Change addbot command to use spaces.

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1,5 +1,5 @@
 Eggdrop Tcl Commands
-Last revised: June 20, 2016
+Last revised: December 14, 2017
 
 ====================
 Eggdrop Tcl Commands
@@ -353,16 +353,18 @@ adduser <handle> [hostmask]
 
   Module: core
 
-^^^^^^^^^^^^^^^^^^^^^^^^^
-addbot <handle> <address>
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+addbot <handle> <address> [botport [userport]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Description: adds a new bot to the userlist with the handle and botaddress given (with no password and no flags). <address> format is one of:
 
-  - ipaddress/botport/userport
+  - ipaddress
   - ipv4address:botport/userport    [DEPRECATED]
   - [ipv6address]:botport/userport  [DEPRECATED]
 
-  Returns: 1 if successful; 0 if the bot already exists
+  In the latter two cases, another botport and/or userport given as separate arguments are ignored.
+
+  Returns: 1 if successful; 0 if the bot already exists or a port is invalid
 
   Module: core
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -362,7 +362,8 @@ addbot <handle> <address> [botport [userport]]
   - ipv4address:botport/userport    [DEPRECATED]
   - [ipv6address]:botport/userport  [DEPRECATED]
 
-  In the latter two cases, another botport and/or userport given as separate arguments are ignored.
+NOTE 1: The []s around the ipv6address argument are literal []s, not optional arguments.
+NOTE 2: In the deprecated formats, an additional botport and/or userport given as follow-on arguments are ignored.
 
   Returns: 1 if successful; 0 if the bot already exists or a port is invalid
 


### PR DESCRIPTION
Use spaces in the address instead of '/' or ':'. Command is now `addbot handle address [bot-port [relay-port]]`.
For backward compatibility, address can still be built up like `host[:bot-port[/relay-port]]`. If host is in IPv6 format, ports van only be specified when using '\[' '\]'.
The separate port arguments are ignored if the old address format is used.
