### PR TITLE
Include '+' port prefix in $server. Fixes #538

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1267,7 +1267,12 @@ static char *traced_server(ClientData cdata, Tcl_Interp *irp,
     int servidx = findanyidx(serv);
 
     /* return real server name */
+#ifdef TLS
+    simple_sprintf(s, "%s:%s%u", realservername, dcc[servidx].ssl ? "+" : "",
+                   dcc[servidx].port);
+#else
     simple_sprintf(s, "%s:%u", realservername, dcc[servidx].port);
+#endif
   } else
     s[0] = 0;
   Tcl_SetVar2(interp, name1, name2, s, TCL_GLOBAL_ONLY);


### PR DESCRIPTION
Found by: maimizuno
Patch by: Geo
Fixes: #538 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.tcl putlog $server
[15:58:58] barjavel.freenode.net:+7000
```
and
```
.tcl putlog $server
[16:00:21] barjavel.freenode.net:6667
```