### PR TITLE
Cleanup dead store / dead initialization

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -532,7 +532,6 @@ void putlog EGG_VARARGS_DEF(int, arg1)
   format = va_arg(va, char *);
 
   /* Create the timestamp */
-  t = localtime(&now2);
   if (shtime) {
     egg_strftime(stamp, sizeof(stamp) - 2, log_ts, t);
     strcat(stamp, " ");

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1245,7 +1245,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
   int i, x = 0, found, old_status = chan->status,
       old_mode_mns_prot = chan->mode_mns_prot,
       old_mode_pls_prot = chan->mode_pls_prot;
-  struct udef_struct *ul = udef;
+  struct udef_struct *ul;
   char s[121];
   char *endptr;
   module_entry *me;

--- a/src/mod/transfer.mod/transferqueue.c
+++ b/src/mod/transfer.mod/transferqueue.c
@@ -71,7 +71,7 @@ static void deq_this(fileq_t *this)
  */
 static void flush_fileq(char *to)
 {
-  fileq_t *q = fileq;
+  fileq_t *q;
   int fnd = 1;
 
   while (fnd) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: dead store / dead initialization

One-line summary:
found by clang static analyzer

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
tiny test was fine: compile, run, connect, join #test