### PR TITLE
fix operating system (linux) dependency, see http://www.ioplex.com/~m…

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -531,9 +531,9 @@ int open_telnet_raw(int sock, sockname_t *addr)
       select(sock + 1, &sockset, NULL, NULL, &tv);
       res_len = sizeof(res);
       getsockopt(sock, SOL_SOCKET, SO_ERROR, &res, &res_len);
-      if (res == 115)
-        return sock;  // This could probably fail somewhere
-      if (res == 111) {
+      if (res == EINPROGRESS) /* Operation now in progress */
+        return sock; /* This could probably fail somewhere */
+      if (res == ECONNREFUSED) { /* Connection refused */
         debug1("net: attempted socket connection refused: %s", iptostr(&addr->addr.sa));
         return -4;
       }


### PR DESCRIPTION
…iallen/errcmpp.html

Found by: michaelortmann
Patch by: michaelortmann
Fixes: operating system (linux) dependency

One-line summary:
fix operating system (linux) dependency, see http://www.ioplex.com/~miallen/errcmpp.html

Additional description (if needed):
doesnt fix #550, but #550 shows the importance of this fix, because the error message in #550 is currently only displayed under systems where ECONNREFUSED == 111 (linux and cygwin). other systems have other numbers, see http://www.ioplex.com/~miallen/errcmpp.html
i found and corrected this issue before in #549, but i thought now its better to seperate it here for a faster merge.

Test cases demonstrating functionality (if applicable):
compiled and startet eggdrop, but i didnt test the patched code path yet