### PR TITLE
Add + when using TLS for TELNET in Tcl dcclist.

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1433,7 +1433,7 @@ static void eof_dcc_telnet(int idx)
 
 static void display_telnet(int idx, char *buf)
 {
-  sprintf(buf, "lstn  %d%s", dcc[idx].port,
+  sprintf(buf, "lstn  %s%d%s", dcc[idx].ssl ? "+" : "", dcc[idx].port,
           (dcc[idx].status & LSTN_PUBLIC) ? " pub" : "");
 }
 


### PR DESCRIPTION
Found by: maimizuno
Patch by: maimizuno
Fixes: #555 

One-line summary: Adds a + when using a TLS TELNET listen port in the Tcl `dcclist` output.

Additional description (if needed): The `.dccstat` output is slightly altered aswell, the INFO column will now show this + as well.