### PR TITLE
Remove all inline keywords

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -796,7 +796,7 @@ int init_language(int);
 int ssl_init();
 #endif
 
-static inline void garbage_collect(void)
+static void garbage_collect(void)
 {
   static u_8bit_t run_cnt = 0;
 

--- a/src/match.c
+++ b/src/match.c
@@ -381,7 +381,7 @@ int cidr_match(char *m, char *n, int count)
 /* Inline for cron_match (obviously).
  * Matches a single field of a crontab expression.
  */
-static inline int cron_matchfld(char *mask, int match)
+static int cron_matchfld(char *mask, int match)
 {
   int skip = 0, f, t;
   char *p, *q;

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -263,7 +263,7 @@ static int ismasked(masklist *m, char *user)
 
 /* Unlink chanset element from chanset list.
  */
-static inline int chanset_unlink(struct chanset_t *chan)
+static int chanset_unlink(struct chanset_t *chan)
 {
   struct chanset_t *c, *c_old = NULL;
 

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -175,7 +175,7 @@ static int uncompress_to_file(char *f_src, char *f_target)
 
 /* Enforce limits.
  */
-static inline void adjust_mode_num(int *mode)
+static void adjust_mode_num(int *mode)
 {
   if (*mode > 9)
     *mode = 9;

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -258,14 +258,14 @@ static struct resolve *allocresolve()
 
 /* Return the hash bucket number for id.
  */
-static inline u_32bit_t getidbash(u_16bit_t id)
+static u_32bit_t getidbash(u_16bit_t id)
 {
   return (u_32bit_t) BASH_MODULO(id);
 }
 
 /* Return the hash bucket number for ip.
  */
-static inline u_32bit_t getipbash(IP ip)
+static u_32bit_t getipbash(IP ip)
 {
   return (u_32bit_t) BASH_MODULO(ip);
 }

--- a/src/mod/filesys.mod/filelist.c
+++ b/src/mod/filesys.mod/filelist.c
@@ -77,7 +77,7 @@ static void filelist_addout(filelist_t *flist, char *desc)
 }
 
 /* Dump all data to specified idx */
-static inline void filelist_idxshow(filelist_t *flist, int idx)
+static void filelist_idxshow(filelist_t *flist, int idx)
 {
   int i;
 

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -53,7 +53,7 @@ static memberlist *newmember(struct chanset_t *chan)
 }
 
 /* Remove channel members for which no WHO reply was received */
-static inline void sync_members(struct chanset_t *chan)
+static void sync_members(struct chanset_t *chan)
 {
   memberlist *m, *next, *prev;
 

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -532,7 +532,7 @@ static int tcl_getchanidle STDVAR
   return TCL_OK;
 }
 
-static inline int tcl_chanmasks(masklist *m, Tcl_Interp *irp)
+static int tcl_chanmasks(masklist *m, Tcl_Interp *irp)
 {
   char work[20], *p;
   EGG_CONST char *list[3];

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -379,7 +379,7 @@ static void eof_dcc_send(int idx)
 
 /* Determine byte order. Used for resend DCC startup packets.
  */
-static inline u_8bit_t byte_order_test(void)
+static u_8bit_t byte_order_test(void)
 {
   u_16bit_t test = TRANSFER_REGET_PACKETID;
 
@@ -392,7 +392,7 @@ static inline u_8bit_t byte_order_test(void)
 
 /* Parse and handle resend DCC startup packets.
  */
-static inline void handle_resend_packet(int idx, transfer_reget *reget_data)
+static void handle_resend_packet(int idx, transfer_reget *reget_data)
 {
   if (byte_order_test() != reget_data->byte_order) {
     /* The sender's byte order does not match our's so we need to switch the

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -61,7 +61,7 @@ static int builtin_log();
 
 /* Allocate and initialise a chunk of memory.
  */
-static inline void *n_malloc_null(int size, const char *file, int line)
+static void *n_malloc_null(int size, const char *file, int line)
 {
 #ifdef DEBUG_MEM
 #  define nmalloc_null(size) n_malloc_null(size, __FILE__, __LINE__)
@@ -78,7 +78,7 @@ static inline void *n_malloc_null(int size, const char *file, int line)
 
 /* Delete trigger/command.
  */
-static inline void tcl_cmd_delete(tcl_cmd_t *tc)
+static void tcl_cmd_delete(tcl_cmd_t *tc)
 {
   nfree(tc->func_name);
   nfree(tc);
@@ -86,7 +86,7 @@ static inline void tcl_cmd_delete(tcl_cmd_t *tc)
 
 /* Delete bind and its elements.
  */
-static inline void tcl_bind_mask_delete(tcl_bind_mask_t *tm)
+static void tcl_bind_mask_delete(tcl_bind_mask_t *tm)
 {
   tcl_cmd_t *tc, *tc_next;
 
@@ -100,7 +100,7 @@ static inline void tcl_bind_mask_delete(tcl_bind_mask_t *tm)
 
 /* Delete bind list and its elements.
  */
-static inline void tcl_bind_list_delete(tcl_bind_list_t *tl)
+static void tcl_bind_list_delete(tcl_bind_list_t *tl)
 {
   tcl_bind_mask_t *tm, *tm_next;
 
@@ -160,7 +160,7 @@ void garbage_collect_tclhash(void)
   }
 }
 
-static inline int tcl_cmd_expmem(tcl_cmd_t *tc)
+static int tcl_cmd_expmem(tcl_cmd_t *tc)
 {
   int tot;
 
@@ -170,7 +170,7 @@ static inline int tcl_cmd_expmem(tcl_cmd_t *tc)
   return tot;
 }
 
-static inline int tcl_bind_mask_expmem(tcl_bind_mask_t *tm)
+static int tcl_bind_mask_expmem(tcl_bind_mask_t *tm)
 {
   int tot = 0;
   tcl_cmd_t *tc;
@@ -183,7 +183,7 @@ static inline int tcl_bind_mask_expmem(tcl_bind_mask_t *tm)
   return tot;
 }
 
-static inline int tcl_bind_list_expmem(tcl_bind_list_t *tl)
+static int tcl_bind_list_expmem(tcl_bind_list_t *tl)
 {
   int tot = 0;
   tcl_bind_mask_t *tm;
@@ -710,7 +710,7 @@ static int builtin_idx STDVAR
  *
  * Note: This is INLINE code for check_tcl_bind().
  */
-static inline int trigger_bind(const char *proc, const char *param,
+static int trigger_bind(const char *proc, const char *param,
                                char *mask)
 {
   int x;
@@ -762,7 +762,7 @@ static inline int trigger_bind(const char *proc, const char *param,
  *
  * Note: This is INLINE code for check_tcl_bind().
  */
-static inline int check_bind_match(const char *match, char *mask,
+static int check_bind_match(const char *match, char *mask,
                                    int match_type)
 {
   switch (match_type & 0x07) {
@@ -796,7 +796,7 @@ static inline int check_bind_match(const char *match, char *mask,
  *
  * Note: This is INLINE code for check_tcl_bind().
  */
-static inline int check_bind_flags(struct flag_record *flags,
+static int check_bind_flags(struct flag_record *flags,
                                    struct flag_record *atr, int match_type)
 {
   if (match_type & BIND_USE_ATTR) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: c89 and optimization bloat

One-line summary:
inline keyword is not c89. and as thommey put it: eggdrop will suffer 450% performance penalty due to this patch ;). no, rly, the compiler does a great job, if we let her.

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
just a quick ./eggdrop -nt, worked.