### PR TITLE
Force no TLS on plaintext botlinks with -<port>

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1605,10 +1605,10 @@ setdccaway <idx> <message>
   Module: core
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
-connect <host> <[+]port>
+connect <host> <[+|-]port>
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: makes an outgoing connection attempt and creates a dcc entry for it. A 'control' command should be used immediately after a successful 'connect' so no input is lost. If the port is prefixed with a plus sign, SSL encrypted connection will be attempted.
+  Description: makes an outgoing connection attempt and creates a dcc entry for it. A 'control' command should be used immediately after a successful 'connect' so no input is lost. If the port is prefixed with a plus sign, SSL encrypted connection will be attempted, when prefixed with a minus sign, secure connections are disallowed.
 
   Returns: idx of the new connection
 
@@ -1618,7 +1618,7 @@ connect <host> <[+]port>
 listen <port> <type> [options] [flag]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: opens a listening port to accept incoming telnets; type must be one of "bots", "all", "users", "script", or "off". Prefixing the port with a plus sign will make eggdrop accept SSL connections on it.
+  Description: opens a listening port to accept incoming telnets; type must be one of "bots", "all", "users", "script", or "off". Prefixing the port with a plus sign will make eggdrop accept SSL connections on it, prefixing with a minus sign will disallow secure connections.
 
     listen <port> bots [mask]
 

--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -70,7 +70,8 @@ plain text connections from being allowed), prefix the listen port in the
 hub configuration file with a plus (+) sign. Conversely, to force a leaf 
 to only allow SSL (not plain text) connections with a hub, you must 
 prefix the hub's listen port with a plus when adding it to the leaf via 
-+bot/chaddr commands. The nickname and password are sent before SSL 
++bot/chaddr commands. To force not using TLS, prefix the ports on the leafs
+with a minus (-) sign instead. The nickname and password are sent before SSL 
 negotiation takes place (the password is not sent in plain text anyway).
 If SSL negotiation fails and either the hub or leaf is set to require SSL,
 the connection is deliberately aborted and no clear text is ever sent.

--- a/help/cmds1.help
+++ b/help/cmds1.help
@@ -1,10 +1,11 @@
 %{help=+bot}%{+t}
-###  %b+bot%b <handle> [address [[+]bot port[/[+]user port]]] [host]
+###  %b+bot%b <handle> [address [[+|-]bot port[/[+|-]user port]]] [host]
    Creates a user record for a new bot with the handle given. If no hostmask
    is specified, the bot will try to automatically add a host from the channel.
    The bot's address will be used in linking. If the bot has a separate port
    for bots and users they should be separated with a slash (/). Prefixing
-   the port with a plus sign will only allow secure (SSL) linking to be used.
+   the port with a plus sign will only allow secure (SSL) linking to be used,
+   prefixing with a minus sign will disallow secure linking to be used.
 
 See also: -bot
 %{help=+host}%{+t|m}
@@ -152,11 +153,12 @@ See also: bottree, vbottree, botinfo
 
 See also: bots, botinfo, vbottree
 %{help=chaddr}%{+t}
-###  %bchaddr%b <bot> <address> [[+]bot port[/[+]user port]]
+###  %bchaddr%b <bot> <address> [[+|-]bot port[/[+|-]user port]]
    Changes the address for a bot. This is the address your bot will try to
    connect to when linking. If the bot has a separate port for bots and users,
    they should be separated  by a slash (/). Prefixing the port with a plus
-   sign will only allow secure (SSL) linking to be used.
+   sign will only allow secure (SSL) linking to be used, prefixing with a minus
+   sign will disallow secure linking to be used.
 
 See also: link, +bot
 %{help=chat}%{-}

--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -1482,8 +1482,8 @@ static void bot_versions(int sock, char *par)
 static void bot_starttls(int idx, char *par)
 {
   char *con;
-  /* We're already using ssl, ignore the request */
-  if (dcc[idx].ssl)
+  /* We're already using ssl or rejecting it, ignore the request */
+  if (dcc[idx].ssl & (DCC_TLS_USE | DCC_TLS_REJ))
     return;
 
   con = newsplit(&par);
@@ -1497,7 +1497,7 @@ static void bot_starttls(int idx, char *par)
     ssl_handshake(dcc[idx].sock, TLS_CONNECT, tls_vfybots, LOG_BOTS,
                   dcc[idx].host, NULL);
   }
