### PR TITLE
Change output for logmodes ghtu to show b instead of m

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -350,9 +350,9 @@ static void dcc_bot_new(int idx, char *buf, int x)
 
   if (raw_log) {
     if (!strncmp(buf, "s ", 2))
-      putlog(LOG_BOTSHRIN, "*", "{m<-%s} %s", dcc[idx].nick, buf + 2);
+      putlog(LOG_BOTSHRIN, "*", "{b<-%s} %s", dcc[idx].nick, buf + 2);
     else
-      putlog(LOG_BOTNETIN, "*", "[m<-%s] %s", dcc[idx].nick, buf);
+      putlog(LOG_BOTNETIN, "*", "[b<-%s] %s", dcc[idx].nick, buf);
   }
 
   code = newsplit(&buf);
@@ -466,9 +466,9 @@ static void out_dcc_bot(int idx, char *buf, void *x)
     }
 
     if (!strncmp(p, "s ", 2))
-      putlog(LOG_BOTSHROUT, "*", "{m->%s} %s", dcc[idx].nick, p + 2);
+      putlog(LOG_BOTSHROUT, "*", "{b->%s} %s", dcc[idx].nick, p + 2);
     else
-      putlog(LOG_BOTNETOUT, "*", "[m->%s] %s", dcc[idx].nick, p);
+      putlog(LOG_BOTNETOUT, "*", "[b->%s] %s", dcc[idx].nick, p);
 
     if (fnd)
       nfree(fnd);
@@ -501,9 +501,9 @@ static void dcc_bot(int idx, char *code, int i)
 
   if (raw_log) {
     if (!strncmp(code, "s ", 2))
-      putlog(LOG_BOTSHRIN, "*", "{m<-%s} %s", dcc[idx].nick, code + 2);
+      putlog(LOG_BOTSHRIN, "*", "{b<-%s} %s", dcc[idx].nick, code + 2);
     else
-      putlog(LOG_BOTNETIN, "*", "[m<-%s] %s", dcc[idx].nick, code);
+      putlog(LOG_BOTNETIN, "*", "[b<-%s] %s", dcc[idx].nick, code);
   }
   msg = strchr(code, ' ');
   if (msg) {
@@ -642,9 +642,9 @@ static void dcc_chat_pass(int idx, char *buf, int atr)
   if (atr & USER_BOT) {
     if (raw_log) {
       if (!strncmp(buf, "s ", 2))
-        putlog(LOG_BOTSHRIN, "*", "{m<-%s} %s", dcc[idx].nick, buf + 2);
+        putlog(LOG_BOTSHRIN, "*", "{b<-%s} %s", dcc[idx].nick, buf + 2);
       else
-        putlog(LOG_BOTNETIN, "*", "[m<-%s] %s", dcc[idx].nick, buf);
+        putlog(LOG_BOTNETIN, "*", "[b<-%s] %s", dcc[idx].nick, buf);
     }
 #ifdef TLS
     if (!egg_strncasecmp(buf, "starttls ", 9)) {
@@ -1564,9 +1564,9 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
 
   if (glob_bot(fr) && raw_log) {
     if (!strncmp(buf, "s ", 2))
-      putlog(LOG_BOTSHRIN, "*", "{m<-%s} %s", dcc[idx].user->handle, buf + 2);
+      putlog(LOG_BOTSHRIN, "*", "{b<-%s} %s", dcc[idx].user->handle, buf + 2);
     else
-      putlog(LOG_BOTNETIN, "*", "[m<-%s] %s", dcc[idx].user->handle, buf);
+      putlog(LOG_BOTNETIN, "*", "[b<-%s] %s", dcc[idx].user->handle, buf);
   }
 #ifdef TLS
   if (dcc[idx].ssl && (tls_auth == 2)) {

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1410,7 +1410,7 @@ static void shareout_mod EGG_VARARGS_DEF(struct chanset_t *, arg1)
           get_user_flagrec(dcc[i].user, &fr, chan->dname);
         }
         if (!chan || bot_chan(fr) || bot_global(fr)) {
-          putlog(LOG_BOTSHROUT, "*", "{m->%s} %s", dcc[i].nick, s + 2);
+          putlog(LOG_BOTSHROUT, "*", "{b->%s} %s", dcc[i].nick, s + 2);
           tputs(dcc[i].sock, s, l + 2);
         }
       }
@@ -1444,7 +1444,7 @@ static void shareout_but EGG_VARARGS_DEF(struct chanset_t *, arg1)
         get_user_flagrec(dcc[i].user, &fr, chan->dname);
       }
       if (!chan || bot_chan(fr) || bot_global(fr)) {
-        putlog(LOG_BOTSHROUT, "*", "{m->%s} %s", dcc[i].nick, s + 2);
+        putlog(LOG_BOTSHROUT, "*", "{b->%s} %s", dcc[i].nick, s + 2);
         tputs(dcc[i].sock, s, l + 2);
       }
     }


### PR DESCRIPTION
Found by: maimizuno
Patch by: Cizzle
Fixes: #521 

One-line summary: Output for logmodes ghtu (botnet in and out and botnet share in and out) will now use a "b" instead of an "m".