### PR TITLE
(WIP) be portable and c89 and posix 2001

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -291,6 +291,9 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
+/* Define to 1 if you have the `strlcpy' function. */
+#undef HAVE_STRLCPY
+
 /* Define to 1 if you have the `strncasecmp' function. */
 #undef HAVE_STRNCASECMP
 

--- a/configure
+++ b/configure
@@ -6919,7 +6919,7 @@ ac_config_commands="$ac_config_commands $ac_stdint_h"
 
 
 # Checks for functions and their arguments.
-for ac_func in clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop
+for ac_func in clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strlcpy strncasecmp uname vsnprintf inet_ntop
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ EGG_CHECK_SOCKLEN_T
 AX_CREATE_STDINT_H([eggint.h])
 
 # Checks for functions and their arguments.
-AC_CHECK_FUNCS([clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop])
+AC_CHECK_FUNCS([clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strlcpy strncasecmp uname vsnprintf inet_ntop])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_VPRINTF
 AC_FUNC_STRFTIME

--- a/src/language.c
+++ b/src/language.c
@@ -88,7 +88,7 @@ static lang_sec *langsection = NULL;
 static lang_pri *langpriority = NULL;
 
 static int del_lang(char *);
-static int add_message(int, char *);
+static int add_message(unsigned int, char *);
 static void recheck_lang_sections(void);
 static void read_lang(char *);
 void add_lang_section(char *);
@@ -160,7 +160,7 @@ static int del_lang(char *lang)
   return 0;
 }
 