-  dcc[idx].ssl = 1;
+  dcc[idx].ssl = DCC_TLS_USE;
 }
 #endif
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1024,25 +1024,33 @@ int botlink(char *linker, int idx, char *nick)
     } else {
       correct_handle(nick);
 
-      if (idx > -2)
+      if (idx > -2) {
 #ifdef IPV6
-      {
         if (strchr(bi->address, ':'))
+#  ifdef TLS
+          putlog(LOG_BOTS, "*", "%s %s at [%s]:%s%d ...", BOT_LINKING, nick,
+                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : "")),
+                 bi->telnet_port);
+#  else
           putlog(LOG_BOTS, "*", "%s %s at [%s]:%d ...", BOT_LINKING, nick,
                  bi->address, bi->telnet_port);
+#  endif
         else
+#endif
+#ifdef TLS
+          putlog(LOG_BOTS, "*", "%s %s at %s:%s%d ...", BOT_LINKING, nick,
+                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : "")),
+                 bi->telnet_port);
+#else
           putlog(LOG_BOTS, "*", "%s %s at %s:%d ...", BOT_LINKING, nick,
                  bi->address, bi->telnet_port);
-      }
-#else
-        putlog(LOG_BOTS, "*", "%s %s at %s:%d ...", BOT_LINKING, nick,
-               bi->address, bi->telnet_port);
 #endif
+      }
       i = new_dcc(&DCC_DNSWAIT, sizeof(struct dns_info));
       dcc[i].timeval = now;
       dcc[i].port = bi->telnet_port;
 #ifdef TLS
-      dcc[i].ssl = (bi->ssl & TLS_BOT);
+      dcc[i].ssl = (bi->ssl & (TLS_BOT | TLS_BOT_REJ));
 #endif
       dcc[i].user = u;
       strcpy(dcc[i].nick, nick);
@@ -1189,7 +1197,7 @@ void tandem_relay(int idx, char *nick, int i)
 
   dcc[i].port = bi->relay_port;
 #ifdef TLS
-  dcc[i].ssl = (bi->ssl & TLS_RELAY);
+  dcc[i].ssl = (bi->ssl & (TLS_RELAY | TLS_RELAY_REJ));
 #endif
   dcc[i].addr = 0L;
   strcpy(dcc[i].nick, nick);
@@ -1197,12 +1205,24 @@ void tandem_relay(int idx, char *nick, int i)
   strcpy(dcc[i].host, bi->address);
 #ifdef IPV6
   if (strchr(bi->address, ':'))
+#  ifdef TLS
+    dprintf(idx, "%s %s @ [%s]:%s%d ...\n", BOT_CONNECTINGTO, nick,
+            bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : "")),
+            bi->relay_port);
+#  else
     dprintf(idx, "%s %s @ [%s]:%d ...\n", BOT_CONNECTINGTO, nick,
             bi->address, bi->relay_port);
+#  endif
   else
 #endif
+#ifdef TLS
+  dprintf(idx, "%s %s @ %s:%s%d ...\n", BOT_CONNECTINGTO, nick,
+          bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : "")),
+          bi->relay_port);
+#else
   dprintf(idx, "%s %s @ %s:%d ...\n", BOT_CONNECTINGTO, nick,
           bi->address, bi->relay_port);
