### PR TITLE
Fix adding botflag s for a channel

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -50,11 +50,11 @@ struct flag_record {
  *   unused letters: bcdefjkmnoqtuvwxyz
  *
  * chanflags:
- *   a??defg???klmno?qr???vw?yz + user defined A-Z
- *   unused letters: bchijpstuw
+ *   a??defg???klmno?qrs??vw?yz + user defined A-Z
+ *   unused letters: bchijptuw (s from bot flags)
  */
 #define USER_VALID 0x003fbfeff   /* Sum of all valid USER_ flags */
-#define CHAN_VALID 0x003637c79   /* Sum of all valid CHAN_ flags */
+#define CHAN_VALID 0x003677c79   /* Sum of all valid CHAN_ flags */
 #define BOT_VALID  0x07fe689C1   /* Sum of all valid BOT_  flags */
 
 


### PR DESCRIPTION
Found by: someone Geo knows
Patch by: Cizzle
Fixes: #525 

One-line summary: Adding the botflag s to a channel is now possible again

Test cases demonstrating functionality (if applicable):
 - Add bot: `.+bot bot host`
 - Add channel: `.+chan #channel`
 - Try adding botflag s for that channel: `.botattr bot +s #channel`
