### PR TITLE
Add support links to motd

### DIFF
--- a/text/motd
+++ b/text/motd
@@ -8,6 +8,10 @@ Connected to %B, running %V
 Hey %b%N!%b  My name is %b%B%b and I am running %b%V%b, on %b%U%b.
 
 Local time is now %b%T%b
+
+Website: https://eggheads.org/
+IRC:     freenode #eggdrop
+
 %{+n}
 You are an owner of this bot. Only +n users can see this! For more info,
 see %b.help set motd%b. Please edit the %bmotd%b file in your bot's 'text'

--- a/text/motd
+++ b/text/motd
@@ -1,16 +1,15 @@
 Connected to %B, running %V
-     ____                __
-    / __/___ _ ___ _ ___/ /____ ___   ___
-   / _/ / _ `// _ `// _  // __// _ \ / _ \
-  /___/ \_, / \_, / \_,_//_/   \___// .__/
-       /___/ /___/                 /_/
+       ____                __
+      / __/___ _ ___ _ ___/ /____ ___   ___
+     / _/ / _ `// _ `// _  // __// _ \ / _ \
+    /___/ \_, / \_, / \_,_//_/   \___// .__/
+         /___/ /___/                 /_/
+-------------------------------------------------
+{ www.eggheads.org | chat.freenode.net/#eggdrop }
 
 Hey %b%N!%b  My name is %b%B%b and I am running %b%V%b, on %b%U%b.
 
 Local time is now %b%T%b
-
-Website: https://eggheads.org/
-IRC:     freenode #eggdrop
 
 %{+n}
 You are an owner of this bot. Only +n users can see this! For more info,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: enhancement

One-line summary:
see commit

Additional description (if needed):
it was my idea to add support links to eggdrop motd, like
https://github.com/freebsd/freebsd/blob/master/etc/motd
open for discussion, including reject

Test cases demonstrating functionality (if applicable):