+#endif
   dprintf(idx, "%s\n", BOT_BYEINFO1);
   dcc[idx].type = &DCC_PRE_RELAY;
   ci = dcc[idx].u.chat;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1029,7 +1029,7 @@ int botlink(char *linker, int idx, char *nick)
         if (strchr(bi->address, ':'))
 #  ifdef TLS
           putlog(LOG_BOTS, "*", "%s %s at [%s]:%s%d ...", BOT_LINKING, nick,
-                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : "")),
+                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : ""),
                  bi->telnet_port);
 #  else
           putlog(LOG_BOTS, "*", "%s %s at [%s]:%d ...", BOT_LINKING, nick,
@@ -1039,7 +1039,7 @@ int botlink(char *linker, int idx, char *nick)
 #endif
 #ifdef TLS
           putlog(LOG_BOTS, "*", "%s %s at %s:%s%d ...", BOT_LINKING, nick,
-                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : "")),
+                 bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : ""),
                  bi->telnet_port);
 #else
           putlog(LOG_BOTS, "*", "%s %s at %s:%d ...", BOT_LINKING, nick,
@@ -1050,7 +1050,7 @@ int botlink(char *linker, int idx, char *nick)
       dcc[i].timeval = now;
       dcc[i].port = bi->telnet_port;
 #ifdef TLS
-      dcc[i].ssl = (bi->ssl & (TLS_BOT | TLS_BOT_REJ));
+      dcc[i].ssl = (bi->ssl & TLS_BOT) ? DCC_TLS_USE : ((bi->ssl & TLS_BOT_REJ) ? DCC_TLS_REJ : 0);
 #endif
       dcc[i].user = u;
       strcpy(dcc[i].nick, nick);
@@ -1103,8 +1103,8 @@ static void botlink_resolve_success(int i)
   if (ret < 0)
     failed_link(i);
 #ifdef TLS
-  else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
-           tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
+  else if ((dcc[i].ssl & DCC_TLS_USE) && ssl_handshake(dcc[i].sock,
+           TLS_CONNECT, tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
     failed_link(i);
 #endif
 }
@@ -1147,8 +1147,8 @@ static void failed_tandem_relay(int idx)
       open_telnet_raw(dcc[idx].sock, &dcc[idx].sockname) < 0)
     failed_tandem_relay(idx);
 #ifdef TLS
-  else if (dcc[idx].ssl && ssl_handshake(dcc[idx].sock, TLS_CONNECT,
-           tls_vfybots, LOG_BOTS, dcc[idx].host, NULL))
+  else if ((dcc[idx].ssl & DCC_TLS_USE) && ssl_handshake(dcc[idx].sock,
+           TLS_CONNECT, tls_vfybots, LOG_BOTS, dcc[idx].host, NULL))
     failed_tandem_relay(idx);
 #endif
 }
@@ -1197,7 +1197,7 @@ void tandem_relay(int idx, char *nick, int i)
 
   dcc[i].port = bi->relay_port;
 #ifdef TLS
-  dcc[i].ssl = (bi->ssl & (TLS_RELAY | TLS_RELAY_REJ));
+  dcc[i].ssl = (bi->ssl & TLS_RELAY) ? DCC_TLS_USE : ((bi->ssl & TLS_RELAY_REJ) ? DCC_TLS_REJ : 0);
 #endif
   dcc[i].addr = 0L;
   strcpy(dcc[i].nick, nick);
