### PR TITLE
delete register keyword, trust in good compiler optimization

### DIFF
--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -787,7 +787,7 @@ static void bot_trace(int idx, char *par)
  */
 static void bot_traced(int idx, char *par)
 {
-  char *to, *p;
+  char *to, *p, *c;
   int i, sock;
 
   to = newsplit(&par);
@@ -823,7 +823,7 @@ static void bot_traced(int idx, char *par)
           int j = 0;
 
           {
-            register char *c = p;
+            c = p;
 
             for (; *c != '\0'; c++)
               if (*c == ':')
@@ -1302,6 +1302,7 @@ static void bot_part(int idx, char *par)
   struct userrec *u;
   int sock, partyidx;
   int silent = 0;
+  int chan;
 
   if (bot_flags(dcc[idx].user) & BOT_ISOLATE)
     return;
@@ -1330,7 +1331,7 @@ static void bot_part(int idx, char *par)
     if (party[partyidx].chan >= 0)
       check_tcl_chpt(bot, nick, sock, party[partyidx].chan);
     if ((b_numver(idx) >= NEAT_BOTNET) && !silent) {
-      register int chan = party[partyidx].chan;
+      chan = party[partyidx].chan;
 
       if (par[0])
         chanout_but(-1, chan, "*** (%s) %s %s %s (%s).\n", bot, nick,

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -737,7 +737,7 @@ void tell_bottree(int idx, int showver)
  */
 void dump_links(int z)
 {
-  register int i, l;
+  int i, l;
   char x[1024];
   tand_t *bot;
 
@@ -876,7 +876,7 @@ int users_in_subtree(tand_t *bot)
 int botunlink(int idx, char *nick, char *reason, char *from)
 {
   char s[20];
-  register int i;
+  int i;
   int bots, users;
   tand_t *bot;
 
@@ -985,7 +985,7 @@ int botlink(char *linker, int idx, char *nick)
 {
   struct bot_addr *bi;
   struct userrec *u;
-  register int i;
+  int i;
 
   u = get_user_by_handle(userlist, nick);
   if (!u || !(u->flags & USER_BOT)) {
@@ -1151,7 +1151,7 @@ static void tandem_relay_resolve_success(int);
 
 /* Relay to another tandembot
  */
-void tandem_relay(int idx, char *nick, register int i)
+void tandem_relay(int idx, char *nick, int i)
 {
   struct userrec *u;
   struct bot_addr *bi;
@@ -1224,7 +1224,7 @@ void tandem_relay(int idx, char *nick, register int i)
 static void tandem_relay_resolve_failure(int idx)
 {
   struct chat_info *ci;
-  register int uidx = -1, i;
+  int uidx = -1, i;
 
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_PRE_RELAY) &&
@@ -1286,9 +1286,9 @@ static void tandem_relay_resolve_success(int i)
 
 /* Input from user before connect is ready
  */
-static void pre_relay(int idx, char *buf, register int i)
+static void pre_relay(int idx, char *buf, int i)
 {
-  register int tidx = -1;
+  int tidx = -1;
 
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_FORK_RELAY) &&
@@ -1334,7 +1334,7 @@ static void pre_relay(int idx, char *buf, register int i)
  */
 static void failed_pre_relay(int idx)
 {
-  register int tidx = -1, i;
+  int tidx = -1, i;
 
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_FORK_RELAY) &&
@@ -1376,9 +1376,9 @@ static void failed_pre_relay(int idx)
   lostdcc(idx);
 }
 
-static void cont_tandem_relay(int idx, char *buf, register int i)
+static void cont_tandem_relay(int idx, char *buf, int i)
 {
-  register int uidx = -1;
+  int uidx = -1;
   struct relay_info *ri;
 
   for (i = 0; i < dcc_total; i++)
@@ -1417,7 +1417,7 @@ static void cont_tandem_relay(int idx, char *buf, register int i)
 
 static void eof_dcc_relay(int idx)
 {
-  register int j;
+  int j;
   struct chat_info *ci;
 
   for (j = 0; j < dcc_total; j++)
@@ -1454,7 +1454,7 @@ static void eof_dcc_relay(int idx)
 
 static void eof_dcc_relaying(int idx)
 {
-  register int j, x = dcc[idx].u.relay->sock;
+  int j, x = dcc[idx].u.relay->sock;
 
   putlog(LOG_MISC, "*", "%s [%s]%s/%d", BOT_LOSTDCCUSER, dcc[idx].nick,
          dcc[idx].host, dcc[idx].port);
@@ -1569,7 +1569,7 @@ static void display_pre_relay(int i, char *other)
 
 static int expmem_relay(void *x)
 {
-  register struct relay_info *p = (struct relay_info *) x;
+  struct relay_info *p = (struct relay_info *) x;
   int tot = sizeof(struct relay_info);
 
   if (p->chat)
@@ -1579,7 +1579,7 @@ static int expmem_relay(void *x)
 
 static void kill_relay(int idx, void *x)
 {
-  register struct relay_info *p = (struct relay_info *) x;
+  struct relay_info *p = (struct relay_info *) x;
 
   if (p->chat)
     DCC_CHAT.kill(idx, p->chat);
@@ -1601,7 +1601,7 @@ struct dcc_table DCC_RELAY = {
 
 static void out_relay(int idx, char *buf, void *x)
 {
-  register struct relay_info *p = (struct relay_info *) x;
+  struct relay_info *p = (struct relay_info *) x;
 
   if (p && p->chat)
     DCC_CHAT.output(idx, buf, p->chat);

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -70,7 +70,7 @@ char owner[121] = "";              /* Permanent botowner(s)        */
  */
 void rmspace(char *s)
 {
-  register char *p = NULL, *q = NULL;
+  char *p = NULL, *q = NULL;
 
   if (!s || !*s)
     return;
@@ -91,7 +91,7 @@ void rmspace(char *s)
  */
 memberlist *ismember(struct chanset_t *chan, char *nick)
 {
-  register memberlist *x;
+  memberlist *x;
 
   for (x = chan->channel.member; x && x->nick[0]; x = x->next)
     if (!rfc_casecmp(x->nick, nick))
@@ -103,7 +103,7 @@ memberlist *ismember(struct chanset_t *chan, char *nick)
  */
 struct chanset_t *findchan(const char *name)
 {
-  register struct chanset_t *chan;
+  struct chanset_t *chan;
 
   for (chan = chanset; chan; chan = chan->next)
     if (!rfc_casecmp(chan->name, name))
@@ -115,7 +115,7 @@ struct chanset_t *findchan(const char *name)
  */
 struct chanset_t *findchan_by_dname(const char *name)
 {
-  register struct chanset_t *chan;
+  struct chanset_t *chan;
 
   for (chan = chanset; chan; chan = chan->next)
     if (!rfc_casecmp(chan->dname, name))
@@ -134,8 +134,8 @@ struct chanset_t *findchan_by_dname(const char *name)
 struct userrec *check_chanlist(const char *host)
 {
   char *nick, *uhost, buf[UHOSTLEN];
-  register memberlist *m;
-  register struct chanset_t *chan;
+  memberlist *m;
+  struct chanset_t *chan;
 
   strncpyz(buf, host, sizeof buf);
   uhost = buf;
@@ -151,8 +151,8 @@ struct userrec *check_chanlist(const char *host)
  */
 struct userrec *check_chanlist_hand(const char *hand)
 {
-  register struct chanset_t *chan;
-  register memberlist *m;
+  struct chanset_t *chan;
+  memberlist *m;
 
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
@@ -168,8 +168,8 @@ struct userrec *check_chanlist_hand(const char *hand)
  */
 void clear_chanlist(void)
 {
-  register memberlist *m;
-  register struct chanset_t *chan;
+  memberlist *m;
+  struct chanset_t *chan;
 
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
@@ -185,8 +185,8 @@ void clear_chanlist(void)
  */
 void clear_chanlist_member(const char *nick)
 {
-  register memberlist *m;
-  register struct chanset_t *chan;
+  memberlist *m;
+  struct chanset_t *chan;
 
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
@@ -202,8 +202,8 @@ void clear_chanlist_member(const char *nick)
 void set_chanlist(const char *host, struct userrec *rec)
 {
   char *nick, *uhost, buf[UHOSTLEN];
-  register memberlist *m;
-  register struct chanset_t *chan;
+  memberlist *m;
+  struct chanset_t *chan;
 
   strncpyz(buf, host, sizeof buf);
   uhost = buf;
@@ -218,8 +218,8 @@ void set_chanlist(const char *host, struct userrec *rec)
  */
 int expmem_chanprog()
 {
-  register int tot = 0;
-  register tcl_timer_t *t;
+  int tot = 0;
+  tcl_timer_t *t;
 
   for (t = timer; t; t = t->next)
     tot += sizeof(tcl_timer_t) + strlen(t->cmd) + 1;
@@ -674,7 +674,7 @@ void list_timers(Tcl_Interp *irp, tcl_timer_t *stack)
  */
 int isowner(char *name)
 {
-  register char *ptr = NULL, *s = NULL, *n = NULL;
+  char *ptr = NULL, *s = NULL, *n = NULL;
 
   if (!name)
     return 0;

--- a/src/compat/inet_aton.c
+++ b/src/compat/inet_aton.c
@@ -104,12 +104,12 @@ const char *cp;
 struct in_addr *addr;
 {
   static const u_32bit_t max[4] = { 0xffffffff, 0xffffff, 0xffff, 0xff };
-  register u_32bit_t val;       /* changed from u_long --david */
-  register int base;
-  register int n;
-  register char c;
+  u_32bit_t val;       /* changed from u_long --david */
+  int base;
+  int n;
+  char c;
   u_32bit_t parts[4];
-  register u_32bit_t *pp = parts;
+  u_32bit_t *pp = parts;
 
   egg_bzero(parts, sizeof(parts));
 

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -793,7 +793,7 @@ static void display_dcc_chat_pass(int idx, char *buf)
 
 static int expmem_dcc_general(void *x)
 {
-  register struct chat_info *p = (struct chat_info *) x;
+  struct chat_info *p = (struct chat_info *) x;
   int tot = sizeof(struct chat_info);
 
   if (p->away)
@@ -815,7 +815,7 @@ static int expmem_dcc_general(void *x)
 
 static void kill_dcc_general(int idx, void *x)
 {
-  register struct chat_info *p = (struct chat_info *) x;
+  struct chat_info *p = (struct chat_info *) x;
 
   if (p) {
     if (p->buffer) {
@@ -961,7 +961,7 @@ static void append_line(int idx, char *line)
 
 static void out_dcc_general(int idx, char *buf, void *x)
 {
-  register struct chat_info *p = (struct chat_info *) x;
+  struct chat_info *p = (struct chat_info *) x;
   char *y = buf;
 
   strip_mirc_codes(p->strip_flags, buf);
@@ -1490,7 +1490,7 @@ static void display_dupwait(int idx, char *buf)
 
 static int expmem_dupwait(void *x)
 {
-  register struct dupwait_info *p = (struct dupwait_info *) x;
+  struct dupwait_info *p = (struct dupwait_info *) x;
   int tot = sizeof(struct dupwait_info);
 
   if (p && p->chat && DCC_CHAT.expmem)
@@ -1500,7 +1500,7 @@ static int expmem_dupwait(void *x)
 
 static void kill_dupwait(int idx, void *x)
 {
-  register struct dupwait_info *p = (struct dupwait_info *) x;
+  struct dupwait_info *p = (struct dupwait_info *) x;
 
   if (p) {
     if (p->chat && DCC_CHAT.kill)
@@ -1528,7 +1528,7 @@ struct dcc_table DCC_DUPWAIT = {
  */
 void dupwait_notify(char *who)
 {
-  register int idx;
+  int idx;
 
   Assert(who);
   for (idx = 0; idx < dcc_total; idx++)
@@ -2134,7 +2134,7 @@ static void display_dcc_script(int idx, char *buf)
 
 static int expmem_dcc_script(void *x)
 {
-  register struct script_info *p = (struct script_info *) x;
+  struct script_info *p = (struct script_info *) x;
   int tot = sizeof(struct script_info);
 
   if (p->type && p->u.other)
@@ -2144,7 +2144,7 @@ static int expmem_dcc_script(void *x)
 
 static void kill_dcc_script(int idx, void *x)
 {
-  register struct script_info *p = (struct script_info *) x;
+  struct script_info *p = (struct script_info *) x;
 
   if (p->type && p->u.other)
     p->type->kill(idx, p->u.other);
@@ -2153,7 +2153,7 @@ static void kill_dcc_script(int idx, void *x)
 
 static void out_dcc_script(int idx, char *buf, void *x)
 {
-  register struct script_info *p = (struct script_info *) x;
+  struct script_info *p = (struct script_info *) x;
 
   if (p && p->type && p->u.other)
     p->type->output(idx, buf, p->u.other);

--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -116,9 +116,9 @@ int findidx(int z)
   return -1;
 }
 
-int findanyidx(register int z)
+int findanyidx(int z)
 {
-  register int j;
+  int j;
 
   for (j = 0; j < dcc_total; j++)
     if (dcc[j].sock == z)

--- a/src/dns.c
+++ b/src/dns.c
@@ -67,7 +67,7 @@ static void display_dcc_dnswait(int idx, char *buf)
 
 static int expmem_dcc_dnswait(void *x)
 {
-  register struct dns_info *p = (struct dns_info *) x;
+  struct dns_info *p = (struct dns_info *) x;
   int size = 0;
 
   if (p) {
@@ -82,7 +82,7 @@ static int expmem_dcc_dnswait(void *x)
 
 static void kill_dcc_dnswait(int idx, void *x)
 {
-  register struct dns_info *p = (struct dns_info *) x;
+  struct dns_info *p = (struct dns_info *) x;
 
   if (p) {
     if (p->host)

--- a/src/flags.c
+++ b/src/flags.c
@@ -775,7 +775,7 @@ static int botfl_write_userfile(FILE *f, struct userrec *u,
 
 static int botfl_set(struct userrec *u, struct user_entry *e, void *buf)
 {
-  register long atr = ((long) buf & BOT_VALID);
+  long atr = ((long) buf & BOT_VALID);
 
   if (!(u->flags & USER_BOT))
     return 1;                   /* Don't even bother trying to set the

--- a/src/language.c
+++ b/src/language.c
@@ -592,7 +592,7 @@ int expmem_language()
 static int cmd_languagestatus(struct userrec *u, int idx, char *par)
 {
   int ltexts = 0;
-  register int i, c, maxdepth = 0, used = 0, empty = 0;
+  int i, c, maxdepth = 0, used = 0, empty = 0;
   lang_tab *l;
   lang_sec *ls = langsection;
   lang_pri *lp = langpriority;

--- a/src/match.c
+++ b/src/match.c
@@ -49,14 +49,14 @@ int charcmp(unsigned char a, unsigned char b)
 /* Wildcard-matches mask m to n. Uses the comparison function cmp1. If chgpoint
  * isn't NULL, it points at the first character in n where we start using cmp2.
  */
-int _wild_match_per(register unsigned char *m, register unsigned char *n,
+int _wild_match_per(unsigned char *m, unsigned char *n,
                            int (*cmp1)(unsigned char, unsigned char),
                            int (*cmp2)(unsigned char, unsigned char),
                            unsigned char *chgpoint)
 {
   unsigned char *ma = m, *lsm = 0, *lsn = 0, *lpm = 0, *lpn = 0;
   int match = 1, saved = 0, space;
-  register unsigned int sofar = 0;
+  unsigned int sofar = 0;
 
   /* null strings should never match */
   if ((m == 0) || (n == 0) || (!*n) || (!cmp1))
@@ -152,11 +152,11 @@ int _wild_match_per(register unsigned char *m, register unsigned char *n,
 }
 
 /* Generic string matching, use addr_match() for hostmasks! */
-int _wild_match(register unsigned char *m, register unsigned char *n)
+int _wild_match(unsigned char *m, unsigned char *n)
 {
   unsigned char *ma = m, *na = n, *lsm = 0, *lsn = 0;
   int match = 1;
-  register int sofar = 0;
+  int sofar = 0;
 
   /* null strings should never match */
   if ((ma == 0) || (na == 0) || (!*ma) || (!*na))

--- a/src/misc.c
+++ b/src/misc.c
@@ -183,9 +183,9 @@ int egg_strcatn(char *dst, const char *src, size_t max)
   return tmpmax - max;
 }
 
-int my_strcpy(register char *a, register char *b)
+int my_strcpy(char *a, char *b)
 {
-  register char *c = b;
+  char *c = b;
 
   while (*b)
     *a++ = *b++;
@@ -272,7 +272,7 @@ void remove_crlf(char **line)
 
 char *newsplit(char **rest)
 {
-  register char *o, *r;
+  char *o, *r;
 
   if (!rest)
     return "";
@@ -320,7 +320,7 @@ char *newsplit(char **rest)
 void maskaddr(const char *s, char *nw, int type)
 {
   int d = type % 5, num = 1;
-  register char *p, *u = 0, *h = 0, *ss;
+  char *p, *u = 0, *h = 0, *ss;
 
   /* Look for user and host.. */
   ss = (char *)s;
@@ -1457,7 +1457,7 @@ void make_rand_str(char *s, int len)
  */
 int oatoi(const char *octal)
 {
-  register int i;
+  int i;
 
   if (!*octal)
     return -1;
@@ -1523,10 +1523,10 @@ char *str_escape(const char *str, const char div, const char mask)
  * NOTE: If you look carefully, you'll notice that strchr_unescape()
  *       behaves differently than strchr().
  */
-char *strchr_unescape(char *str, const char div, register const char esc_char)
+char *strchr_unescape(char *str, const char div, const char esc_char)
 {
   char buf[3];
-  register char *s, *p;
+  char *s, *p;
 
   buf[2] = 0;
   for (s = p = str; *s; s++, p++) {
@@ -1561,7 +1561,7 @@ int str_isdigit(const char *str)
 /* As strchr_unescape(), but converts the complete string, without
  * searching for a specific delimiter character.
  */
-void str_unescape(char *str, register const char esc_char)
+void str_unescape(char *str, const char esc_char)
 {
   (void) strchr_unescape(str, 0, esc_char);
 }

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -72,7 +72,7 @@ static int is_compressedfile(char *filename)
   char buf1[50], buf2[50];
   FILE *fin;
   gzFile zin;
-  register int len1, len2, i;
+  int len1, len2, i;
 
   egg_memset(buf1, 0, 50);
   egg_memset(buf2, 0, 50);

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -535,7 +535,7 @@ static void disp_dcc_files_pass(int idx, char *buf)
 
 static void kill_dcc_files(int idx, void *x)
 {
-  register struct file_info *f = (struct file_info *) x;
+  struct file_info *f = (struct file_info *) x;
 
   if (f->chat)
     DCC_CHAT.kill(idx, f->chat);
@@ -553,7 +553,7 @@ static void eof_dcc_files(int idx)
 
 static int expmem_dcc_files(void *x)
 {
-  register struct file_info *p = (struct file_info *) x;
+  struct file_info *p = (struct file_info *) x;
   int tot = sizeof(struct file_info);
 
   if (p->chat)
@@ -563,7 +563,7 @@ static int expmem_dcc_files(void *x)
 
 static void out_dcc_files(int idx, char *buf, void *x)
 {
-  register struct file_info *p = (struct file_info *) x;
+  struct file_info *p = (struct file_info *) x;
 
   if (p->chat)
     DCC_CHAT.output(idx, buf, p->chat);

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -429,7 +429,7 @@ static void kick_all(struct chanset_t *chan, char *hostmask, char *comment,
  */
 static void refresh_ban_kick(struct chanset_t *chan, char *user, char *nick)
 {
-  register maskrec *b;
+  maskrec *b;
   memberlist *m;
   int cycle;
 

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -70,7 +70,7 @@ static char *getnick(char *handle, struct chanset_t *chan)
 {
   char s[UHOSTLEN];
   struct userrec *u;
-  register memberlist *m;
+  memberlist *m;
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -799,7 +799,7 @@ static void got_ban(struct chanset_t *chan, char *nick, char *from, char *who,
   }
   refresh_exempt(chan, who);
   if (nick[0] && channel_enforcebans(chan)) {
-    register maskrec *b;
+    maskrec *b;
     int cycle;
     char resn[512] = "";
 

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -448,9 +448,9 @@
 #define party (*(party_t **)(global[260]))
 #define open_address_listen ((int (*)(sockname_t *, int *))global[261])
 #define str_escape ((char *(*)(const char *, const char, const char))global[262])
-#define strchr_unescape ((char *(*)(char *, const char, register const char))global[263])
+#define strchr_unescape ((char *(*)(char *, const char, const char))global[263])
 /* 264 - 267 */
-#define str_unescape ((void (*)(char *, register const char))global[264])
+#define str_unescape ((void (*)(char *, const char))global[264])
 #define egg_strcatn ((int (*)(char *dst, const char *src, size_t max))global[265])
 #define clear_chanlist_member ((void (*)(const char *nick))global[266])
 #define fixfrom ((char *(*)(char *))global[267])

--- a/src/mod/notes.mod/notes.c
+++ b/src/mod/notes.mod/notes.c
@@ -830,10 +830,10 @@ static void notes_hourly()
 {
   expire_notes();
   if (notify_users) {
-    register struct chanset_t *chan;
-    register memberlist *m;
+    struct chanset_t *chan;
+    memberlist *m;
     int k;
-    register int l;
+    int l;
     char s1[NICKMAX+UHOSTLEN+1];
     struct userrec *u;
 

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -251,7 +251,7 @@ static void deq_msg()
 static int calc_penalty(char *msg)
 {
   char *cmd, *par1, *par2, *par3;
-  register int penalty, i, ii;
+  int penalty, i, ii;
 
   if (!use_penalties && net_type != NETT_UNDERNET &&
       net_type != NETT_HYBRID_EFNET)
@@ -380,7 +380,7 @@ static int calc_penalty(char *msg)
 
 char *splitnicks(char **rest)
 {
-  register char *o, *r;
+  char *o, *r;
 
   if (!rest)
     return *rest = "";
@@ -1199,7 +1199,7 @@ static char *nick_change(ClientData cdata, Tcl_Interp *irp,
  */
 static void rand_nick(char *nick)
 {
-  register char *p = nick;
+  char *p = nick;
 
   while ((p = strchr(p, '?')) != NULL) {
     *p = '0' + randint(10);
@@ -1724,7 +1724,7 @@ static void server_die()
 
 static void msgq_clear(struct msgq_head *qh)
 {
-  register struct msgq *q, *qq;
+  struct msgq *q, *qq;
 
   for (q = qh->head; q; q = qq) {
     qq = q->next;
@@ -1737,8 +1737,8 @@ static void msgq_clear(struct msgq_head *qh)
 
 static int msgq_expmem(struct msgq_head *qh)
 {
-  register int tot = 0;
-  register struct msgq *m;
+  int tot = 0;
+  struct msgq *m;
 
   for (m = qh->head; m; m = m->next) {
     tot += m->len + 1;

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -58,11 +58,11 @@ static struct dcc_table DCC_SEND, DCC_GET, DCC_GET_PENDING;
  * wildcard characters. This is basically a direct copy of wild_match_per(),
  * but without support for '%', or '~'.
  */
-static int wild_match_file(register char *m, register char *n)
+static int wild_match_file(char *m, char *n)
 {
   char *ma = m, *lsm = 0, *lsn = 0;
   int match = 1;
-  register unsigned int sofar = 0;
+  unsigned int sofar = 0;
 
   /* null strings should never match */
   if ((m == 0) || (n == 0) || (!*n))
@@ -131,7 +131,7 @@ static int at_limit(char *nick)
  */
 static char *replace_spaces(char *fn)
 {
-  register char *ret, *p;
+  char *ret, *p;
 
   p = ret = nmalloc(strlen(fn) + 1);
   strcpy(ret, fn);
@@ -214,7 +214,7 @@ static void check_tcl_toutlost(struct userrec *u, char *nick, char *path,
  */
 #define PMAX_SIZE 4096
 static unsigned long pump_file_to_sock(FILE *file, long sock,
-                                       register unsigned long pending_data)
+                                       unsigned long pending_data)
 {
   unsigned long actual_size, r;
   const unsigned long buf_len = pending_data >= PMAX_SIZE ?
@@ -750,7 +750,7 @@ static void display_dcc_fork_send(int idx, char *buf)
 
 static int expmem_dcc_xfer(void *x)
 {
-  register struct xfer_info *p = (struct xfer_info *) x;
+  struct xfer_info *p = (struct xfer_info *) x;
   int tot;
 
   tot = sizeof(struct xfer_info);
@@ -766,7 +766,7 @@ static int expmem_dcc_xfer(void *x)
 
 static void kill_dcc_xfer(int idx, void *x)
 {
-  register struct xfer_info *p = (struct xfer_info *) x;
+  struct xfer_info *p = (struct xfer_info *) x;
 
   if (p->filename)
     nfree(p->filename);

--- a/src/mod/transfer.mod/transfer.h
+++ b/src/mod/transfer.mod/transfer.h
@@ -111,7 +111,7 @@ enum dccsend_types {
 #define queue_file(a,b,c,d) (((void (*)(char *,char *,char *,char *))transfer_funcs[8])(a,b,c,d))
 #define raw_dcc_send(a,b,c) (((int (*) (char *,char *,char *))transfer_funcs[9])(a,b,c))
 #define show_queued_files(a) (((void (*) (int))transfer_funcs[10])(a))
-#define wild_match_file(a,b) (((int (*)(register char *, register char *))transfer_funcs[11])(a,b))
+#define wild_match_file(a,b) (((int (*)(char *, char *))transfer_funcs[11])(a,b))
 /* 12 - 15 */
 /* Was wipe_tmp_filename (obsoleted) */
 #define DCC_GET (*(struct dcc_table *)(transfer_funcs[13]))
@@ -145,7 +145,7 @@ static int fstat_tcl_set(Tcl_Interp *irp, struct userrec *u,
                          struct user_entry *e, int argc, char **argv);
 static void stats_add_dnload(struct userrec *u, unsigned long bytes);
 static void stats_add_upload(struct userrec *u, unsigned long bytes);
-static int wild_match_file(register char *, register char *);
+static int wild_match_file(char *, char *);
 static int server_transfer_setup(char *);
 
 #define TRANSFER_REGET_PACKETID 0xfeab

--- a/src/mod/transfer.mod/transferfstat.c
+++ b/src/mod/transfer.mod/transferfstat.c
@@ -51,7 +51,7 @@ static int fstat_unpack(struct userrec *u, struct user_entry *e)
 
 static int fstat_pack(struct userrec *u, struct user_entry *e)
 {
-  register struct filesys_stats *fs;
+  struct filesys_stats *fs;
   struct list_type *l = user_malloc(sizeof(struct list_type));
 
   fs = e->u.extra;
@@ -68,7 +68,7 @@ static int fstat_pack(struct userrec *u, struct user_entry *e)
 static int fstat_write_userfile(FILE *f, struct userrec *u,
                                 struct user_entry *e)
 {
-  register struct filesys_stats *fs;
+  struct filesys_stats *fs;
 
   fs = e->u.extra;
   if (fprintf(f, "--FSTAT %09u %09u %09u %09u\n", fs->uploads, fs->upload_ks,
@@ -80,7 +80,7 @@ static int fstat_write_userfile(FILE *f, struct userrec *u,
 
 static int fstat_set(struct userrec *u, struct user_entry *e, void *buf)
 {
-  register struct filesys_stats *fs = buf;
+  struct filesys_stats *fs = buf;
 
   if (e->u.extra != fs) {
     if (e->u.extra)
@@ -265,7 +265,7 @@ static int fstat_dupuser(struct userrec *u, struct userrec *o,
 static void stats_add_dnload(struct userrec *u, unsigned long bytes)
 {
   struct user_entry *ue;
-  register struct filesys_stats *fs;
+  struct filesys_stats *fs;
 
   if (u) {
     if (!(ue = find_user_entry(&USERENTRY_FSTAT, u)) || !(fs = ue->u.extra)) {
@@ -282,7 +282,7 @@ static void stats_add_dnload(struct userrec *u, unsigned long bytes)
 static void stats_add_upload(struct userrec *u, unsigned long bytes)
 {
   struct user_entry *ue;
-  register struct filesys_stats *fs;
+  struct filesys_stats *fs;
 
   if (u) {
     if (!(ue = find_user_entry(&USERENTRY_FSTAT, u)) || !(fs = ue->u.extra)) {
@@ -299,7 +299,7 @@ static void stats_add_upload(struct userrec *u, unsigned long bytes)
 static int fstat_tcl_set(Tcl_Interp *irp, struct userrec *u,
                          struct user_entry *e, int argc, char **argv)
 {
-  register struct filesys_stats *fs;
+  struct filesys_stats *fs;
   int f = 0, k = 0;
 
   BADARGS(4, 6, " handle FSTAT u/d ?files ?ks??");

--- a/src/modules.h
+++ b/src/modules.h
@@ -53,7 +53,7 @@ extern struct hook_entry {
 } *hook_list[REAL_HOOKS];
 
 #define call_hook(x) do {                                       \
-        register struct hook_entry *p, *pn;                     \
+        struct hook_entry *p, *pn;                              \
                                                                 \
         for (p = hook_list[x]; p; p = pn) {                     \
                 pn = p->next;                                   \

--- a/src/net.c
+++ b/src/net.c
@@ -319,10 +319,10 @@ int allocsock(int sock, int options)
  *
  * alloctclsock() can be called by Tcl threads
  */
-int alloctclsock(register int sock, int mask, Tcl_FileProc *proc, ClientData cd)
+int alloctclsock(int sock, int mask, Tcl_FileProc *proc, ClientData cd)
 {
   int f = -1;
-  register int i;
+  int i;
   struct threaddata *td = threaddata();
 
   for (i = 0; i < td->MAXSOCKS; i++) {
@@ -391,9 +391,9 @@ int getsock(int af, int options)
 
 /* Done with a socket
  */
-void killsock(register int sock)
+void killsock(int sock)
 {
-  register int i;
+  int i;
   struct threaddata *td = threaddata();
 
   /* Ignore invalid sockets.  */
@@ -433,9 +433,9 @@ void killsock(register int sock)
  *
  * killtclsock() can be called by Tcl threads
  */
-void killtclsock(register int sock)
+void killtclsock(int sock)
 {
-  register int i;
+  int i;
   struct threaddata *td = threaddata();
 
   if (sock < 0)
@@ -1162,9 +1162,9 @@ int sockgets(char *s, int *len)
  *
  * NOTE: Do NOT put Contexts in here if you want DEBUG to be meaningful!!
  */
-void tputs(register int z, char *s, unsigned int len)
+void tputs(int z, char *s, unsigned int len)
 {
-  register int i, x, idx;
+  int i, x, idx;
   char *p;
   static int inhere = 0;
 

--- a/src/proto.h
+++ b/src/proto.h
@@ -192,8 +192,8 @@ int mainloop(int);
 /* match.c */
 int casecharcmp(unsigned char, unsigned char);
 int charcmp(unsigned char, unsigned char);
-int _wild_match(register unsigned char *, register unsigned char *);
-int _wild_match_per(register unsigned char *, register unsigned char *,
+int _wild_match(unsigned char *, unsigned char *);
+int _wild_match_per(unsigned char *, unsigned char *,
                     int (*)(unsigned char, unsigned char),
                     int (*)(unsigned char, unsigned char),
                     unsigned char *);
@@ -255,8 +255,8 @@ int oatoi(const char *);
 int is_file(const char *);
 void logsuffix_change(char *);
 char *str_escape(const char *, const char, const char);
-char *strchr_unescape(char *, const char, register const char);
-void str_unescape(char *, register const char);
+char *strchr_unescape(char *, const char, const char);
+void str_unescape(char *, const char);
 int str_isdigit(const char *);
 void kill_bot(char *, char *);
 

--- a/src/rfc1459.c
+++ b/src/rfc1459.c
@@ -27,9 +27,9 @@
 
 int _rfc_casecmp(const char *s1, const char *s2)
 {
-  register unsigned char *str1 = (unsigned char *) s1;
-  register unsigned char *str2 = (unsigned char *) s2;
-  register int res;
+  unsigned char *str1 = (unsigned char *) s1;
+  unsigned char *str2 = (unsigned char *) s2;
+  int res;
 
   while (!(res = rfc_toupper(*str1) - rfc_toupper(*str2))) {
     if (*str1 == '\0')
@@ -42,9 +42,9 @@ int _rfc_casecmp(const char *s1, const char *s2)
 
 int _rfc_ncasecmp(const char *str1, const char *str2, int n)
 {
-  register unsigned char *s1 = (unsigned char *) str1;
-  register unsigned char *s2 = (unsigned char *) str2;
-  register int res;
+  unsigned char *s1 = (unsigned char *) str1;
+  unsigned char *s2 = (unsigned char *) str2;
+  int res;
 
   while (!(res = rfc_toupper(*s1) - rfc_toupper(*s2))) {
     s1++;

--- a/src/userent.c
+++ b/src/userent.c
@@ -240,7 +240,7 @@ struct user_entry_type USERENTRY_INFO = {
 int pass_set(struct userrec *u, struct user_entry *e, void *buf)
 {
   char new[32];
-  register char *pass = buf;
+  char *pass = buf;
 
   if (e->u.extra)
     nfree(e->u.extra);
@@ -570,7 +570,7 @@ static int botaddr_write_userfile(FILE *f, struct userrec *u,
 {
   int ret = 1;
   char *p, *q, *addr;
-  register struct bot_addr *bi = (struct bot_addr *) e->u.extra;
+  struct bot_addr *bi = (struct bot_addr *) e->u.extra;
 
   p = bi->address;
   addr = user_malloc(strlen(bi->address) + 1);
@@ -595,7 +595,7 @@ static int botaddr_write_userfile(FILE *f, struct userrec *u,
 
 static int botaddr_set(struct userrec *u, struct user_entry *e, void *buf)
 {
-  register struct bot_addr *bi = (struct bot_addr *) e->u.extra;
+  struct bot_addr *bi = (struct bot_addr *) e->u.extra;
 
   if (!bi && !buf)
     return 1;
@@ -667,7 +667,7 @@ static int botaddr_tcl_append(Tcl_Interp * interp, struct userrec *u,
 static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
                            struct user_entry *e, int argc, char **argv)
 {
-  register struct bot_addr *bi = (struct bot_addr *) e->u.extra;
+  struct bot_addr *bi = (struct bot_addr *) e->u.extra;
 
   BADARGS(4, 6, " handle type address ?telnetport ?relayport??");
 
@@ -721,14 +721,14 @@ static int botaddr_tcl_set(Tcl_Interp * irp, struct userrec *u,
 
 static int botaddr_expmem(struct user_entry *e)
 {
-  register struct bot_addr *bi = (struct bot_addr *) e->u.extra;
+  struct bot_addr *bi = (struct bot_addr *) e->u.extra;
 
   return strlen(bi->address) + 1 + sizeof(struct bot_addr);
 }
 
 static void botaddr_display(int idx, struct user_entry *e)
 {
-  register struct bot_addr *bi = (struct bot_addr *) e->u.extra;
+  struct bot_addr *bi = (struct bot_addr *) e->u.extra;
 
   dprintf(idx, "  ADDRESS: %.70s\n", bi->address);
 #ifdef TLS


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: cleanup

One-line summary:
delete register keyword, trust in good compiler optimization

Additional description (if needed):
its 2018
less bloat
while at it moved some variable declaration to function header (ive learned its not needed for c89, but hey)

Test cases demonstrating functionality (if applicable):
basic test. compile. run. connect. worked.