### PR TITLE
fix541

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2605,24 +2605,24 @@ static void cmd_pls_ignore(struct userrec *u, int idx, char *par)
       case 'd':
         *p = 0;
         expire_foo = strtol(p_expire, NULL, 10);
-        if (expire_foo > 365)
-          expire_foo = 365;
-        expire_time += 86400 * expire_foo;
+        if (expire_foo > (INT_MAX - now) / (60 * 60 * 24))
+          expire_foo = (INT_MAX - now) / (60 * 60 * 24);
+        expire_time += 60 * 60 * 24 * expire_foo;
         p_expire = p + 1;
         break;
       case 'h':
         *p = 0;
         expire_foo = strtol(p_expire, NULL, 10);
-        if (expire_foo > 8760)
-          expire_foo = 8760;
-        expire_time += 3600 * expire_foo;
+        if (expire_foo > (INT_MAX - now) / (60 * 60))
+          expire_foo = (INT_MAX - now) / (60 * 60);
+        expire_time += 60 * 60 * expire_foo;
         p_expire = p + 1;
         break;
       case 'm':
         *p = 0;
         expire_foo = strtol(p_expire, NULL, 10);
-        if (expire_foo > 525600)
-          expire_foo = 525600;
+        if (expire_foo > (INT_MAX - now) / 60)
+          expire_foo = (INT_MAX - now) / 60;
         expire_time += 60 * expire_foo;
         p_expire = p + 1;
       }

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -75,24 +75,24 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60 * 24))
-            expire_foo = INT_MAX / (60 * 60 * 24);
+          if (expire_foo > (INT_MAX - now) / (60 * 60 * 24))
+            expire_foo = (INT_MAX - now) / (60 * 60 * 24);
           expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60))
-            expire_foo = INT_MAX / (60 * 60);
+          if (expire_foo > (INT_MAX - now) / (60 * 60))
+            expire_foo = (INT_MAX - now) / (60 * 60);
           expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / 60)
-            expire_foo = INT_MAX / 60;
+          if (expire_foo > (INT_MAX - now) / 60)
+            expire_foo = (INT_MAX - now) / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }
@@ -211,24 +211,24 @@ static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60 * 24))
-            expire_foo = INT_MAX / (60 * 60 * 24);
+          if (expire_foo > (INT_MAX - now) / (60 * 60 * 24))
+            expire_foo = (INT_MAX - now) / (60 * 60 * 24);
           expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60))
-            expire_foo = INT_MAX / (60 * 60);
+          if (expire_foo > (INT_MAX - now) / (60 * 60))
+            expire_foo = (INT_MAX - now) / (60 * 60);
           expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / 60)
-            expire_foo = INT_MAX / 60;
+          if (expire_foo > (INT_MAX - now) / 60)
+            expire_foo = (INT_MAX - now) / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }
@@ -333,24 +333,24 @@ static void cmd_pls_invite(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60 * 24))
-            expire_foo = INT_MAX / (60 * 60 * 24);
+          if (expire_foo > (INT_MAX - now) / (60 * 60 * 24))
+            expire_foo = (INT_MAX - now) / (60 * 60 * 24);
           expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / (60 * 60))
-            expire_foo = INT_MAX / (60 * 60);
+          if (expire_foo > (INT_MAX - now) / (60 * 60))
+            expire_foo = (INT_MAX - now) / (60 * 60);
           expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > INT_MAX / 60)
-            expire_foo = INT_MAX / 60;
+          if (expire_foo > (INT_MAX - now) / 60)
+            expire_foo = (INT_MAX - now) / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -75,24 +75,24 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 365)
-            expire_foo = 365;
-          expire_time += 86400 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60 * 24))
+            expire_foo = INT_MAX / (60 * 60 * 24);
+          expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 8760)
-            expire_foo = 8760;
-          expire_time += 3600 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60))
+            expire_foo = INT_MAX / (60 * 60);
+          expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 525600)
-            expire_foo = 525600;
+          if (expire_foo > INT_MAX / 60)
+            expire_foo = INT_MAX / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }
@@ -211,24 +211,24 @@ static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 365)
-            expire_foo = 365;
-          expire_time += 86400 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60 * 24))
+            expire_foo = INT_MAX / (60 * 60 * 24);
+          expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 8760)
-            expire_foo = 8760;
-          expire_time += 3600 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60))
+            expire_foo = INT_MAX / (60 * 60);
+          expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 525600)
-            expire_foo = 525600;
+          if (expire_foo > INT_MAX / 60)
+            expire_foo = INT_MAX / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }
@@ -333,24 +333,24 @@ static void cmd_pls_invite(struct userrec *u, int idx, char *par)
         case 'd':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 365)
