### PR TITLE
(Fix #504) Fix --with-sslinc --with-sslib for openssl 1.0

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1616,13 +1616,13 @@ AC_DEFUN(EGG_TLS_WITHSSL,
   [
     if test "$enable_tls" != "no"; then
       if test -d "$withval"; then
-        AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-L$withval -lcrypto])
         AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-L$withval -lssl])
+        AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-L$withval -lcrypto])
         if test "$havessllib" = "no"; then
           AC_MSG_WARN([Invalid path to OpenSSL libs. $withval doesn't contain the required files.])
         else
           AC_SUBST(SSL_LIBS, [-L$withval])
-          LDFLAGS="${LDFLAGS} $SSL_LIBS"
+          LDFLAGS="${LDFLAGS} -L$withval"
         fi
       else
         AC_MSG_WARN([You have specified an invalid path to OpenSSL libs. $withval is not a directory.])
@@ -1648,8 +1648,8 @@ AC_DEFUN([EGG_TLS_DETECT],
       ])
     fi
     if test -z "$SSL_LIBS"; then
-      AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
       AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-lssl])
+      AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
       AC_CHECK_FUNCS([EVP_md5 EVP_sha1 a2i_IPADDRESS], , [[
         havessllib="no"
         break

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1622,8 +1622,8 @@ AC_DEFUN(EGG_TLS_WITHSSL,
           AC_MSG_WARN([Invalid path to OpenSSL libs. $withval doesn't contain the required files.])
         else
           AC_SUBST(SSL_LIBS, [-L$withval])
+          LDFLAGS="${LDFLAGS} $SSL_LIBS"
         fi
-        ssllib="-L$withval"
       else
         AC_MSG_WARN([You have specified an invalid path to OpenSSL libs. $withval is not a directory.])
       fi
@@ -1638,7 +1638,6 @@ AC_DEFUN([EGG_TLS_DETECT],
 [
   tls_enabled="no"
   if test "$enable_tls" != "no"; then
-    LDFLAGS="${LDFLAGS} $ssllib"
     if test -z "$SSL_INCLUDES"; then
       AC_CHECK_HEADERS([openssl/ssl.h openssl/x509v3.h], , [havesslinc="no"], [
         #ifdef CYGWIN_HACKS

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1623,6 +1623,7 @@ AC_DEFUN(EGG_TLS_WITHSSL,
         else
           AC_SUBST(SSL_LIBS, [-L$withval])
         fi
+        ssllib="-L$withval"
       else
         AC_MSG_WARN([You have specified an invalid path to OpenSSL libs. $withval is not a directory.])
       fi
@@ -1637,6 +1638,7 @@ AC_DEFUN([EGG_TLS_DETECT],
 [
   tls_enabled="no"
   if test "$enable_tls" != "no"; then
+    LDFLAGS="${LDFLAGS} $ssllib"
     if test -z "$SSL_INCLUDES"; then
       AC_CHECK_HEADERS([openssl/ssl.h openssl/x509v3.h], , [havesslinc="no"], [
         #ifdef CYGWIN_HACKS


### PR DESCRIPTION
Found by: cpg
Patch by: michaelortmann
Fixes: #504 

One-line summary:
Fix --with-sslinc --with-sslib for openssl 1.0

Additional description (if needed):
1.
aclocal.m4 didn't really use --with-ssllib for hex_to_string/string_to_hex detection
2.
some parts of aclocal.m4 save $CC/$CPP, then set them to include $sslinc and then resets them
doing the same here doesn't help fixing the bug, because we need the ld path changed
3.
i have the feeling the rest of aclocal.m4s handling of $CC/$CPP/$sslinc/$SSL_LIB may also be broken
4.
i am no autoconf expert, but i think setting CPPFLAGS/LDFLAGS instead of $CC/$CPP should be preferred
5.
after the configure was fixed, the make failed while linking:
[...]
ssl_sess.c:(.text+0x208c): undefined reference to `ENGINE_get_ssl_client_cert_function'
[...]

reversing the order of -lcrypto -lssl fixed the make

this patch is a minimal solution for #504

Test cases demonstrating functionality (if applicable):
./configure
[...]
checking for hex_to_string... no
checking for OPENSSL_hexstr2buf... yes
checking for string_to_hex... no
checking for OPENSSL_buf2hexstr... yes
[...]
SSL/TLS Support: yes (OpenSSL 1.1.0i  14 Aug 2018)
[...]

./configure --with-sslinc=/home/michael/opt/openssl-1.0.2p/include/ --with-ssllib=/home/michael/opt/openssl-1.0.2p/lib/
[...]
checking for hex_to_string... yes
checking for string_to_hex... yes
[...]
SSL/TLS Support: yes (OpenSSL 1.0.2p  14 Aug 2018)
[...]

a tiny test compile and run was successful