### PR TITLE
rewrote replace_spaces(), to be O(n) instead of O(N**2)

### DIFF
--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -1008,11 +1008,11 @@ static int raw_dcc_resend_send(char *filename, char *nick, char *from,
   strcpy(dcc[i].host, "irc");
   dcc[i].u.xfer->filename = get_data_ptr(strlen(filename) + 1);
   strcpy(dcc[i].u.xfer->filename, filename);
-  replace_spaces(nfn);
-  dcc[i].u.xfer->origname = get_data_ptr(strlen(nfn) + 1);
-  strcpy(dcc[i].u.xfer->origname, nfn);
   strncpyz(dcc[i].u.xfer->from, from, NICKLEN);
   strncpyz(dcc[i].u.xfer->dir, filename, DIRLEN);
+  replace_spaces(nfn); /* modifying nfn modifies filename */
+  dcc[i].u.xfer->origname = get_data_ptr(strlen(nfn) + 1);
+  strcpy(dcc[i].u.xfer->origname, nfn);
   dcc[i].u.xfer->length = dccfilesize;
   dcc[i].timeval = now;
   dcc[i].u.xfer->f = f;

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -126,20 +126,15 @@ static int at_limit(char *nick)
   return (x >= dcc_limit);
 }
 
-/* Replaces all spaces with underscores (' ' -> '_').  The returned buffer
- * needs to be freed after use.
+/* Replaces all spaces with underscores (' ' -> '_').
  */
-static char *replace_spaces(char *fn)
+static void *replace_spaces(char *p)
 {
-  register char *ret, *p;
-
-  p = ret = nmalloc(strlen(fn) + 1);
-  strcpy(ret, fn);
-  while ((p = strchr(p, ' ')) != NULL)
-    *p = '_';
-  return ret;
+  for (; *p != '\0'; ++p) {
+    if (*p == ' ')
+      *p = '_';
+  }
 }
-
 
 static int builtin_sentrcvd STDVAR
 {
@@ -951,7 +946,7 @@ static int raw_dcc_resend_send(char *filename, char *nick, char *from,
                                int resend)
 {
   int zz, port, i;
-  char *nfn, *buf = NULL;
+  char *nfn = NULL;
   long dccfilesize;
   FILE *f;
 
@@ -1013,8 +1008,7 @@ static int raw_dcc_resend_send(char *filename, char *nick, char *from,
   strcpy(dcc[i].host, "irc");
   dcc[i].u.xfer->filename = get_data_ptr(strlen(filename) + 1);
   strcpy(dcc[i].u.xfer->filename, filename);
-  if (strchr(nfn, ' '))
-    nfn = buf = replace_spaces(nfn);
+  replace_spaces(nfn);
   dcc[i].u.xfer->origname = get_data_ptr(strlen(nfn) + 1);
   strcpy(dcc[i].u.xfer->origname, nfn);
   strncpyz(dcc[i].u.xfer->from, from, NICKLEN);
@@ -1037,9 +1031,6 @@ static int raw_dcc_resend_send(char *filename, char *nick, char *from,
              nick);
     }
   }
-
-  if (buf)
-    nfree(buf);
 
   return DCCSEND_OK;
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: fat

One-line summary:
replace_spaces() was O(N**2) and memory unfriendly

Additional description (if needed):
function replace_spaces() in transfer.c is used only once in transfer.c. so side effects of patching this function are somewhat limited. the function was O(N**2) while using strchr again and again from the start of string instead of the last occurrence. it was allocating, copying, freeing without need. this patch slims eggdrop.

Test cases demonstrating functionality (if applicable):
  created file "dccsend test.txt" in eggdrop directory
  bot:
    .tcl dccsend "dccsend test.txt" testuser
  irc client with nick=testuser:
    *** DCC SEND (dccsend_test.txt 12) request received from[...]