### PR TITLE
(WIP) fix stringop-truncation warning

### DIFF
--- a/src/mod/blowfish.mod/blowfish.c
+++ b/src/mod/blowfish.mod/blowfish.c
@@ -34,7 +34,8 @@
 #undef global
 static Function *global = NULL;
 
-static char bf_mode[4];
+/* ECB by default for now, change at v1.9.0! */
+static char bf_mode[] = "ecb";
 
 /* Each box takes up 4k so be very careful here */
 #define BOXES 3
@@ -728,8 +729,6 @@ char *blowfish_start(Function *global_funcs)
     add_hook(HOOK_DECRYPT_STRING, (Function) decrypt_string);
   }
 
-  /* ECB by default for now, change at v1.9.0! */
-  strncpyz(bf_mode, "ecb", sizeof bf_mode);
   add_tcl_commands(mytcls);
   add_tcl_strings(my_tcl_strings);
   add_help_reference("blowfish.help");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: stringop-truncation warning

One-line summary:
fixes the only stringop-truncation warning

Additional description (if needed):
modern gcc throws exactly 1 direct stringop-truncation warning on eggdrop. this patch fixes this. i guess the original author found no other solution of setting bf_mode. i tried #define which crashed and *bf_mode = "ecb" which doesnt work. the solution is bfmode[] = "ecb".

there are another 13 indirect warnings, but those disappear, if you would set -Wno-format-truncation.

Test cases demonstrating functionality (if applicable):
./eggdrop -ntm
[...]
.set blowfish-use-mode
[03:51:47] #-HQ# set blowfish-use-mode
Currently: ecb