### PR TITLE
Fix percentsign being interpreted by format printers.

### DIFF
--- a/src/botmsg.c
+++ b/src/botmsg.c
@@ -44,16 +44,16 @@ void tandout_but EGG_VARARGS_DEF(int, arg1)
 {
   int i, x, len;
   char *format;
-  char s[601];
+  char s[511];
   va_list va;
 
   x = EGG_VARARGS_START(int, arg1, va);
   format = va_arg(va, char *);
 
-  len = egg_vsnprintf(s, 511, format, va);
+  len = egg_vsnprintf(s, sizeof s, format, va);
   va_end(va);
-  if (len >= sizeof(s)) {
-    len = sizeof(s) - 1;
+  if (len >= sizeof s) {
+    len = sizeof s - 1;
     s[len] = 0;
   }
 
@@ -199,9 +199,7 @@ void send_tand_but(int x, char *buf, int len)
   int i, iso = 0;
 
   if (len < 0) {
-    /* -INT_MIN is INT_MAX+1 which is... INT_MIN */
-    if (len == INT_MIN)
-      ++len;
+    /* Very unlikely len would be INT_MIN */
     len = -len;
     iso = 1;
   }

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -737,7 +737,7 @@ void tell_bottree(int idx, int showver)
  */
 void dump_links(int z)
 {
-  register int i;
+  register int i, l;
   char x[1024];
   tand_t *bot;
 
@@ -750,13 +750,13 @@ void dump_links(int z)
       p = bot->uplink->bot;
 #ifndef NO_OLD_BOTNET
     if (b_numver(z) < NEAT_BOTNET)
-      simple_sprintf(x, "nlinked %s %s %c%d\n", bot->bot,
+      l = simple_sprintf(x, "nlinked %s %s %c%d\n", bot->bot,
                          p, bot->share, bot->ver);
     else
 #endif
-      simple_sprintf(x, "n %s %s %c%D\n", bot->bot, p,
+      l = simple_sprintf(x, "n %s %s %c%D\n", bot->bot, p,
                          bot->share, bot->ver);
-    dprintf(z, x);
+    dprint(z, x, l);
   }
   if (!(bot_flags(dcc[z].user) & BOT_ISOLATE)) {
     /* Dump party line members */
@@ -766,65 +766,65 @@ void dump_links(int z)
             (dcc[i].u.chat->channel < GLOBAL_CHANS)) {
 #ifndef NO_OLD_BOTNET
           if (b_numver(z) < NEAT_BOTNET)
-            simple_sprintf(x, "join %s %s %d %c%d %s\n",
+             l =simple_sprintf(x, "join %s %s %d %c%d %s\n",
                                botnetnick, dcc[i].nick,
                                dcc[i].u.chat->channel, geticon(i),
                                dcc[i].sock, dcc[i].host);
           else
 #endif
-            simple_sprintf(x, "j !%s %s %D %c%D %s\n",
+            l = simple_sprintf(x, "j !%s %s %D %c%D %s\n",
                                botnetnick, dcc[i].nick,
                                dcc[i].u.chat->channel, geticon(i),
                                dcc[i].sock, dcc[i].host);
-          dprintf(z, x);
+          dprint(z, x, l);
 #ifndef NO_OLD_BOTNET
           if (b_numver(z) < NEAT_BOTNET) {
             if (dcc[i].u.chat->away) {
-              simple_sprintf(x, "away %s %d %s\n", botnetnick,
+              l = simple_sprintf(x, "away %s %d %s\n", botnetnick,
                                  dcc[i].sock, dcc[i].u.chat->away);
-              dprintf(z, x);
+              dprint(z, x, l);
             }
-            simple_sprintf(x, "idle %s %d %d\n", botnetnick,
+            l = simple_sprintf(x, "idle %s %d %d\n", botnetnick,
                                dcc[i].sock, now - dcc[i].timeval);
           } else
 #endif
-            simple_sprintf(x, "i %s %D %D %s\n", botnetnick,
+            l = simple_sprintf(x, "i %s %D %D %s\n", botnetnick,
                                dcc[i].sock, now - dcc[i].timeval,
                                dcc[i].u.chat->away ? dcc[i].u.chat->away : "");
-          dprintf(z, x);
+          dprint(z, x, l);
         }
       }
     }
     for (i = 0; i < parties; i++) {
 #ifndef NO_OLD_BOTNET
       if (b_numver(z) < NEAT_BOTNET)
-        simple_sprintf(x, "join %s %s %d %c%d %s\n",
+        l = simple_sprintf(x, "join %s %s %d %c%d %s\n",
                            party[i].bot, party[i].nick,
                            party[i].chan, party[i].flag,
                            party[i].sock, party[i].from);
       else
 #endif
-        simple_sprintf(x, "j %s %s %D %c%D %s\n",
+        l = simple_sprintf(x, "j %s %s %D %c%D %s\n",
                            party[i].bot, party[i].nick,
                            party[i].chan, party[i].flag,
                            party[i].sock, party[i].from);
-      dprintf(z, x);
+      dprint(z, x, l);
       if ((party[i].status & PLSTAT_AWAY) || (party[i].timer != 0)) {
 #ifndef NO_OLD_BOTNET
         if (b_numver(z) < NEAT_BOTNET) {
           if (party[i].status & PLSTAT_AWAY) {
-            simple_sprintf(x, "away %s %d %s\n", party[i].bot,
+            l = simple_sprintf(x, "away %s %d %s\n", party[i].bot,
                                party[i].sock, party[i].away);
-            dprintf(z, x);
+            dprint(z, x, l);
           }
-          simple_sprintf(x, "idle %s %d %d\n", party[i].bot,
+          l = simple_sprintf(x, "idle %s %d %d\n", party[i].bot,
                              party[i].sock, now - party[i].timer);
         } else
 #endif
-          simple_sprintf(x, "i %s %D %D %s\n", party[i].bot,
+          l = simple_sprintf(x, "i %s %D %D %s\n", party[i].bot,
                              party[i].sock, now - party[i].timer,
                              party[i].away ? party[i].away : "");
-        dprintf(z, x);
+        dprint(z, x, l);
       }
     }
   }

--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -166,6 +166,12 @@ void dprintf EGG_VARARGS_DEF(int, arg1)
   buf[sizeof(buf) - 1] = 0;
   len = strlen(buf);
 
+  /* Send it out */
+  dprint(idx, buf, len);
+}
+
+void dprint(int idx, char *buf, int len)
+{
   if (idx < 0) {
     tputs(-idx, buf, len);
   } else if (idx > 0x7FF0) {

--- a/src/proto.h
+++ b/src/proto.h
@@ -137,6 +137,7 @@ int increase_socks_max();
 int findidx(int);
 int findanyidx(int);
 char *add_cr(char *);
+void dprint(int, char *, int);
 void dprintf EGG_VARARGS(int, arg1);
 void chatout EGG_VARARGS(char *, arg1);
 extern void (*shareout) ();


### PR DESCRIPTION
Found by: VertigoRN
Patch by: Cizzle
Fixes: #498 

One-line summary: Fixes the percentsign being dropped half the time for certain botnet commands.