### PR TITLE
Isolate global isban/is[*] checks from channel checks

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -659,75 +659,75 @@ ischanjuped <channel>
 
   Module: channels
 
-^^^^^^^^^^^^^^^^^^^^^
-isban <ban> [channel]
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isban <ban> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified ban is in the global ban list; 0 otherwise. If a channel is specified, that channel's ban list is checked as well.
-
-  Module: channels
-
-^^^^^^^^^^^^^^^^^^^^^^^^^
-ispermban <ban> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Returns: 1 if the specified ban is in the global ban list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's ban list is checked as well.
+  Returns: 1 if the specified ban is in the global ban list; 0 otherwise. If a channel is specified, that channel's ban list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel bans are checked.
 
   Module: channels
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isexempt <exempt> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ispermban <ban> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified exempt is in the global exempt list; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well.
-
-  Module: channels
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-ispermexempt <exempt> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Returns: 1 if the specified exempt is in the global exempt list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well.
+  Returns: 1 if the specified ban is in the global ban list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's ban list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel bans are checked.
 
   Module: channels
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isinvite <invite> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isexempt <exempt> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified invite is in the global invite list; 0 otherwise. If a channel is specified, that channel's invite list is checked as well.
-
-  Module: channels
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isperminvite <invite> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Returns: 1 if the specified invite is in the global invite list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's invite list is checked as well.
+  Returns: 1 if the specified exempt is in the global exempt list; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel exempts are checked.
 
   Module: channels
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isbansticky <ban> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ispermexempt <exempt> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified ban is marked as sticky in the global ban list; 0 otherwise. If a channel is specified, that channel's ban list is checked as well.
-
-  Module: channels
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isexemptsticky <exempt> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Returns: 1 if the specified exempt is marked as sticky in the global exempt list; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well.
+  Returns: 1 if the specified exempt is in the global exempt list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel exempts are checked.
 
   Module: channels
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-isinvitesticky <invite> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isinvite <invite> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if the specified invite is marked as sticky in the global invite list; 0 otherwise. If a channel is specified, that channel's invite list is checked as well.
+  Returns: 1 if the specified invite is in the global invite list; 0 otherwise. If a channel is specified, that channel's invite list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel invites are checked.
+
+  Module: channels
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isperminvite <invite> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Returns: 1 if the specified invite is in the global invite list AND is marked as permanent; 0 otherwise. If a channel is specified, that channel's invite list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel invites are checked.
+
+  Module: channels
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isbansticky <ban> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Returns: 1 if the specified ban is marked as sticky in the global ban list; 0 otherwise. If a channel is specified, that channel's ban list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel bans are checked.
+
+  Module: channels
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isexemptsticky <exempt> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Returns: 1 if the specified exempt is marked as sticky in the global exempt list; 0 otherwise. If a channel is specified, that channel's exempt list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel exempts are checked.
+
+  Module: channels
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+isinvitesticky <invite> [channel [-channel]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Returns: 1 if the specified invite is marked as sticky in the global invite list; 0 otherwise. If a channel is specified, that channel's invite list is checked as well. If the -channel flag is used at the end of the command, \*only\* the channel invites are checked.
 
   Module: channels
 

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -125,11 +125,11 @@ static int tcl_killchaninvite STDVAR
 static int tcl_stick STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " ban ?channel?");
