### PR TITLE
Fix c89 comments and arg validation

### DIFF
--- a/src/lang.h
+++ b/src/lang.h
@@ -241,7 +241,6 @@
 #define IRC_NICK_FLOOD          get_language(0x673)
 
 /* Eggdrop command line usage */
-#define EGG_USAGE               get_language(0x700)
 #define EGG_RUNNING1            get_language(0x701)
 #define EGG_RUNNING2            get_language(0x702)
 #define EGG_NOWRITE             get_language(0x703)

--- a/src/main.c
+++ b/src/main.c
@@ -537,62 +537,68 @@ void show_help() {
   printf("\n%s\n\n", version);
   printf("Usage: eggdrop [options] [config-file]\n\n"
          "Options:\n"
-         "-n Don't background; send all log entries to console.\n"
-         "-nc  Don't background; display channel stats every 10 seconds.\n"
-         "-nt  Don't background; use terminal to simulate DCC chat.\n"
-         "-m   Create userfile.\n"
-         "-h   Show this help.\n"
-         "-v   Show version info, then quit.\n\n");
+         "-n  Don't background; send all log entries to console.\n"
+         "-nc Don't background; display channel stats every 10 seconds.\n"
+         "-nt Don't background; use terminal to simulate DCC chat.\n"
+         "-m  Create userfile.\n"
+         "-h  Show this help.\n"
+         "-v  Show version info, then quit.\n\n");
   bg_send_quit(BG_ABORT);
 }
 
 static void do_arg()
 {
   int option = 0;
-/* Bitmask structure to hold cli flags
-   | QUIT| BAD FLAG| h| n| c| t| m| v|
-   |  128|       64|32|16| 8| 4| 2| 1|
-*/
   unsigned char cliflags = 0;
+  #define CLI_V        1 << 0
+  #define CLI_M        1 << 1
+  #define CLI_T        1 << 2
+  #define CLI_C        1 << 3
+  #define CLI_N        1 << 4
+  #define CLI_H        1 << 5
+  #define CLI_BAD_FLAG 1 << 6
 
   while ((option = getopt(argc, argv, "hnctmv")) != -1) {
     switch (option) {
       case 'n':
-        cliflags |= 16;
+        cliflags |= CLI_N;
         backgrd = 0;
         break;
       case 'c':
-        cliflags |= 8;
+        cliflags |= CLI_C;
         con_chan = 1;
         term_z = 0;
         break;
       case 't':
-        cliflags |= 4;
+        cliflags |= CLI_T;
         con_chan = 0;
         term_z = 1;
         break;
       case 'm':
-        cliflags |= 2;
+        cliflags |= CLI_M;
         make_userfile = 1;
         break;
       case 'v':
-        cliflags |= 129;		//128 + 1
+        cliflags |= CLI_V;
         break;
       case 'h':
-        cliflags |= 160;		//128 + 32
+        cliflags |= CLI_H;
         break;
       default:
-        cliflags |= 192;		//128 + 64
+        cliflags |= CLI_BAD_FLAG;
         break;
     }
   }
-  if ((cliflags & 64) || (cliflags & 32)) {
+  if (cliflags & CLI_H) {
     show_help();
     exit(0);
-  } else if (cliflags & 1) {
+  } else if (cliflags & CLI_BAD_FLAG) {
+    show_help();
+    exit(1);
+  } else if (cliflags & CLI_V) {
     show_ver();
     exit(0);
-  } else if (!(cliflags & 16) && ((cliflags & 8) || (cliflags & 4))) {
+  } else if (!(cliflags & CLI_N) && ((cliflags & CLI_C) || (cliflags & CLI_T))) {
     printf("\n%s\n", version);
     printf("ERROR: The -n flag is required when using the -c or -t flags. Exiting...\n\n");
     exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -503,7 +503,7 @@ void eggAssert(const char *file, int line, const char *module)
 }
 #endif
 
-void show_ver() {
+static void show_ver() {
   char x[512], *z = x;
 
   strncpyz(x, egg_version, sizeof x);
@@ -533,7 +533,7 @@ void show_ver() {
    meaning other languages can't be loaded yet.
    English (or an error) is the only possible option.
 */
-void show_help() {
+static void show_help() {
   printf("\n%s\n\n", version);
   printf("Usage: eggdrop [options] [config-file]\n\n"
          "Options:\n"

--- a/src/main.c
+++ b/src/main.c
@@ -535,14 +535,14 @@ static void show_ver() {
 */
 static void show_help() {
   printf("\n%s\n\n", version);
-  printf("Usage: eggdrop [options] [config-file]\n\n"
+  printf("Usage: %s [options] [config-file]\n\n"
          "Options:\n"
          "-n  Don't background; send all log entries to console.\n"
          "-nc Don't background; display channel stats every 10 seconds.\n"
          "-nt Don't background; use terminal to simulate DCC chat.\n"
          "-m  Create userfile.\n"
-         "-h  Show this help.\n"
-         "-v  Show version info, then quit.\n\n");
+         "-h  Show this help and exit.\n"
+         "-v  Show version info and exit.\n\n", argv[0]);
   bg_send_quit(BG_ABORT);
 }
 

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1528,7 +1528,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
         }
       } else {
         if ((*item[i]) && !strtol(item[i], &endptr, 10) && !(*endptr)) {
-          *pthr = 0;  // Shortcut for .chanset #chan flood-x 0 to activate 0:0
+          *pthr = 0;  /* Shortcut for .chanset #chan flood-x 0 to activate 0:0 */
           *ptime = 0;
         } else {
           if (irp)

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -157,7 +157,7 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
       return 1;
     }
 
-// * Check if SSL, IPv4, or IPv6 were requested
+/* Check if SSL, IPv4, or IPv6 were requested */
     if (
 #ifdef IPV6
     (!egg_strcasecmp(keyword, "CHAT6")) ||


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: c89 comments, arg validation

One-line summary:
Fixes c89 comments, option alignment, flag constants, exit code for bad option, static functions

Additional description (if needed):
**Fix "CFLAGS="-std=c89" ./configure" throws compiler error: " error: C++ style comments are not allowed in ISO C90" found with gcc**
Fix comments to be c89 style
Align help/usage options
Improve command line arg validation code readability
exit(1) instead of exit(0) for bad option
Make show_help() and show_ver() static functions
Don't hardcode program name for show_help() / Usage
Slightly changed wording for show_help() / Usage -h and -v

this patch was part of #549 and is hereby seperated to be easy to merge

first i wanted only to fix the comments to be c89,
but the non c89 comments in main.c showed some code there
which screamed for more improvement
and while reading and testing it became clear
**there was also a tiny bug inside
in case of an unknown bad flag eggdrop would exit(0) as if everything were fine**

Test cases demonstrating functionality (if applicable):
tested all command line options and a bad option