### PR TITLE
(Help #174) Help with dns.mod netbsd problem

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -810,6 +810,11 @@ AC_DEFUN([EGG_CHECK_OS],
       # FreeBSD/OpenBSD/NetBSD
       SHLIB_CC="$CC -fPIC"
       SHLIB_LD="$CC -shared"
+      case "$egg_cv_var_system_type" in
+        *NetBSD)
+          AC_DEFINE(NETBSD_HACKS, 1, [Define if running under NetBSD.])
+        ;;
+      esac
     ;;
     Darwin)
       # Mac OS X

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1274,6 +1274,13 @@ static int init_dns_core(void)
 
   /* Initialise the resolv library. */
   res_init();
+  #ifdef NETBSD_HACKS
+    puts("netbsd found. if eggdrop crashes with\n"
+         "  _res is not supported for multi-threaded programs.\n"
+         "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
+         "dns.mod must be disabled by commenting out in eggdrop.conf\n"
+         "  #loadmodule dns"
+  #endif
   _res.options |= RES_RECURSE | RES_DEFNAMES | RES_DNSRCH;
   for (i = 0; i < _res.nscount; i++)
     _res.nsaddr_list[i].sin_family = AF_INET;

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1279,7 +1279,7 @@ static int init_dns_core(void)
          "  _res is not supported for multi-threaded programs.\n"
          "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
          "dns.mod must be disabled by commenting out in eggdrop.conf\n"
-         "  #loadmodule dns"
+         "  #loadmodule dns");
   #endif
   _res.options |= RES_RECURSE | RES_DEFNAMES | RES_DNSRCH;
   for (i = 0; i < _res.nscount; i++)


### PR DESCRIPTION
Found by: fhorst
Patch by: michaelortmann
Fixes: doesnt fix, but helps with #174 

One-line summary:
if eggdrop finds netbsd it will aid the user in fixing a problem with dns.mod and netbsd, see Test case

Additional description (if needed):
**when merging, please run misc/runautotools**

Test cases demonstrating functionality (if applicable):

**before (netbsd 6.1.5):**

```
Eggdrop v1.8.3+acupdates (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[20:06:27] --- Loading eggdrop v1.8.3+acupdates (Mon Sep 3 2018)
[20:06:27] Listening for telnet connections on 0.0.0.0:2513 (all).
[20:06:27] Module loaded: blowfish
_res is not supported for multi-threaded programs.
[1] Abort trap (core dumped) ./eggdrop -nt
```

**after (netbsd 6.1.5):**

```
netbsd$ ./eggdrop -nt
Eggdrop v1.8.3+acupdates (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[22:06:08] --- Loading eggdrop v1.8.3+acupdates (Mon Sep  3 2018)
[22:06:08] Listening for telnet connections on 0.0.0.0:2513 (all).
[22:06:08] Module loaded: blowfish        
netbsd found. if eggdrop crashes with
  _res is not supported for multi-threaded programs.
  [1]   Abort trap (core dumped) ./eggdrop -nt
dns.mod must be disabled by commenting out in eggdrop.conf
  #loadmodule dns
_res is not supported for multi-threaded programs.
[1]   Abort trap (core dumped) ./eggdrop -nt
```

**after (linux):**

```
Eggdrop v1.8.3+acupdates (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[23:51:31] --- Loading eggdrop v1.8.3+acupdates (Mon Sep  3 2018)
[23:51:31] Listening for telnet connections on 0.0.0.0:2513 (all).
[23:51:31] Module loaded: blowfish        
[23:51:31] Module loaded: dns             
[23:51:31] Module loaded: channels
[...]
```

nothing changed, running fine, as expected