-            expire_foo = 365;
-          expire_time += 86400 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60 * 24))
+            expire_foo = INT_MAX / (60 * 60 * 24);
+          expire_time += 60 * 60 * 24 * expire_foo;
           p_expire = p + 1;
           break;
         case 'h':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 8760)
-            expire_foo = 8760;
-          expire_time += 3600 * expire_foo;
+          if (expire_foo > INT_MAX / (60 * 60))
+            expire_foo = INT_MAX / (60 * 60);
+          expire_time += 60 * 60 * expire_foo;
           p_expire = p + 1;
           break;
         case 'm':
           *p = 0;
           expire_foo = strtol(p_expire, NULL, 10);
-          if (expire_foo > 525600)
-            expire_foo = 525600;
+          if (expire_foo > INT_MAX / 60)
+            expire_foo = INT_MAX / 60;
           expire_time += 60 * expire_foo;
           p_expire = p + 1;
         }

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.8.3"
-#define EGG_NUMVER 1080301
-#define EGG_PATCH "archdetect"
+#define EGG_NUMVER 1080302
+#define EGG_PATCH "bandelimit"


### PR DESCRIPTION
Found by: Robby
Patch by: michaelortmann
Fixes:  #541

One-line summary:
old limit was arbitrary 365 days (~1 year) per specifier; new limit is 2000 days all specifiers combined.

Additional description (if needed):
old limit was arbitrary 365 days (~1 year) per specifier.
if you did all 3 specifiers %d%h%m the combined limit was ~3 years.
new limit could be max. ~19years.
so that time in seconds doesnt overflow (INT_MAX - now).
eggdrop suffers like most? software from year 2038 problem, see:
https://en.wikipedia.org/wiki/Year_2038_problem
this new limit would be dynamic.
it was decided to set a static combined limit of 2000 days.
this is what this patch does.
see the troll come back in 2000 days.
capped commands are:
  .+ban
  .+exempt
  .+invite
  .+ignore 

Test cases demonstrating functionality (if applicable):

**before:**

.+ban *!*@2001:db8::/32 %730d You have been banned for... something.
[23:30:32] #-HQ# (GLOBAL) +ban *!*@2001:db8::/32 (You have been banned for... something.)
New ban: *!*@2001:db8::/32 (You have been banned for... something.)
.bans *!*@2001:db8::/32
[23:30:45] #-HQ# bans *!*@2001:db8::/32
Global bans:
  [  1] *!*@2001:db8::/32 (expires in 364 days)
        -HQ: You have been banned for... something.
        Created 23:30

**after:**

.+ban test1 %2000d
[03:51:30] #-HQ# (GLOBAL) +ban test1!*@* (requested)
New ban: test1!*@* (requested)

.+ban test2 %2001d
Limit for expire time is 2000 days.

.+ban test3 %2000d1h
Limit for expire time is 2000 days.

.+ban test4 %2000d1m
Limit for expire time is 2000 days.

.bans all
[03:51:43] #-HQ# bans all
Global bans:
  [  1] test1!*@* (expires in 1999 days)
        -HQ: requested
        Created 03:51

.+exempt test5 %2000d
[03:51:48] #-HQ# (GLOBAL) +exempt test5!*@* (requested)
New exempt: test5!*@* (requested)

.+exempt test6 %2001d
Limit for expire time is 2000 days.

.exempts all
[03:51:56] #-HQ# exempts all
Global exempts:
  [  1] test5!*@* (expires in 1999 days)
        -HQ: requested
        Created 03:51

.+invite test7 %2000d
[03:52:01] #-HQ# (GLOBAL) +invite test7!*@* (requested)
New invite: test7!*@* (requested)

.+invite test8 %2001d
Limit for expire time is 2000 days.

.invites all
[03:52:09] #-HQ# invites all
Global invites:
  [  1] test7!*@* (expires in 1999 days)
        -HQ: requested
        Created 03:52

.+ignore test9 %2000d
Now ignoring: test9!*@* (requested)
[03:52:14] #-HQ# +ignore test9!*@* requested

.+ignore test10 %2001d
Limit for expire time is 2000 days.

.ignores    
[03:52:28] #-HQ# ignores 
Currently ignoring:
  [  1] test9!*@* (expires in 1999 days)
        -HQ: requested
        Started 03:52