### PR TITLE
Fix typos

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2405,7 +2405,7 @@ static void dcc_telnet_got_ident(int i, char *host)
   /* Displays a customizable banner. */
   if (use_telnet_banner)
     show_banner(i);
-  /* This is so we dont tell someone doing a portscan anything
+  /* This is so we don't tell someone doing a portscan anything
    * about ourselves. <cybah>
    */
   if (stealth_telnets)

--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -284,7 +284,7 @@ void dcc_chatter(int idx)
     if (dcc[idx].u.chat->channel == 234567) {
       /* If the chat channel has already been altered it's *highly*
        * probably join/part messages have been broadcast everywhere,
-       * so dont bother sending them
+       * so don't bother sending them
        */
       if (i == -2)
         i = 0;

--- a/src/flags.c
+++ b/src/flags.c
@@ -376,7 +376,7 @@ void break_down_flags(const char *string, struct flag_record *plus,
     else if (flags & FR_CHAN)
       mode = 1;
     else
-      return;                   /* We dont actually want any..huh? */
+      return;                   /* We don't actually want any..huh? */
   }
   egg_bzero(plus, sizeof(struct flag_record));
 
@@ -586,7 +586,7 @@ int flagrec_ok(struct flag_record *req, struct flag_record *have)
       return 1;
     return 0;
   }
-  return 0;                     /* fr0k3 binding, dont pass it */
+  return 0;                     /* fr0k3 binding, don't pass it */
 }
 
 int flagrec_eq(struct flag_record *req, struct flag_record *have)
@@ -629,7 +629,7 @@ int flagrec_eq(struct flag_record *req, struct flag_record *have)
     }
     return 0;
   }
-  return 0;                     /* fr0k3 binding, dont pass it */
+  return 0;                     /* fr0k3 binding, don't pass it */
 }
 
 void set_user_flagrec(struct userrec *u, struct flag_record *fr,

--- a/src/main.c
+++ b/src/main.c
@@ -266,7 +266,7 @@ static void write_debug()
     /* Yoicks, if we have this there's serious trouble!
      * All of these are pretty reliable, so we'll try these.
      *
-     * NOTE: dont try and display context-notes in here, it's
+     * NOTE: don't try and display context-notes in here, it's
      *       _not_ safe <cybah>
      */
     x = creat("DEBUG.DEBUG", 0644);

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1618,7 +1618,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
     }
   }
   /* If protect_readonly == 0 and chan_hack == 0 then
-   * bot is now processing the configfile, so dont do anything,
+   * bot is now processing the configfile, so don't do anything,
    * we've to wait the channelfile that maybe override these settings
    * (note: it may cause problems if there is no chanfile!)
    * <drummer/1999/10/21>

--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -962,7 +962,7 @@ static void cmd_mkdir(int idx, char *par)
     flags = newsplit(&par);
     chan = newsplit(&par);
     if (!chan[0] && flags[0] && (strchr(CHANMETA, flags[0]) != NULL)) {
-      /* Need some extra checking here to makesure we dont mix up
+      /* Need some extra checking here to make sure we don't mix up
        * the flags with a +channel. <cybah>
        */
       if (!findchan(flags) && flags[0] != '+') {

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -1018,7 +1018,7 @@ char *filesys_start(Function *global_funcs)
   my_memcpy(&USERENTRY_DCCDIR, &USERENTRY_INFO,
             sizeof(struct user_entry_type) - sizeof(char *));
 
-  USERENTRY_DCCDIR.got_share = 0;       /* We dont want it shared tho */
+  USERENTRY_DCCDIR.got_share = 0;       /* We don't want it shared tho */
   add_entry_type(&USERENTRY_DCCDIR);
   DCC_FILES_PASS.timeout_val = &password_timeout;
   add_lang_section("filesys");

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1680,7 +1680,7 @@ static int gotjoin(char *from, char *chname)
   if (!chan && chname[0] == '!') {
     /* As this is a !channel, we need to search for it by display (short)
      * name now. This will happen when we initially join the channel, as we
-     * dont know the unique channel name that the server has made up. <cybah>
+     * don't know the unique channel name that the server has made up. <cybah>
      */
     int l_chname = strlen(chname);
 
@@ -1712,7 +1712,7 @@ static int gotjoin(char *from, char *chname)
     }
   } else if (!chan) {
     /* As this is not a !chan, we need to search for it by display name now.
-     * Unlike !chan's, we dont need to remove the unique part.
+     * Unlike !chan's, we don't need to remove the unique part.
      */
     chan = findchan_by_dname(chname);
   }

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -101,9 +101,9 @@ static void flush_mode(struct chanset_t *chan, int pri)
     nfree(chan->key), chan->key = NULL;
   }
 
-  /* max +l is signed 2^32 on IRCnet at least... so makesure we've got at least
+  /* max +l is signed 2^32 on IRCnet at least... so make sure we've got at least
    * a 13 char buffer for '-2147483647 \0'. We'll be overwriting the existing
-   * terminating null in 'post', so makesure postsize >= 12.
+   * terminating null in 'post', so make sure postsize >= 12.
    */
   if (chan->limit != 0 && postsize >= 12) {
     if (plus != 1) {

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -297,7 +297,7 @@ static int tcl_do_console(Tcl_Interp *irp, ClientData cd, int argc,
     if (argv[arg][0] && !reset && ((strchr(CHANMETA, argv[arg][0]) 
         != NULL) || (argv[arg][0] == '*'))) {
       if ((argv[arg][0] != '*') && (!findchan_by_dname(argv[arg]))) {
-        /* If we dont find the channel, and it starts with a +, assume it
+        /* If we don't find the channel, and it starts with a +, assume it
          * should be the console flags to set. */
         if (argv[arg][0] == '+')
           goto do_console_flags;

--- a/src/userent.c
+++ b/src/userent.c
@@ -366,7 +366,7 @@ static int laston_set(struct userrec *u, struct user_entry *e, void *buf)
 
     li = e->u.extra = buf;
   }
-  /* donut share laston info */
+  /* don't share laston info */
   return 1;
 }
 

--- a/src/userent.c
+++ b/src/userent.c
@@ -366,7 +366,7 @@ static int laston_set(struct userrec *u, struct user_entry *e, void *buf)
 
     li = e->u.extra = buf;
   }
-  /* don't share laston info */
+  /* donut share laston info */
   return 1;
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: typos

One-line summary:
Fix typos

Additional description (if needed):

makesure -> make sure
dont -> don't
donut -> don't

Test cases demonstrating functionality (if applicable):
quick compile, run test was fine.