### PR TITLE
respect CFLAGS

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -41,7 +41,7 @@ linkstart:
 	touch mod/mod.xlibs
 
 link:
-	$(LD) -o ../$(EGGEXEC) $(eggdrop_objs) $(MODOBJS) $(XLIBS) md5/md5c.o compat/*.o `cat mod/mod.xlibs`
+	$(LD) $(CFLAGS) -o ../$(EGGEXEC) $(eggdrop_objs) $(MODOBJS) $(XLIBS) md5/md5c.o compat/*.o `cat mod/mod.xlibs`
 
 linkfinish:
 	@$(STRIP) ../$(EGGEXEC) && \

--- a/src/mod/assoc.mod/Makefile
+++ b/src/mod/assoc.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../assoc.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/assoc.c && mv -f assoc.o ../
 
 ../../../assoc.$(MOD_EXT): ../assoc.o
-	$(LD) -o ../../../assoc.$(MOD_EXT) ../assoc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../assoc.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../assoc.$(MOD_EXT) ../assoc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../assoc.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/assoc.c -MT ../assoc.o > .depend

--- a/src/mod/blowfish.mod/Makefile
+++ b/src/mod/blowfish.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../blowfish.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/blowfish.c && mv -f blowfish.o ../
 
 ../../../blowfish.$(MOD_EXT): ../blowfish.o
-	$(LD) -o ../../../blowfish.$(MOD_EXT) ../blowfish.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../blowfish.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../blowfish.$(MOD_EXT) ../blowfish.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../blowfish.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/blowfish.c -MT ../blowfish.o > .depend

--- a/src/mod/channels.mod/Makefile
+++ b/src/mod/channels.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../channels.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/channels.c && mv -f channels.o ../
 
 ../../../channels.$(MOD_EXT): ../channels.o
-	$(LD) -o ../../../channels.$(MOD_EXT) ../channels.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../channels.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../channels.$(MOD_EXT) ../channels.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../channels.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/channels.c -MT ../channels.o > .depend

--- a/src/mod/compress.mod/Makefile.in
+++ b/src/mod/compress.mod/Makefile.in
@@ -19,7 +19,7 @@ modules: ../../../compress.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/compress.c && mv -f compress.o ../
 
 ../../../compress.$(MOD_EXT): ../compress.o
-	$(LD) -o ../../../compress.$(MOD_EXT) ../compress.o $(ZLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../compress.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../compress.$(MOD_EXT) ../compress.o $(ZLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../compress.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/compress.c -MT ../compress.o > .depend

--- a/src/mod/console.mod/Makefile
+++ b/src/mod/console.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../console.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/console.c && mv -f console.o ../
 
 ../../../console.$(MOD_EXT): ../console.o
-	$(LD) -o ../../../console.$(MOD_EXT) ../console.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../console.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../console.$(MOD_EXT) ../console.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../console.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/console.c -MT ../console.o > .depend

--- a/src/mod/ctcp.mod/Makefile
+++ b/src/mod/ctcp.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../ctcp.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/ctcp.c && mv -f ctcp.o ../
 
 ../../../ctcp.$(MOD_EXT): ../ctcp.o
-	$(LD) -o ../../../ctcp.$(MOD_EXT) ../ctcp.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../ctcp.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../ctcp.$(MOD_EXT) ../ctcp.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../ctcp.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/ctcp.c -MT ../ctcp.o > .depend

--- a/src/mod/dns.mod/Makefile.in
+++ b/src/mod/dns.mod/Makefile.in
@@ -20,7 +20,7 @@ modules: ../../../dns.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(RESINCLUDE) -DMAKING_MODS -c $(srcdir)/dns.c && mv -f dns.o ../
 
 ../../../dns.$(MOD_EXT): ../dns.o
-	$(LD) -o ../../../dns.$(MOD_EXT) ../dns.o $(RESLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../dns.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../dns.$(MOD_EXT) ../dns.o $(RESLIB) $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../dns.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/dns.c -MT ../dns.o > .depend

--- a/src/mod/filesys.mod/Makefile
+++ b/src/mod/filesys.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../filesys.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/filesys.c && mv -f filesys.o ../
 
 ../../../filesys.$(MOD_EXT): ../filesys.o
-	$(LD) -o ../../../filesys.$(MOD_EXT) ../filesys.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../filesys.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../filesys.$(MOD_EXT) ../filesys.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../filesys.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/filesys.c -MT ../filesys.o > .depend

--- a/src/mod/irc.mod/Makefile
+++ b/src/mod/irc.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../irc.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c && mv -f irc.o ../
 
 ../../../irc.$(MOD_EXT): ../irc.o
-	$(LD) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../irc.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../irc.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/irc.c -MT ../irc.o > .depend

--- a/src/mod/notes.mod/Makefile
+++ b/src/mod/notes.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../notes.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/notes.c && mv -f notes.o ../
 
 ../../../notes.$(MOD_EXT): ../notes.o
-	$(LD) -o ../../../notes.$(MOD_EXT) ../notes.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../notes.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../notes.$(MOD_EXT) ../notes.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../notes.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/notes.c -MT ../notes.o > .depend

--- a/src/mod/seen.mod/Makefile
+++ b/src/mod/seen.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../seen.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/seen.c && mv -f seen.o ../
 
 ../../../seen.$(MOD_EXT): ../seen.o
-	$(LD) -o ../../../seen.$(MOD_EXT) ../seen.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../seen.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../seen.$(MOD_EXT) ../seen.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../seen.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/seen.c -MT ../seen.o > .depend

--- a/src/mod/server.mod/Makefile
+++ b/src/mod/server.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../server.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/server.c && mv -f server.o ../
 
 ../../../server.$(MOD_EXT): ../server.o
-	$(LD) -o ../../../server.$(MOD_EXT) ../server.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../server.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../server.$(MOD_EXT) ../server.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../server.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/server.c -MT ../server.o > .depend

--- a/src/mod/share.mod/Makefile
+++ b/src/mod/share.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../share.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/share.c && mv -f share.o ../
 
 ../../../share.$(MOD_EXT): ../share.o
-	$(LD) -o ../../../share.$(MOD_EXT) ../share.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../share.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../share.$(MOD_EXT) ../share.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../share.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/share.c -MT ../share.o > .depend

--- a/src/mod/transfer.mod/Makefile
+++ b/src/mod/transfer.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../transfer.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/transfer.c && mv -f transfer.o ../
 
 ../../../transfer.$(MOD_EXT): ../transfer.o
-	$(LD) -o ../../../transfer.$(MOD_EXT) ../transfer.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../transfer.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../transfer.$(MOD_EXT) ../transfer.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../transfer.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/transfer.c -MT ../transfer.o > .depend

--- a/src/mod/uptime.mod/Makefile
+++ b/src/mod/uptime.mod/Makefile
@@ -16,7 +16,7 @@ modules: ../../../uptime.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/uptime.c && mv -f uptime.o ../
 
 ../../../uptime.$(MOD_EXT): ../uptime.o
-	$(LD) -o ../../../uptime.$(MOD_EXT) ../uptime.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../uptime.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../uptime.$(MOD_EXT) ../uptime.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../uptime.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/uptime.c -MT ../uptime.o > .depend

--- a/src/mod/woobie.mod/Makefile
+++ b/src/mod/woobie.mod/Makefile
@@ -17,7 +17,7 @@ modules: ../../../woobie.$(MOD_EXT)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/woobie.c && mv -f woobie.o ../
 
 ../../../woobie.$(MOD_EXT): ../woobie.o
-	$(LD) -o ../../../woobie.$(MOD_EXT) ../woobie.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../woobie.$(MOD_EXT)
+	$(LD) $(CFLAGS) -o ../../../woobie.$(MOD_EXT) ../woobie.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../woobie.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/woobie.c -MT ../woobie.o > .depend


### PR DESCRIPTION
Found by: sbraz
Patch by: michaelortmann
Fixes: #526

One-line summary:
respect CFLAGS

Additional description (if needed):
i can reproduce a problem with CFLAGS, and i fixed it.
i cant say the same about LDFLAGS.
pls. review/merge this patch to fix CFLAGS.
if you want a look at LDFLAGS again, pls. write a test case / actual problem with LDFLAGS.

Test cases demonstrating functionality (if applicable):
test under linux, gnu make, gcc:

before:

test case 1:

> make distclean
> CFLAGS=-fsanitize=address ./configure && make config && make

gcc -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o  -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl  md5/md5c.o compat/*.o `cat mod/mod.xlibs`
/usr/bin/ld: bg.o: in function `bg_do_detach':
/home/michael/projects/eggdrop/src/bg.c:115: undefined reference to `__asan_handle_no_return'
[...]
make: *** [Makefile:248: debug] Error 2

test case 2:

> make distclean
> CFLAGS=-fsanitize=address ./configure && make config && make 2>&1 |grep gcc|grep -v sanitize 

'-DLDFLAGS="gcc"' \
gcc   -shared -o ../../../compress.so ../compress.o -lz -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../compress.so
gcc   -shared -o ../../../assoc.so ../assoc.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../assoc.so
gcc   -shared -o ../../../blowfish.so ../blowfish.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../blowfish.so
gcc   -shared -o ../../../ctcp.so ../ctcp.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../ctcp.so
gcc   -shared -o ../../../console.so ../console.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../console.so
gcc   -shared -o ../../../dns.so ../dns.o -lresolv -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../dns.so
gcc   -shared -o ../../../channels.so ../channels.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../channels.so
gcc   -shared -o ../../../notes.so ../notes.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../notes.so
gcc   -shared -o ../../../seen.so ../seen.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../seen.so
gcc   -shared -o ../../../filesys.so ../filesys.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../filesys.so
gcc   -shared -o ../../../server.so ../server.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../server.so
gcc   -shared -o ../../../irc.so ../irc.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../irc.so
gcc   -shared -o ../../../share.so ../share.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../share.so
gcc   -shared -o ../../../uptime.so ../uptime.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../uptime.so
gcc   -shared -o ../../../transfer.so ../transfer.o -L/usr/lib -ltcl8.6 -ldl -lz  -lpthread -lm -lcrypto -lssl -ldl -lnsl   && touch ../../../transfer.so

after:

test case 1:

no more error

test case 2:

CFLAGS respected