### PR TITLE
Add port and TLS info as a separate list item for tcl dcclist.

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1575,7 +1575,7 @@ dccused
 dcclist [type]
 ^^^^^^^^^^^^^^
 
-  Returns: a list of active connections, each item in the list is a sublist containing six elements:
+  Returns: a list of active connections, each item in the list is a sublist containing seven elements:
   {<idx> <handle> <hostname> <[+]port> <type> {<other>} <timestamp>}.
 
   The types are: chat, bot, files, file_receiving, file_sending, file_send_pending, script, socket (these are connections that have not yet been put under 'control'), telnet, and server. The timestamp is in unixtime format.

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1576,7 +1576,7 @@ dcclist [type]
 ^^^^^^^^^^^^^^
 
   Returns: a list of active connections, each item in the list is a sublist containing six elements:
-  {<idx> <handle> <hostname> <type> {<other>} <timestamp>}.
+  {<idx> <handle> <hostname> <[+]port> <type> {<other>} <timestamp>}.
 
   The types are: chat, bot, files, file_receiving, file_sending, file_send_pending, script, socket (these are connections that have not yet been put under 'control'), telnet, and server. The timestamp is in unixtime format.
 

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -649,7 +649,7 @@ static int tcl_dcclist STDVAR
 {
   int i;
   char *p, idxstr[10], timestamp[11], other[160];
-  char portstring[7];
+  char portstring[7]; /* ssl + portmax + NULL */
   long tv;
   EGG_CONST char *list[7];
 


### PR DESCRIPTION
Found by: Cizzle
Patch by: Cizzle
Fixes: Suggestion 2 at #155 

One-line summary: Adds the port and possible TLS info as a separate list item to tcl `dcclist`.