### PR TITLE
(Cleanup) Remove unnecessary bloat from Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -84,7 +84,7 @@ MODULE_XLIBS = @MODULE_XLIBS@
 modconf = $(top_srcdir)/misc/modconfig --top_srcdir=$(top_srcdir)
 
 egg_test_run = if [ '$(EGG_CROSS_COMPILING)' = 'no' ]; \
-               	then EGG_LANGDIR=$(top_srcdir)/language ./$(EGGEXEC) -v; \
+               	then ./$(EGGEXEC) -v; \
                	else echo 'This build is a cross-compilation, skipping test run...'; \
                fi
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: bloat

One-line summary:
init_language() is not called when started with -v, so Makefile was slimmed

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
small test with eggdrop -v and eggdrop -ntm started.