### PR TITLE
(Fix #601) - Beware of SizeofPtr bug

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1036,12 +1036,12 @@ static void next_server(int *ptr, char *serv, unsigned int *port, char *pass)
         if (!egg_strcasecmp(x->name, serv)) {
           *ptr = i;
 #ifdef TLS
-            x->ssl = use_ssl;
+          x->ssl = use_ssl;
 #endif
           return;
         } else if (x->realname && !egg_strcasecmp(x->realname, serv)) {
           *ptr = i;
-          strncpyz(serv, x->realname, sizeof serv);
+          strncpyz(serv, x->realname, UHOSTLEN);
 #ifdef TLS
           use_ssl = x->ssl;
 #endif


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #601

One-line summary:
Fixes a string truncation for .jump realname

Additional description (if needed):
ugly, but no security risk

Test cases demonstrating functionality (if applicable):

before:

.jump zen.localdomain 6667
[14:55:53] #-HQ# jump zen.localdomain 6667
[14:55:54] Trying server [zen.loc]:6667

after:

.jump zen.localdomain 6667
[15:37:16] #-HQ# jump zen.localdomain 6667 
[15:37:17] Trying server [zen.localdomain]:6667