+  BADARGS(2, 4, " ban ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -138,8 +138,16 @@ static int tcl_stick STDVAR
     if (u_setsticky_ban(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  else if (!ok && u_setsticky_ban(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (!ok && u_setsticky_ban(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+      0 : 1) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -151,11 +159,11 @@ static int tcl_stick STDVAR
 static int tcl_stickinvite STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " invite ?channel?");
+  BADARGS(2, 4, " invite ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -164,8 +172,16 @@ static int tcl_stickinvite STDVAR
     if (u_setsticky_invite(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  else if (!ok && u_setsticky_invite(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (!ok && u_setsticky_invite(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+      0 : 1) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -177,11 +193,11 @@ static int tcl_stickinvite STDVAR
 static int tcl_stickexempt STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " exempt ?channel?");
+  BADARGS(2, 4, " exempt ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -190,8 +206,16 @@ static int tcl_stickexempt STDVAR
     if (u_setsticky_exempt(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  else if (!ok && u_setsticky_exempt(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (!ok && u_setsticky_exempt(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+      0 : 1) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -203,11 +227,11 @@ static int tcl_stickexempt STDVAR
 static int tcl_isban STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " ban ?channel?");
+  BADARGS(2, 4, " ban ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -216,7 +240,15 @@ static int tcl_isban STDVAR
     if (u_equals_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  else if (u_equals_mask(global_bans, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_equals_mask(global_bans, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -228,11 +260,11 @@ static int tcl_isban STDVAR
 static int tcl_isexempt STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " exempt ?channel?");
+  BADARGS(2, 4, " exempt ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -241,7 +273,15 @@ static int tcl_isexempt STDVAR
     if (u_equals_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  else if (u_equals_mask(global_exempts, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_equals_mask(global_exempts, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -253,11 +293,11 @@ static int tcl_isexempt STDVAR
 static int tcl_isinvite STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " invite ?channel?");
+  BADARGS(2, 4, " invite ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -266,7 +306,15 @@ static int tcl_isinvite STDVAR
     if (u_equals_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  else if (u_equals_mask(global_invites, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_equals_mask(global_invites, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -279,11 +327,11 @@ static int tcl_isinvite STDVAR
 static int tcl_isbansticky STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " ban ?channel?");
+  BADARGS(2, 4, " ban ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -292,7 +340,15 @@ static int tcl_isbansticky STDVAR
     if (u_sticky_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  else if (u_sticky_mask(global_bans, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_sticky_mask(global_bans, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -304,11 +360,11 @@ static int tcl_isbansticky STDVAR
 static int tcl_isexemptsticky STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " exempt ?channel?");
+  BADARGS(2, 4, " exempt ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -317,7 +373,15 @@ static int tcl_isexemptsticky STDVAR
     if (u_sticky_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  else if (u_sticky_mask(global_exempts, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_sticky_mask(global_exempts, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -329,11 +393,11 @@ static int tcl_isexemptsticky STDVAR
 static int tcl_isinvitesticky STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " invite ?channel?");
+  BADARGS(2, 4, " invite ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -342,7 +406,15 @@ static int tcl_isinvitesticky STDVAR
     if (u_sticky_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  else if (u_sticky_mask(global_invites, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if (u_sticky_mask(global_invites, argv[1]) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -354,11 +426,11 @@ static int tcl_isinvitesticky STDVAR
 static int tcl_ispermban STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " ban ?channel?");
+  BADARGS(2, 4, " ban ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -367,7 +439,15 @@ static int tcl_ispermban STDVAR
     if (u_equals_mask(chan->bans, argv[1]) == 2)
       ok = 1;
   }
-  else if (u_equals_mask(global_bans, argv[1]) == 2)
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_equals_mask(global_bans, argv[1]) == 2) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -379,11 +459,11 @@ static int tcl_ispermban STDVAR
 static int tcl_ispermexempt STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " exempt ?channel?");
+  BADARGS(2, 4, " exempt ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -392,7 +472,15 @@ static int tcl_ispermexempt STDVAR
     if (u_equals_mask(chan->exempts, argv[1]) == 2)
       ok = 1;
   }
-  else if (u_equals_mask(global_exempts, argv[1]) == 2)
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_equals_mask(global_exempts, argv[1]) == 2) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -404,11 +492,11 @@ static int tcl_ispermexempt STDVAR
 static int tcl_isperminvite STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " invite ?channel?");
+  BADARGS(2, 4, " invite ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -417,7 +505,15 @@ static int tcl_isperminvite STDVAR
     if (u_equals_mask(chan->invites, argv[1]) == 2)
       ok = 1;
   }
-  else if (u_equals_mask(global_invites, argv[1]) == 2)
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_equals_mask(global_invites, argv[1]) == 2) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -429,11 +525,11 @@ static int tcl_isperminvite STDVAR
 static int tcl_matchban STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " user!nick@host ?channel?");
+  BADARGS(2, 4, " user!nick@host ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -442,7 +538,15 @@ static int tcl_matchban STDVAR
     if (u_match_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  else if (u_match_mask(global_bans, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_match_mask(global_bans, argv[1])) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -454,11 +558,11 @@ static int tcl_matchban STDVAR
 static int tcl_matchexempt STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " user!nick@host ?channel?");
+  BADARGS(2, 4, " user!nick@host ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -467,7 +571,15 @@ static int tcl_matchexempt STDVAR
     if (u_match_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  else if (u_match_mask(global_exempts, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_match_mask(global_exempts, argv[1])) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -479,11 +591,11 @@ static int tcl_matchexempt STDVAR
 static int tcl_matchinvite STDVAR
 {
   struct chanset_t *chan;
-  int ok = 0;
+  int chanarg = 1, ok = 0;
 
-  BADARGS(2, 3, " user!nick@host ?channel?");
+  BADARGS(2, 4, " user!nick@host ?channel? ?-channel?");
 
-  if (argc == 3) {
+  if (argc >= 3) {
     chan = findchan_by_dname(argv[2]);
     if (chan == NULL) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -492,7 +604,15 @@ static int tcl_matchinvite STDVAR
     if (u_match_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  else if (u_match_mask(global_invites, argv[1]))
+  if (argc == 4) {
+    if (!strcasecmp(argv[3], "-channel")) {
+      chanarg = 0;
+    } else {
+      Tcl_AppendResult(irp, "invalid flag", NULL);
+      return TCL_ERROR;
+    }
+  }
+  if ((u_match_mask(global_invites, argv[1])) && chanarg)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -125,11 +125,11 @@ static int tcl_killchaninvite STDVAR
 static int tcl_stick STDVAR
 {
   struct chanset_t *chan;
-  int chanarg = 1, ok = 0;
+  int ok = 0;
 
-  BADARGS(2, 4, " ban ?channel? ?-channel?");
+  BADARGS(2, 3, " ban ?channel?");
 
-  if (argc >= 3) {
+  if (argc == 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -138,16 +138,8 @@ static int tcl_stick STDVAR
     if (u_setsticky_ban(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (argc == 4) {
-    if (!strcasecmp(argv[3], "-channel")) {
-      chanarg = 0;
-    } else {
-      Tcl_AppendResult(irp, "invalid flag", NULL);
-      return TCL_ERROR;
-    }
-  }
   if (!ok && u_setsticky_ban(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1) && chanarg)
+      0 : 1))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -159,11 +151,11 @@ static int tcl_stick STDVAR
 static int tcl_stickinvite STDVAR
 {
   struct chanset_t *chan;
-  int chanarg = 1, ok = 0;
+  int ok = 0;
 
-  BADARGS(2, 4, " invite ?channel? ?-channel?");
+  BADARGS(2, 3, " invite ?channel?");
 
-  if (argc >= 3) {
+  if (argc == 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -172,16 +164,8 @@ static int tcl_stickinvite STDVAR
     if (u_setsticky_invite(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (argc == 4) {
-    if (!strcasecmp(argv[3], "-channel")) {
-      chanarg = 0;
-    } else {
-      Tcl_AppendResult(irp, "invalid flag", NULL);
-      return TCL_ERROR;
-    }
-  }
   if (!ok && u_setsticky_invite(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1) && chanarg)
+      0 : 1))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -193,11 +177,11 @@ static int tcl_stickinvite STDVAR
 static int tcl_stickexempt STDVAR
 {
   struct chanset_t *chan;
-  int chanarg = 1, ok = 0;
+  int ok = 0;
 
-  BADARGS(2, 4, " exempt ?channel? ?-channel?");
+  BADARGS(2, 3, " exempt ?channel?");
 
-  if (argc >= 3) {
+  if (argc == 3) {
     chan = findchan_by_dname(argv[2]);
     if (!chan) {
       Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
@@ -206,16 +190,8 @@ static int tcl_stickexempt STDVAR
     if (u_setsticky_exempt(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (argc == 4) {
-    if (!strcasecmp(argv[3], "-channel")) {
-      chanarg = 0;
-    } else {
-      Tcl_AppendResult(irp, "invalid flag", NULL);
-      return TCL_ERROR;
-    }
-  }
   if (!ok && u_setsticky_exempt(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
-      0 : 1) && chanarg)
+      0 : 1))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -138,7 +138,7 @@ static int tcl_stick STDVAR
     if (u_setsticky_ban(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (!ok && u_setsticky_ban(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+  else if (!ok && u_setsticky_ban(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
       0 : 1))
     ok = 1;
   if (ok)
@@ -164,7 +164,7 @@ static int tcl_stickinvite STDVAR
     if (u_setsticky_invite(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (!ok && u_setsticky_invite(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+  else if (!ok && u_setsticky_invite(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
       0 : 1))
     ok = 1;
   if (ok)
@@ -190,7 +190,7 @@ static int tcl_stickexempt STDVAR
     if (u_setsticky_exempt(chan, argv[1], !strncmp(argv[0], "un", 2) ? 0 : 1))
       ok = 1;
   }
-  if (!ok && u_setsticky_exempt(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
+  else if (!ok && u_setsticky_exempt(NULL, argv[1], !strncmp(argv[0], "un", 2) ?
       0 : 1))
     ok = 1;
   if (ok)
@@ -216,7 +216,7 @@ static int tcl_isban STDVAR
     if (u_equals_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  if (u_equals_mask(global_bans, argv[1]))
+  else if (u_equals_mask(global_bans, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -241,7 +241,7 @@ static int tcl_isexempt STDVAR
     if (u_equals_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  if (u_equals_mask(global_exempts, argv[1]))
+  else if (u_equals_mask(global_exempts, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -266,7 +266,7 @@ static int tcl_isinvite STDVAR
     if (u_equals_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  if (u_equals_mask(global_invites, argv[1]))
+  else if (u_equals_mask(global_invites, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -292,7 +292,7 @@ static int tcl_isbansticky STDVAR
     if (u_sticky_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  if (u_sticky_mask(global_bans, argv[1]))
+  else if (u_sticky_mask(global_bans, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -317,7 +317,7 @@ static int tcl_isexemptsticky STDVAR
     if (u_sticky_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  if (u_sticky_mask(global_exempts, argv[1]))
+  else if (u_sticky_mask(global_exempts, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -342,7 +342,7 @@ static int tcl_isinvitesticky STDVAR
     if (u_sticky_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  if (u_sticky_mask(global_invites, argv[1]))
+  else if (u_sticky_mask(global_invites, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -367,7 +367,7 @@ static int tcl_ispermban STDVAR
     if (u_equals_mask(chan->bans, argv[1]) == 2)
       ok = 1;
   }
-  if (u_equals_mask(global_bans, argv[1]) == 2)
+  else if (u_equals_mask(global_bans, argv[1]) == 2)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -392,7 +392,7 @@ static int tcl_ispermexempt STDVAR
     if (u_equals_mask(chan->exempts, argv[1]) == 2)
       ok = 1;
   }
-  if (u_equals_mask(global_exempts, argv[1]) == 2)
+  else if (u_equals_mask(global_exempts, argv[1]) == 2)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -417,7 +417,7 @@ static int tcl_isperminvite STDVAR
     if (u_equals_mask(chan->invites, argv[1]) == 2)
       ok = 1;
   }
-  if (u_equals_mask(global_invites, argv[1]) == 2)
+  else if (u_equals_mask(global_invites, argv[1]) == 2)
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -442,7 +442,7 @@ static int tcl_matchban STDVAR
     if (u_match_mask(chan->bans, argv[1]))
       ok = 1;
   }
-  if (u_match_mask(global_bans, argv[1]))
+  else if (u_match_mask(global_bans, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -467,7 +467,7 @@ static int tcl_matchexempt STDVAR
     if (u_match_mask(chan->exempts, argv[1]))
       ok = 1;
   }
-  if (u_match_mask(global_exempts, argv[1]))
+  else if (u_match_mask(global_exempts, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);
@@ -492,7 +492,7 @@ static int tcl_matchinvite STDVAR
     if (u_match_mask(chan->invites, argv[1]))
       ok = 1;
   }
-  if (u_match_mask(global_invites, argv[1]))
+  else if (u_match_mask(global_invites, argv[1]))
     ok = 1;
   if (ok)
     Tcl_AppendResult(irp, "1", NULL);


### PR DESCRIPTION
Found by: maimizuno
Patch by: Geo
Fixes: #531 

One-line summary:
Stops isban (and other is* commands) from returning 1 on a channel query when only a global ban/whatever exists. 

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.bans *!*@test.com
Global bans:
! [  1] *!foo@test.com (perm)
        vanosg: requested
        Created 03:34
Channel bans for #foober:  (* = not placed by bot)

.tcl isban *!foo@test.com
Tcl: 1
.tcl isban *!foo@test.com #foober 
Tcl: 0

### Now add a channel ban, so both global and channel exist:
.+ban *!foo@test.com #foober
New #foober ban: *!foo@test.com (requested)
.tcl isban *!foo@test.com #foober 
Tcl: 1
.tcl isban *!foo@test.com
Tcl: 1

### Now remove global, so only channel ban exists:
.-ban *!foo@test.com
Removed ban: *!foo@test.com
.tcl isban *!foo@test.com         
Tcl: 0
.tcl isban *!foo@test.com #foober 
Tcl: 1
