### PR TITLE
make 2 code pathes/errors look different, _may_ also help debug #580

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -665,7 +665,7 @@ void ssl_info(SSL *ssl, int where, int ret)
         /* Errors to be ignored for non-blocking */
         debug1("TLS: awaiting more %s", (err & SSL_ERROR_WANT_READ) ? "reads" : "writes");
       } else {
-        putlog(data->loglevel, "*", "TLS: failed in: %s.",
+        putlog(data->loglevel, "*", "TLS: error in: %s.",
                SSL_state_string_long(ssl));
       }
     }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: problem figuring out which code path was taken

One-line summary:
without this patch 2 different code pathes produce same error message, so one cant tell from the log which code path was taken.

Additional description (if needed):
the code comment says the code was copied from man page example
but the (current) example of ssl_set_info_callback(3) has different error messages

Test cases demonstrating functionality (if applicable):
i did only a small compile/start test, i didnt check tls dunctionality at all.
but this patch only changes log text, what could probably go wrong.