### PR TITLE
get rid of less useful random() in mainloop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -816,15 +816,6 @@ int mainloop(int toplevel)
    * calls to periodic_timers
    */
   now = time(NULL);
-  /*
-   * FIXME: Get rid of this, it's ugly and wastes lots of cpu.
-   *
-   * pre-1.3.0 Eggdrop had random() in the once a second block below.
-   *
-   * This attempts to keep random() more random by constantly
-   * calling random() and updating the state information.
-   */
-  random();                /* Woop, lets really jumble things */
 
   /* If we want to restart, we have to unwind to the toplevel.
    * Tcl will Panic if we kill the interp with Tcl_Eval in progress.


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: FIXME

One-line summary:
fixes a FIXME, which is true, its a waste of cpu, doesnt help much, esp. now that we have a better seed in place and are sure this random() is used for trivia instead of crypto.

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
./eggdrop -ntm
[...]
.tcl rand 1000
Tcl: 398