@@ -1207,7 +1207,7 @@ void tandem_relay(int idx, char *nick, int i)
   if (strchr(bi->address, ':'))
 #  ifdef TLS
     dprintf(idx, "%s %s @ [%s]:%s%d ...\n", BOT_CONNECTINGTO, nick,
-            bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : "")),
+            bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : ""),
             bi->relay_port);
 #  else
     dprintf(idx, "%s %s @ [%s]:%d ...\n", BOT_CONNECTINGTO, nick,
@@ -1217,7 +1217,7 @@ void tandem_relay(int idx, char *nick, int i)
 #endif
 #ifdef TLS
   dprintf(idx, "%s %s @ %s:%s%d ...\n", BOT_CONNECTINGTO, nick,
-          bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : "")),
+          bi->address, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : ""),
           bi->relay_port);
 #else
   dprintf(idx, "%s %s @ %s:%d ...\n", BOT_CONNECTINGTO, nick,
@@ -1298,7 +1298,7 @@ static void tandem_relay_resolve_success(int i)
   if (open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0)
     failed_tandem_relay(i);
 #ifdef TLS
-  else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
+  else if ((dcc[i].ssl & DCC_TLS_USE) && ssl_handshake(dcc[i].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
     failed_tandem_relay(i);
 #endif

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1089,7 +1089,7 @@ static void cmd_fprint(struct userrec *u, int idx, char *par)
   }
   new = newsplit(&par);
   if (!strcmp(new, "+")) {
-    if (!dcc[idx].ssl) {
+    if (!(dcc[idx].ssl & DCC_TLS_USE)) {
       dprintf(idx, "You aren't connected with SSL. "
               "Please set your fingerprint manually.\n");
       return;

--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -427,7 +427,8 @@ void tell_dcc(int zidx)
     }
       dprintf(zidx, format, dcc[i].sock, iptostr(&dcc[i].sockname.addr.sa),
 #ifdef TLS
-              dcc[i].ssl ? '+' : ' ', dcc[i].port, dcc[i].nick, other);
+              (dcc[i].ssl & DCC_TLS_USE) ? '+' : ((dcc[i].ssl & DCC_TLS_REJ) ? '-' : ' '),
+              dcc[i].port, dcc[i].nick, other);
 #else
               ' ', dcc[i].port, dcc[i].nick, other);
 #endif

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -383,6 +383,8 @@ struct dcc_t {
   unsigned int port;
 #ifdef TLS
   int ssl;
+#  define DCC_TLS_USE 1
+#  define DCC_TLS_REJ 2
 #endif
   struct userrec *user;
   char nick[NICKLEN];

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -181,7 +181,8 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
     for (i = 0; i < dcc_total; i++) {
       if ((dcc[i].type->flags & DCT_LISTEN) &&
 #ifdef TLS
-          (ssl == dcc[i].ssl) &&
+          ((ssl && dcc[i].ssl & DCC_TLS_USE) ||
+           (!ssl && dcc[i].ssl & DCC_TLS_REJ)) &&
 #endif
           (!strcmp(dcc[i].nick, "(telnet)") ||
            !strcmp(dcc[i].nick, "(users)")) &&

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -805,7 +805,7 @@ static void filesys_dcc_send_hostresolved(int i)
       open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0)
         dcc[i].type->eof(i);
 #ifdef TLS
-      else if (dcc[i].ssl & DCC_TLS_USE && ssl_handshake(dcc[i].sock,
+      else if ((dcc[i].ssl & DCC_TLS_USE) && ssl_handshake(dcc[i].sock,
                TLS_CONNECT, tls_vfydcc, LOG_FILES, dcc[i].host, NULL))
         dcc[i].type->eof(i);
 #endif

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -682,7 +682,7 @@ static void filesys_dcc_send(char *nick, char *from, struct userrec *u,
       dcc[i].u.dns->ip = &dcc[i].sockname;
       dcc[i].sock = -1;
 #ifdef TLS
-      dcc[i].ssl = ssl;
+      dcc[i].ssl = ssl ? DCC_TLS_USE : 0;
 #endif
       dcc[i].user = u;
       strlcpy(dcc[i].nick, nick, sizeof dcc[i].nick);
@@ -805,8 +805,8 @@ static void filesys_dcc_send_hostresolved(int i)
       open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0)
         dcc[i].type->eof(i);
 #ifdef TLS
-      else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT, tls_vfydcc,
-                                           LOG_FILES, dcc[i].host, NULL))
+      else if (dcc[i].ssl & DCC_TLS_USE && ssl_handshake(dcc[i].sock,
+               TLS_CONNECT, tls_vfydcc, LOG_FILES, dcc[i].host, NULL))
         dcc[i].type->eof(i);
 #endif
     }

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1305,7 +1305,7 @@ static void server_resolve_success(int servidx)
     return;
   }
 #ifdef TLS
-  if (dcc[servidx].ssl && ssl_handshake(serv, TLS_CONNECT, tls_vfyserver,
+  if (dcc[servidx].ssl & DCC_TLS_USE && ssl_handshake(serv, TLS_CONNECT, tls_vfyserver,
                                         LOG_SERV, dcc[servidx].host, NULL)) {
     putlog(LOG_SERV, "*", "%s %s (%s)", IRC_FAILEDCONNECT, dcc[servidx].host,
            "TLS negotiation failure");

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -2032,8 +2032,8 @@ static void start_sending_users(int idx)
           if (bi) {
 #ifdef TLS
             egg_snprintf(s2, sizeof s2, "s c BOTADDR %s %s %s%d %s%d\n",
-                         u->handle, bi->address, (bi->ssl & TLS_BOT) ? "+" : "",
-                         bi->telnet_port, (bi->ssl & TLS_RELAY) ? "+" : "",
+                         u->handle, bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : ""),
+                         bi->telnet_port, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : ""),
                          bi->relay_port);
 #else
             egg_snprintf(s2, sizeof s2, "s c BOTADDR %s %s %d %d\n", u->handle,

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1219,7 +1219,7 @@ static void share_ufsend(int idx, char *par)
       dcc[i].sock = sock;
 #ifdef TLS
       if (*port == '+')
-        dcc[i].ssl = 1;
+        dcc[i].ssl = DCC_TLS_USE;
 #endif
       strcpy(dcc[i].host, dcc[idx].nick);
 
@@ -2003,8 +2003,8 @@ static void start_sending_users(int idx)
     strcpy(dcc[i].host, dcc[idx].nick); /* Store bot's nick */
     getdccaddr(&dcc[i].sockname, s, sizeof s);
 #ifdef TLS
-    if (dcc[idx].ssl) {
-      dcc[i].ssl = 1;
+    if (dcc[idx].ssl & DCC_TLS_USE) {
+      dcc[i].ssl = DCC_TLS_USE;
       dprintf(idx, "s us %s +%d %lu\n", s, dcc[i].port, dcc[i].u.xfer->length);
     } else
 #endif

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -2031,10 +2031,11 @@ static void start_sending_users(int idx)
           /* Send address */
           if (bi) {
 #ifdef TLS
-            egg_snprintf(s2, sizeof s2, "s c BOTADDR %s %s %s%d %s%d\n",
-                         u->handle, bi->address, (bi->ssl & TLS_BOT) ? "+" : ((bi->ssl & TLS_BOT_REJ) ? "-" : ""),
-                         bi->telnet_port, (bi->ssl & TLS_RELAY) ? "+" : ((bi->ssl & TLS_RELAY_REJ) ? "-" : ""),
-                         bi->relay_port);
+            egg_snprintf(s2, sizeof s2, "s c BOTADDR %s %s %s%d%s %s%d%s\n",
+                         u->handle, bi->address, (bi->ssl & TLS_BOT) ? "+" : "",
+                         bi->telnet_port, (bi->ssl & TLS_BOT_REJ) ? "-" : "",
+                         (bi->ssl & TLS_RELAY) ? "+" : "", bi->relay_port,
+                         (bi->ssl & TLS_RELAY_REJ) ? "-" : "");
 #else
             egg_snprintf(s2, sizeof s2, "s c BOTADDR %s %s %d %d\n", u->handle,
                          bi->address, bi->telnet_port, bi->relay_port);

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -875,7 +875,7 @@ static void dcc_get_pending(int idx, char *buf, int len)
   i = answer(dcc[idx].sock, &dcc[idx].sockname, &port, 1);
   killsock(dcc[idx].sock);
 #ifdef TLS
-  if (dcc[idx].ssl && ssl_handshake(i, TLS_LISTEN, tls_vfydcc,
+  if (dcc[idx].ssl & DCC_TLS_USE && ssl_handshake(i, TLS_LISTEN, tls_vfydcc,
                                     LOG_FILES, dcc[idx].host, NULL)) {
     putlog(LOG_FILES, "*", "DCC failed SSL handshake: GET %s (%s!%s)",
            dcc[idx].u.xfer->origname, dcc[idx].nick, dcc[idx].host);

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -875,7 +875,7 @@ static void dcc_get_pending(int idx, char *buf, int len)
   i = answer(dcc[idx].sock, &dcc[idx].sockname, &port, 1);
   killsock(dcc[idx].sock);
 #ifdef TLS
-  if (dcc[idx].ssl & DCC_TLS_USE && ssl_handshake(i, TLS_LISTEN, tls_vfydcc,
+  if ((dcc[idx].ssl & DCC_TLS_USE) && ssl_handshake(i, TLS_LISTEN, tls_vfydcc,
                                     LOG_FILES, dcc[idx].host, NULL)) {
     putlog(LOG_FILES, "*", "DCC failed SSL handshake: GET %s (%s!%s)",
            dcc[idx].u.xfer->origname, dcc[idx].nick, dcc[idx].host);

--- a/src/proto.h
+++ b/src/proto.h
@@ -119,7 +119,7 @@ float getcputime();
 /* cmds.c */
 int check_dcc_attrs(struct userrec *, int);
 int check_dcc_chanattrs(struct userrec *, char *, int, int);
-int check_int_range(char *value, int min, int max);
+int strtoport(char *value);
 int stripmodes(char *);
 char *stripmasktype(int);
 

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -892,7 +892,7 @@ static int tcl_connect STDVAR
     Tcl_AppendResult(irp, "Could not allocate socket.", NULL);
     return TCL_ERROR;
   }
-  sock = open_telnet(i, argv[1], atoi(argv[2]));
+  sock = open_telnet(i, argv[1], abs(atoi(argv[2])));
   if (sock < 0) {
     switch (sock) {
       case -3:
@@ -942,7 +942,7 @@ static int tcl_listen STDVAR
 
   BADARGS(3, 5, " port type ?mask?/?proc ?flag??");
 
-  port = realport = atoi(argv[1]);
+  port = realport = abs(atoi(argv[1]));
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next)
     if (pmap->realport == port) {
       port = pmap->mappedto;

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -916,7 +916,9 @@ static int tcl_connect STDVAR
       Tcl_AppendResult(irp, s, NULL);
       return TCL_ERROR;
     } else
-      dcc[i].ssl = 1;
+      dcc[i].ssl = DCC_TLS_USE;
+  } else if (*argv[2] == '-') {
+      dcc[i].ssl = DCC_TLS_REJ;
   }
 #endif
   strcpy(dcc[i].nick, "*");
@@ -1005,7 +1007,9 @@ static int tcl_listen STDVAR
   }
 #ifdef TLS
   if (*argv[1] == '+')
-    dcc[idx].ssl = 1;
+    dcc[idx].ssl = DCC_TLS_USE;
+  else if (*argv[1] == '-')
+    dcc[idx].ssl = DCC_TLS_REJ;
   else
     dcc[idx].ssl = 0;
 #endif

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -300,7 +300,7 @@ static int tcl_addbot STDVAR
   struct bot_addr *bi;
   /* Max addr len is 60 ? (see cmd_pls_bot in cmds.c) + brackets + delims + ports + 0 */
   char *p, *q, addr[75], hand[HANDLEN + 1];
-  int i, colon=0, braced = 0, ipv6 = 0, count = 0;
+  int i, tport, rport, colon=0, braced = 0, ipv6 = 0, count = 0;
 
 
   BADARGS(3, 5, " handle address ?telnet-port ?relay-port??");
@@ -382,12 +382,12 @@ static int tcl_addbot STDVAR
 
 #endif
     /* Verify */
-    /* check_int_range returns 0 if q or p is NULL */
-    if (q && (!check_int_range(q, -65536, 0) || !check_int_range(q, 0, 65536))) {
+    /* strtoport returns 0 if q or p is NULL */
+    if (q && !(tport = strtoport(q))) {
       Tcl_AppendResult(irp, "0", NULL);
       return TCL_OK;
     }
-    if (p && (!check_int_range(p, -65536, 0) || !check_int_range(p, 0, 65536))) {
+    if (p && !(rport = strtoport(p))) {
       Tcl_AppendResult(irp, "0", NULL);
       return TCL_OK;
     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -826,7 +826,7 @@ static int tcl_istls STDVAR
     Tcl_AppendResult(irp, "invalid idx", NULL);
     return TCL_ERROR;
   }
-  if (dcc[j].ssl)
+  if (dcc[j].ssl & DCC_TLS_USE)
     Tcl_AppendResult(irp, "1", NULL);
   else
     Tcl_AppendResult(irp, "0", NULL);
@@ -848,7 +848,7 @@ static int tcl_starttls STDVAR
     Tcl_AppendResult(irp, "invalid idx", NULL);
     return TCL_ERROR;
   }
-  if (dcc[j].ssl) {
+  if (dcc[j].ssl & DCC_TLS_USE) {
     Tcl_AppendResult(irp, "already started", NULL);
     return TCL_ERROR;
   }
@@ -888,7 +888,7 @@ static int tcl_tlsstatus STDVAR
     return TCL_ERROR;
   }
   j = findsock(dcc[i].sock);
-  if (!j || !dcc[i].ssl || !td->socklist[j].ssl) {
+  if (!j || !(dcc[i].ssl & DCC_TLS_USE) || !td->socklist[j].ssl) {
     Tcl_AppendResult(irp, "not a TLS connection", NULL);
     return TCL_ERROR;
   }

--- a/src/users.h
+++ b/src/users.h
@@ -86,6 +86,8 @@ struct bot_addr {
 #ifdef TLS
 #  define TLS_BOT 1
 #  define TLS_RELAY 2
+#  define TLS_BOT_REJ 4
+#  define TLS_RELAY_REJ 8
   int ssl;
 #endif
 };


### PR DESCRIPTION
Found by: simple, maimizuno, ...
Patch by: Cizzle
Fixes: #535 

One-line summary: Adds functionality to add "-" before a port in a botaddr, which forces keeping the link plaintext instead of trying STARTTLS.

Test cases demonstrating functionality (if applicable):
 - Add a plain listen port first on the hub.
 - Enable console modes +gh on slave and hub
 - Add a bot or change a bot's botaddr to use the plain port, once with and once without "-".
 - The logmessages should show STARTTLS being sent by the hub on both occasions, but being ignored when using "-".
