### PR TITLE
replace getdtablesize() and FD_SETSIZE with maxfd+1

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -99,9 +99,6 @@
 /* Define to 1 if you have the `fsync' function. */
 #undef HAVE_FSYNC
 
-/* Define to 1 if you have the `getdtablesize' function. */
-#undef HAVE_GETDTABLESIZE
-
 /* Define to 1 if you have the `gethostbyname2' function. */
 #undef HAVE_GETHOSTBYNAME2
 

--- a/configure
+++ b/configure
@@ -6919,7 +6919,7 @@ ac_config_commands="$ac_config_commands $ac_stdint_h"
 
 
 # Checks for functions and their arguments.
-for ac_func in clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop
+for ac_func in clock dprintf fsync getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure
+++ b/configure
@@ -6919,7 +6919,7 @@ ac_config_commands="$ac_config_commands $ac_stdint_h"
 
 
 # Checks for functions and their arguments.
-for ac_func in clock dprintf fsync getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop
+for ac_func in clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ EGG_CHECK_SOCKLEN_T
 AX_CREATE_STDINT_H([eggint.h])
 
 # Checks for functions and their arguments.
-AC_CHECK_FUNCS([clock dprintf fsync getdtablesize getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop])
+AC_CHECK_FUNCS([clock dprintf fsync getrusage inet_aton isascii mbrlen memcpy memset random rand lrand48 rename setpgid sigaction sigemptyset snprintf strcasecmp strncasecmp uname vsnprintf inet_ntop])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_VPRINTF
 AC_FUNC_STRFTIME

--- a/src/proto.h
+++ b/src/proto.h
@@ -284,7 +284,6 @@ int getdccaddr(sockname_t *, char *, size_t);
 int getdccfamilyaddr(sockname_t *, char *, size_t, int);
 void tputs(int, char *, unsigned int);
 void dequeue_sockets();
-int preparefdset(fd_set *, sock_list *, int, int, int);
 int sockread(char *, int *, sock_list *, int, int);
 int sockgets(char *, int *);
 void tell_netdebug(int);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: getdtablesize

One-line summary:
unnecessary and unwanted getdtablesize() in mainloop

Additional description (if needed):
getdtablesize() is not rly posix 2001 so select() should be used with FD_SETSIZE or (better) a calculated maxfd. we could easily calculate maxfd where we FD_SET() but we don't need to to get the other benefits. less fat in src and less stress in mainloop. getdtablesize() -> prlimit64() was called every second. you can check the prlimit64() call (or a similar call) with strace(). right after that call the result of getdtablesize() was set to FD_SETSIZE  in case FD_SETSIZE was defined and lower.
meanwhile this fix calculates maxfd and uses select(max + 1, ...).

Test cases demonstrating functionality (if applicable):
started eggdrop, connected to server

this patch touches eggdrops networking core so i would like to see at least two LGTMs here.