### PR TITLE
Fix small issues found while compiling on sunos

### DIFF
--- a/src/bg.c
+++ b/src/bg.c
@@ -105,7 +105,7 @@ static void bg_do_detach(pid_t p)
   unlink(pid_file);
   fp = fopen(pid_file, "w");
   if (fp != NULL) {
-    fprintf(fp, "%u\n", p);
+    fprintf(fp, "%li\n", (long) p);
     if (fflush(fp)) {
       /* Kill bot incase a botchk is run from crond. */
       printf(EGG_NOWRITE, pid_file);
@@ -117,7 +117,7 @@ static void bg_do_detach(pid_t p)
     fclose(fp);
   } else
     printf(EGG_NOWRITE, pid_file);
-  printf("Launched into the background  (pid: %d)\n\n", p);
+  printf("Launched into the background  (pid: %li)\n\n", (long) p);
 #ifdef HAVE_SETPGID
   setpgid(p, p);
 #endif

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -608,7 +608,7 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
 
   MD5_Init(&md5context);
 
-  egg_snprintf(digest_string, 33, "<%x%x@", getpid(),
+  egg_snprintf(digest_string, 33, "<%lx%x@", (long) getpid(),
                (unsigned int) dcc[idx].timeval);
   MD5_Update(&md5context, (unsigned char *) digest_string,
              strlen(digest_string));

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -724,7 +724,7 @@ static char *mktempfile(char *filename)
     fn[l] = 0;
   }
   tempname = nmalloc(l + MKTEMPFILE_TOT + 1);
-  sprintf(tempname, "%u-%s-%s", getpid(), rands, fn);
+  sprintf(tempname, "%li-%s-%s", (long) getpid(), rands, fn);
   if (fn != filename)
     my_free(fn);
   return tempname;

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -804,9 +804,8 @@ static inline int check_bind_flags(struct flag_record *flags,
       return (flagrec_ok(flags, atr));
     else
       return (flagrec_eq(flags, atr));
-  } else
-    return 1;
-  return 0;
+  }
+  return 1;
 }
 
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: small issues found while compiling on sunos

One-line summary:
silence some sunos compiler warnings and clean up code

Additional description (if needed):
see commit messages below

Test cases demonstrating functionality (if applicable):
small test, start eggdrop, pid is displayed fine here:
./eggdrop
[...]
Launched into the background  (pid: 18138)