### PR TITLE
Fix Nullpointer warning

### DIFF
--- a/src/users.c
+++ b/src/users.c
@@ -228,8 +228,8 @@ void check_expired_ignores()
   }
 }
 
-/*        Channel mask loaded from user file. This function is
- *      add(ban|invite|exempt)_fully merged into one. <cybah>
+/* Channel mask loaded from user file. This function is
+ * add(ban|invite|exempt)_fully merged into one. <cybah>
  */
 static void addmask_fully(struct chanset_t *chan, maskrec ** m, char *mask,
                           char *from, char *note, time_t expire_time, int flags,

--- a/src/users.c
+++ b/src/users.c
@@ -231,16 +231,14 @@ void check_expired_ignores()
 /*        Channel mask loaded from user file. This function is
  *      add(ban|invite|exempt)_fully merged into one. <cybah>
  */
-static void addmask_fully(struct chanset_t *chan, maskrec ** m,
-                          maskrec ** global, char *mask, char *from, char *note,
-                          time_t expire_time, int flags, time_t added,
-                          time_t last)
+static void addmask_fully(struct chanset_t *chan, maskrec ** m, char *mask,
+                          char *from, char *note, time_t expire_time, int flags,
+                          time_t added, time_t last)
 {
   maskrec *p = user_malloc(sizeof(maskrec));
-  maskrec **u = (chan) ? m : global;
 
-  p->next = *u;
-  *u = p;
+  p->next = *m;
+  *m = p;
   p->expire = expire_time;
   p->added = added;
   p->lastactive = last;
@@ -285,7 +283,7 @@ static void restore_chanban(struct chanset_t *chan, char *host)
             if (desc) {
               *desc = 0;
               desc++;
-              addmask_fully(chan, &chan->bans, &global_bans, host, user,
+              addmask_fully(chan, chan ? &chan->bans : &global_bans, host, user,
                             desc, atoi(expi), flags, atoi(add), atoi(last));
               return;
             }
@@ -296,8 +294,8 @@ static void restore_chanban(struct chanset_t *chan, char *host)
         if (desc) {
           *desc = 0;
           desc++;
-          addmask_fully(chan, &chan->bans, &global_bans, host, add, desc,
-                        atoi(expi), flags, now, 0);
+          addmask_fully(chan, chan ? &chan->bans : &global_bans, host, add,
+                        desc, atoi(expi), flags, now, 0);
           return;
         }
       }
@@ -339,8 +337,9 @@ static void restore_chanexempt(struct chanset_t *chan, char *host)
             if (desc) {
               *desc = 0;
               desc++;
-              addmask_fully(chan, &chan->exempts, &global_exempts, host, user,
-                            desc, atoi(expi), flags, atoi(add), atoi(last));
+              addmask_fully(chan, chan ? &chan->exempts : &global_exempts, host,
+                            user, desc, atoi(expi), flags, atoi(add),
+                            atoi(last));
               return;
             }
           }
@@ -350,7 +349,7 @@ static void restore_chanexempt(struct chanset_t *chan, char *host)
         if (desc) {
           *desc = 0;
           desc++;
-          addmask_fully(chan, &chan->exempts, &global_exempts, host, add,
+          addmask_fully(chan, chan ? &chan->exempts : &global_exempts, host, add,
                         desc, atoi(expi), flags, now, 0);
           return;
         }
@@ -393,8 +392,9 @@ static void restore_chaninvite(struct chanset_t *chan, char *host)
             if (desc) {
               *desc = 0;
               desc++;
-              addmask_fully(chan, &chan->invites, &global_invites, host, user,
-                            desc, atoi(expi), flags, atoi(add), atoi(last));
+              addmask_fully(chan, chan ? &chan->invites : &global_invites, host,
+                            user, desc, atoi(expi), flags, atoi(add),
+                            atoi(last));
               return;
             }
           }
@@ -404,8 +404,8 @@ static void restore_chaninvite(struct chanset_t *chan, char *host)
         if (desc) {
           *desc = 0;
           desc++;
-          addmask_fully(chan, &chan->invites, &global_invites, host, add,
-                        desc, atoi(expi), flags, now, 0);
+          addmask_fully(chan, chan ? &chan->invites : &global_invites, host,
+                        add, desc, atoi(expi), flags, now, 0);
           return;
         }
       }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Nullpointer warning

One-line summary:
Fixes Nullpointer warning: runtime error: member access within null pointer of type 'struct chanset_t'

Additional description (if needed):
gcc

CFLAGS=-fsanitize=address,undefined                                              
                                                                                 
./eggdrop -nt                                                                    
[...]                                                                            
[00:25:20] Writing channel file...                                               
users.c:288:15: runtime error: member access within null pointer of type 'struct chanset_t'
users.c:342:15: runtime error: member access within null pointer of type 'struct chanset_t'
users.c:396:15: runtime error: member access within null pointer of type 'struct chanset_t'
[00:25:20] Userfile loaded, unpacking...                                         
[...]

it doesn't access the nullpointer, it only calculates a bogus pointer from it (NULL + offset), and gives it to the next function addmask_fully(), which skips the bogus pointer here:
maskrec **u = (chan) ? m : global;

still it confuses code analyzers and this patch changes the code to not calculate and give around bogus pointers anymore.

Test cases demonstrating functionality (if applicable):