-static int add_message(int lidx, char *ltext)
+static int add_message(unsigned int lidx, char *ltext)
 {
   lang_tab *l = langtab[lidx & 63];
 
@@ -213,7 +213,7 @@ static void read_lang(char *langfile)
   char lbuf[512];
   char *ltext = NULL;
   char *ctmp, *ctmp1;
-  int lidx;
+  unsigned int lidx;
   int lnew = 1;
   int lline = 1;
   int lskip = 0;
@@ -526,7 +526,8 @@ static int cmd_languagedump(struct userrec *u, int idx, char *par)
 {
   lang_tab *l;
   char ltext2[512];
-  int idx2, i;
+  unsigned int idx2;
+  int i;
 
   putlog(LOG_CMDS, "*", "#%s# ldump %s", dcc[idx].nick, par);
   if (par[0]) {
@@ -534,7 +535,7 @@ static int cmd_languagedump(struct userrec *u, int idx, char *par)
     if (strlen(par) > 2 && par[0] == '0' && par[1] == 'x')
       sscanf(par, "%x", &idx2);
     else
-      idx2 = (int) strtol(par, (char **) NULL, 10);
+      idx2 = strtol(par, (char **) NULL, 10);
     strncpyz(ltext2, get_language(idx2), sizeof ltext2);
     dprintf(idx, "0x%x: %s\n", idx2, ltext2);
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -533,7 +533,7 @@ void show_help() {
   printf("\n%s\n\n", version);
   printf("Usage: eggdrop [options] [config-file]\n\n"
          "Options:\n"
-         "-n Don't background; send all log entries to console.\n"
+         "-n   Don't background; send all log entries to console.\n"
          "-nc  Don't background; display channel stats every 10 seconds.\n"
          "-nt  Don't background; use terminal to simulate DCC chat.\n"
          "-m   Create userfile.\n"
@@ -541,6 +541,15 @@ void show_help() {
          "-v   Show version info, then quit.\n\n");
   bg_send_quit(BG_ABORT);
 }
+
+#define CLI_V        1 << 0
+#define CLI_M        1 << 1
+#define CLI_T        1 << 2
+#define CLI_C        1 << 3
+#define CLI_N        1 << 4
+#define CLI_H        1 << 5
+#define CLI_BAD_FLAG 1 << 6
+#define CLI_QUIT     1 << 7
 
 static void do_arg()
 {
@@ -554,41 +563,41 @@ static void do_arg()
   while ((option = getopt(argc, argv, "hnctmv")) != -1) {
     switch (option) {
       case 'n':
-        cliflags |= 16;
+        cliflags |= CLI_N;
         backgrd = 0;
         break;
       case 'c':
-        cliflags |= 8;
+        cliflags |= CLI_C;
         con_chan = 1;
         term_z = 0;
         break;
       case 't':
-        cliflags |= 4;
+        cliflags |= CLI_T;
         con_chan = 0;
         term_z = 1;
         break;
       case 'm':
-        cliflags |= 2;
+        cliflags |= CLI_M;
         make_userfile = 1;
         break;
       case 'v':
-        cliflags |= 129;		//128 + 1
+        cliflags |= (CLI_V | CLI_QUIT);
         break;
       case 'h':
-        cliflags |= 160;		//128 + 32
+        cliflags |= (CLI_H | CLI_QUIT);
         break;
       default:
-        cliflags |= 192;		//128 + 64
+        cliflags |= (CLI_BAD_FLAG | CLI_QUIT);
         break;
     }
   }
-  if ((cliflags & 64) || (cliflags & 32)) {
+  if ((cliflags & CLI_H) || (cliflags & CLI_BAD_FLAG)) {
     show_help();
     exit(0);
-  } else if (cliflags & 1) {
+  } else if (cliflags & CLI_V) {
     show_ver();
     exit(0);
-  } else if (!(cliflags & 16) && ((cliflags & 8) || (cliflags & 4))) {
+  } else if (!(cliflags & CLI_N) && ((cliflags & CLI_C) || (cliflags & CLI_T))) {
     printf("\n%s\n", version);
     printf("ERROR: The -n flag is required when using the -c or -t flags. Exiting...\n\n");
     exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -181,6 +181,10 @@ int ssl_cleanup();
  * strlcpy from freebsd /lib/libc/string/strlcpy.c
  * TODO: use system strlcpy if available and this code here as compat/fallback
  */
+#ifdef HAVE_STRLCPY
+#  include <string.h>
+#  define strncpyz strlcpy
+#else
 size_t strncpyz(char * __restrict dst, const char * __restrict src, size_t dsize)
 {
   const char *osrc = src;
@@ -204,6 +208,7 @@ size_t strncpyz(char * __restrict dst, const char * __restrict src, size_t dsize
 
   return(src - osrc - 1);	/* count does not include NUL */
 }
+#endif
 
 void fatal(const char *s, int recoverable)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -177,6 +177,34 @@ int cx_ptr = 0;
 int ssl_cleanup();
 #endif
 
+/* 
+ * strlcpy from freebsd /lib/libc/string/strlcpy.c
+ * TODO: use system strlcpy if available and this code here as compat/fallback
+ */
+size_t strncpyz(char * __restrict dst, const char * __restrict src, size_t dsize)
+{
+  const char *osrc = src;
+  size_t nleft = dsize;
+
+  /* Copy as many bytes as will fit. */
+  if (nleft != 0) {
+    while (--nleft != 0) {
+      if ((*dst++ = *src++) == '\0')
+        break;
+    }
+  }
+
+  /* Not enough room in dst, add NUL and traverse rest of src. */
+  if (nleft == 0) {
+    if (dsize != 0)
+      *dst = '\0';		/* NUL-terminate dst */
+    while (*src++)
+      ;
+  }
+
+  return(src - osrc - 1);	/* count does not include NUL */
+}
+
 void fatal(const char *s, int recoverable)
 {
   int i;

--- a/src/main.h
+++ b/src/main.h
@@ -129,14 +129,6 @@ extern struct dcc_table DCC_CHAT, DCC_BOT, DCC_LOST, DCC_SCRIPT, DCC_BOT_NEW,
           (x) = newsplit(&(x));                                         \
 } while (0)
 
-/* This macro copies (_len - 1) bytes from _source to _target. The
- * target string is NULL-terminated.
- */
-#define strncpyz(_target, _source, _len) do {                           \
-        strncpy((_target), (_source), (_len) - 1);                      \
-        (_target)[(_len) - 1] = 0;                                      \
-} while (0)
-
 #ifdef BORGCUBES
 #  define O_NONBLOCK 00000004 /* POSIX non-blocking I/O */
 #endif /* BORGCUBES */

--- a/src/misc.c
+++ b/src/misc.c
@@ -269,7 +269,6 @@ void remove_crlf(char **line)
       *p = 0;
       break;
     }
-    p++;
   }
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -571,7 +571,7 @@ void putlog EGG_VARARGS_DEF(int, arg1)
   }
   /* Place the timestamp in the string to be printed */
   if (out[0] && shtime) {
-    strncpy(s, stamp, tsl);
+    memcpy(s, stamp, tsl);
     out = s;
   }
   strcat(out, "\n");

--- a/src/misc.c
+++ b/src/misc.c
@@ -260,14 +260,17 @@ char *splitnick(char **blah)
 
 void remove_crlf(char **line)
 {
-  char *p;
+  char *p = *line;
 
-  p = strchr(*line, '\n');
-  if (p != NULL)
-    *p = 0;
-  p = strchr(*line, '\r');
-  if (p != NULL)
-    *p = 0;
+  for (;*p != '\0'; ++p)
+  {
+    if (*p == '\n' || *p == '\r')
+    {
+      *p = 0;
+      break;
+    }
+    p++;
+  }
 }
 
 char *newsplit(char **rest)

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1544,9 +1544,7 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
           strcpy(parcpy, par);
           irp = Tcl_CreateInterp();
           if (tcl_channel_modify(irp, chan, 2, list) == TCL_OK) {
-            char tocat[sizeof answers];
-            egg_snprintf(tocat, sizeof tocat, "%s { %s }", list[0], parcpy);
-            strncat(answers, tocat, sizeof answers - strlen(answers) - 1);
+            egg_snprintf(answers + strlen(answers), sizeof(answers) - strlen(answers), "%s { %s }", list[0], parcpy);
           } else if (!all || !chan->next)
             dprintf(idx, "Error trying to set %s for %s, %s\n",
                     list[0], all ? "all channels" : chname, Tcl_GetStringResult(irp));

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1528,7 +1528,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
         }
       } else {
         if ((*item[i]) && !strtol(item[i], &endptr, 10) && !(*endptr)) {
-          *pthr = 0;  // Shortcut for .chanset #chan flood-x 0 to activate 0:0
+          *pthr = 0; /* Shortcut for .chanset #chan flood-x 0 to activate 0:0 */
           *ptime = 0;
         } else {
           if (irp)

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -629,10 +629,8 @@ static void display_ban(int idx, int number, maskrec *ban,
     daysago(now, ban->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (ban->added < ban->lastactive) {
-      char tocat[sizeof dates];
       daysago(now, ban->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + strlen(dates), sizeof(dates) - strlen(dates), ", %s %s", MODES_LASTUSED, s);
     }
   } else
     dates[0] = 0;
@@ -674,10 +672,8 @@ static void display_exempt(int idx, int number, maskrec *exempt,
     daysago(now, exempt->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (exempt->added < exempt->lastactive) {
-      char tocat[sizeof dates];
       daysago(now, exempt->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + strlen(dates), sizeof(dates) - strlen(dates), ", %s %s", MODES_LASTUSED, s);
     }
   } else
     dates[0] = 0;
@@ -719,10 +715,8 @@ static void display_invite(int idx, int number, maskrec *invite,
     daysago(now, invite->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (invite->added < invite->lastactive) {
-      char tocat[sizeof dates];
       daysago(now, invite->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + strlen(dates), sizeof(dates) - strlen(dates), ", %s %s", MODES_LASTUSED, s);
     }
   } else
     dates[0] = 0;

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -157,7 +157,7 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
       return 1;
     }
 
-// * Check if SSL, IPv4, or IPv6 were requested
+/* Check if SSL, IPv4, or IPv6 were requested */
     if (
 #ifdef IPV6
     (!egg_strcasecmp(keyword, "CHAT6")) ||

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1053,7 +1053,7 @@ void parserespacket(u_8bit_t *response, int len)
           return;
         }
         ddebug1(RES_MSG "answered domain is CNAME for: %s", namestring);
-        strncpy(stackstring, namestring, 1024);
+        strncpyz(stackstring, namestring, sizeof(stackstring));
         break;
       default:
         ddebug2(RES_ERR "Received unimplemented data type: %u (%s)",

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -504,6 +504,7 @@
 #define tcl_resultint ((int (*)(void))global[300])
 #define tcl_resultstring ((const char *(*)(void))global[301])
 #define getdccfamilyaddr ((int (*) (sockname_t *, char *, socklen_t, int))global[302])
+#define strncpyz ((size_t (*) (char * __restrict, const char * __restrict, size_t))global[303])
 
 
 /* hostmasking */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -802,10 +802,9 @@ static void queue_server(int which, char *msg, int len)
   /* Remove \r\n. We will add these back when we send the text to the server.
    * - Wcc [01/09/2004]
    */
-  strncpy(buf, msg, sizeof buf);
+  strncpyz(buf, msg, sizeof buf);
   msg = buf;
   remove_crlf(&msg);
-  buf[510] = 0;
   len = strlen(buf);
 
   /* No queue for PING and PONG - drummer */

--- a/src/modules.c
+++ b/src/modules.c
@@ -607,7 +607,8 @@ Function global_table[] = {
   /* 300 - 303 */
   (Function) tcl_resultint,
   (Function) tcl_resultstring,
-  (Function) getdccfamilyaddr
+  (Function) getdccfamilyaddr,
+  (Function) strncpyz
 };
 
 void init_modules(void)

--- a/src/net.c
+++ b/src/net.c
@@ -531,9 +531,9 @@ int open_telnet_raw(int sock, sockname_t *addr)
       select(sock + 1, &sockset, NULL, NULL, &tv);
       res_len = sizeof(res);
       getsockopt(sock, SOL_SOCKET, SO_ERROR, &res, &res_len);
-      if (res == 115)
-        return sock;  // This could probably fail somewhere
-      if (res == 111) {
+      if (res == EINPROGRESS) /* Operation now in progress */
+        return sock; /* This could probably fail somewhere */
+      if (res == ECONNREFUSED) { /* Connection refused */
         debug1("net: attempted socket connection refused: %s", iptostr(&addr->addr.sa));
         return -4;
       }

--- a/src/proto.h
+++ b/src/proto.h
@@ -181,7 +181,12 @@ int del_lang_section(char *);
 int exist_lang_section(char *);
 
 /* main.c */
+#ifdef HAVE_STRLCPY
+#  include <string.h>
+#  define strncpyz strlcpy
+#else
 size_t strncpyz(char * __restrict, const char * __restrict, size_t);
+#endif
 void fatal(const char *, int);
 int expected_memory(void);
 void eggContext(const char *, int, const char *);

--- a/src/proto.h
+++ b/src/proto.h
@@ -181,6 +181,7 @@ int del_lang_section(char *);
 int exist_lang_section(char *);
 
 /* main.c */
+size_t strncpyz(char * __restrict, const char * __restrict, size_t);
 void fatal(const char *, int);
 int expected_memory(void);
 void eggContext(const char *, int, const char *);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: be portable and c89 and posix 2001

One-line summary:
be portable and c89 and posix 2001

Additional description (if needed):
be portable means, operating system dependency in net.c in open_telnet_raw() was fixed.
readability for getopt cli flags was fixed
strncpyz macro was replaced with strlcpy (this fixes -Wno-stringop-truncation and/or -Wno-stringop-overflow and using strncpy is mostly misuse, it doesnt equal strlcpy, also zero fills a buffer and was never intended as a safer version of strcpy. sometimes memcpy is a better solution)

Test cases demonstrating functionality (if applicable):
Configured with: 'CFLAGS=-std=c89 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=500 -D_DEFAULT_SOURCE -Wno-format-overflow'

with those CFLAGS make doesn't throw any error or warning

which means, after this patch, eggdrop is pretty c89 and posix 2001

there could be more c86 issues not uncovered by now, maybe even more variable definitions outside function header, and i shall track them down also.

with additional -O2 CFLAG 7 stringop-truncation warnings occured and were fixed with commits:
  https://github.com/eggheads/eggdrop/pull/549/commits/2e534849c68d00c80383afebc644d3033b9f0cc1
  https://github.com/eggheads/eggdrop/pull/549/commits/c9f655bbefec2d29e352fe2d123359dad8cf3388
  https://github.com/eggheads/eggdrop/pull/549/commits/c7430b6b66467af881ad416315915a452e425517
  https://github.com/eggheads/eggdrop/pull/549/commits/dc70597a398baa78b9a4ba1f9d8a3adf8b977b06

eggdrop was tested and connected and joined some channel
https://github.com/eggheads/eggdrop/pull/549/commits/c7430b6b66467af881ad416315915a452e425517 was tested for bans and .tcl need-op:
  .bans must yield a string like Created 22:34, last used 22:45 correctly
  .chanset #c89 need-op test
  Successfully set modes { need-op { test } } on #c89.
strlcpy was testet w/o on linux and w/ on freebsd