### PR TITLE
fix #354 and fix #387 (fix order of binds)

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -2683,7 +2683,9 @@ as 'bind msg - stop msg:stop' (which makes a msg-command "stop" call the
 Tcl proc "msg:stop") will overwrite any previous binding you had for the
 msg command "stop". With stackable bindings, like 'msgm' for example,
 you can bind the same command to multiple procs. When the bind is triggered,
-ALL of the Tcl procs that are bound to it will be called.
+ALL of the Tcl procs that are bound to it will be called. Raw binds are
+triggered before builtin binds, as a builtin bind has the potential to
+modify args.
 
 To remove a bind, use the 'unbind' command. For example, to remove the
 bind for the "stop" msg command, use 'unbind msg - stop msg:stop'.

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -28,7 +28,7 @@
 static time_t last_ctcp = (time_t) 0L;
 static int count_ctcp = 0;
 static time_t last_invtime = (time_t) 0L;
-static char last_invchan[81] = "";
+static char last_invchan[300] = "";
 
 /* ID length for !channels.
  */
@@ -1498,15 +1498,11 @@ static int got475(char *from, char *msg)
 
 /* got invitation
  */
-static int gotinvite(const char *cfrom, const char *cmsg)
+static int gotinvite(char *from, char *msg)
 {
-  char *msg, *from, *nick, *key;
+  char *nick, *key;
   struct chanset_t *chan;
 
-  msg = nmalloc(strlen(cmsg) + 1);
-  memcpy(msg, cmsg, strlen(cmsg) + 1);
-  from = nmalloc(strlen(cfrom) + 1);
-  memcpy(from, cfrom, strlen(cfrom) + 1);
   newsplit(&msg);
   fixcolon(msg);
   nick = splitnick(&from);
@@ -1514,7 +1510,8 @@ static int gotinvite(const char *cfrom, const char *cmsg)
     if (now - last_invtime < 30)
       return 0; /* Two invites to the same channel in 30 seconds? */
   putlog(LOG_MISC, "*", "%s!%s invited me to %s", nick, from, msg);
-  strncpyz(last_invchan, msg, sizeof(last_invchan));
+  strncpy(last_invchan, msg, 299);
+  last_invchan[299] = 0;
   last_invtime = now;
   chan = findchan(msg);
   if (!chan)

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -28,7 +28,7 @@
 static time_t last_ctcp = (time_t) 0L;
 static int count_ctcp = 0;
 static time_t last_invtime = (time_t) 0L;
-static char last_invchan[300] = "";
+static char last_invchan[81] = "";
 
 /* ID length for !channels.
  */
@@ -1498,11 +1498,15 @@ static int got475(char *from, char *msg)
 
 /* got invitation
  */
-static int gotinvite(char *from, char *msg)
+static int gotinvite(const char *cfrom, const char *cmsg)
 {
-  char *nick, *key;
+  char *msg, *from, *nick, *key;
   struct chanset_t *chan;
 
+  msg = nmalloc(strlen(cmsg) + 1);
+  memcpy(msg, cmsg, strlen(cmsg) + 1);
+  from = nmalloc(strlen(cfrom) + 1);
+  memcpy(from, cfrom, strlen(cfrom) + 1);
   newsplit(&msg);
   fixcolon(msg);
   nick = splitnick(&from);
@@ -1510,8 +1514,7 @@ static int gotinvite(char *from, char *msg)
     if (now - last_invtime < 30)
       return 0; /* Two invites to the same channel in 30 seconds? */
   putlog(LOG_MISC, "*", "%s!%s invited me to %s", nick, from, msg);
-  strncpy(last_invchan, msg, 299);
-  last_invchan[299] = 0;
+  strncpyz(last_invchan, msg, sizeof(last_invchan));
   last_invtime = now;
   chan = findchan(msg);
   if (!chan)

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -907,8 +907,15 @@ int check_tcl_bind(tcl_bind_list_t *tl, const char *match,
   if (htc)
     htc->hits++;
 
-  /* Now that we have found at least one bind, we can update the
+  if (cnt > 1)
+    return BIND_AMBIGUOUS;
+
+  /* Now that we have found exactly one bind, we can update the
    * preferred entries information.
+   * Do this only for cnt == 1,
+   * since we don't want to change the order of raw binds vs. builtin binds.
+   * reason 1: order should be raw than builtin
+   * reason 2: builtin could modify args
    */
   if (tm_p && tm_p->next) {
     tm = tm_p->next;            /* Move mask to front of bind's mask list. */
@@ -916,9 +923,6 @@ int check_tcl_bind(tcl_bind_list_t *tl, const char *match,
     tm->next = tl->first;       /* Readd mask to front of list. */
     tl->first = tm;
   }
-
-  if (cnt > 1)
-    return BIND_AMBIGUOUS;
 
   return trigger_bind(proc, param, mask);
 }

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -914,7 +914,7 @@ int check_tcl_bind(tcl_bind_list_t *tl, const char *match,
    * preferred entries information.
    * Do this only for cnt == 1,
    * since we don't want to change the order of raw binds vs. builtin binds.
-   * reason 1: order should be raw than builtin
+   * reason 1: order should be raw then builtin
    * reason 2: builtin could modify args
    */
   if (tm_p && tm_p->next) {


### PR DESCRIPTION
Found by: jack3-again and maimizuno
Patch by: michaelortmann
Fixes: #354 and #387

One-line summary:
fix order of binds, which fixes modification/substitution/truncation of args between binds.

Additional description (if needed):
sometimes the raw bind is executed before the builtin invite. sometimes the other way around.
the builtin invite modifies the args in chan.c gotinvite() in the following 2 lines:
newsplit(&msg);
nick = splitnick(&from);
now i can confirm its the same as issue #387, but its not only newsplit() but also splitnick() and any other function modifying the parameters of the builtin functions. btw: we are able to reproduce the problem now again. see test cases below. the sequence "toggles" every time.
first i prepared a fix to copy "msg" and "from" before those modifying function calls.
but there were more builtins like this.
then it turned out its better to fix the order of binds.
the mysterious "toggle" was found. it is probably an optimization, moving last recently used binds to the front of the bind table.
this leads to toggling the order of execution every time the same binds are triggered.
now i pushed a new solution which keeps the builtin functions as is, keeps the optimization, but fixes the optimization, so that its only done, when there is exactly 1 bind for the trigger.
no more toggle, no more truncation/substitution and a happy maimizuno.

Test cases demonstrating functionality (if applicable):

testscript (modify #foo as you like):

bind raw - invite fix354
proc fix354 args {
    putquick "PRIVMSG #foo :raw invite triggered: [join $args ", "]" 
}
bind raw - mode fix387
proc fix387 args {
    putquick "PRIVMSG #foo :raw mode triggered: [join $args ", "]"
}

/invite botnick chan
/invite botnick chan
before: the 2nd invite leads to reversed bind order and args truncation, as shown in #354 
after: its fine now

/mode #foo +v botnick
/mode #foo +o botnick
before: the end mode change leads reversed bind order and args truncation, as shown in #387
after: its fine now