### PR TITLE
(Fix #607) Enhance stealth-telnets with new eggdrop.conf variable "stealth-prompt"

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -351,7 +351,7 @@ set stealth-telnets 0
 # If stealth-telnets is 1, the string in this setting will replace the
 # traditional Eggdrop banner. Two common choices are listed.
 #set stealth-prompt "login: "
-set stealth-prompt ""\n\nNickname.\n
+set stealth-prompt "\n\nNickname.\n"
 
 # If you want Eggdrop to display a banner when telneting in, set this setting
 # to 1. The telnet banner is set by 'set telnet-banner'.

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -349,7 +349,9 @@ set open-telnets 0
 set stealth-telnets 0
 
 # If stealth-telnets is 1, the string in this setting will replace the
-# traditional Eggdrop banner. Two common choices are listed.
+# traditional Eggdrop banner. Two common choices are listed. (The \n's are
+# present to maintain backwards compatibility and will be removed in a
+# future release)
 #set stealth-prompt "login: "
 set stealth-prompt "\n\nNickname.\n"
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -351,7 +351,7 @@ set stealth-telnets 0
 # If stealth-telnets is 1, the string in this setting will replace the
 # traditional Eggdrop banner. Two common choices are listed.
 #set stealth-prompt "login: "
-#set stealth-prompt "Nickname: "
+set stealth-prompt ""\n\nNickname.\n
 
 # If you want Eggdrop to display a banner when telneting in, set this setting
 # to 1. The telnet banner is set by 'set telnet-banner'.

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -344,15 +344,18 @@ set require-p 1
 set open-telnets 0
 
 # If you don't want Eggdrop to identify itself as an eggdrop on a telnet
-# connection, set this setting to 1. Eggdrop will display 'Nickname' instead.
+# connection, set this setting to 1. Eggdrop will display a logon prompt with
+# only the contents of the stealth-prompt setting.
 set stealth-telnets 0
+
+# If stealth-telnets is 1, the string in this setting will replace the
+# traditional Eggdrop traditional banner. Two common choices are listed.
+# set stealth-prompt "login: "
+set stealth-prompt "Nickname: "
 
 # If you want Eggdrop to display a banner when telneting in, set this setting
 # to 1. The telnet banner is set by 'set telnet-banner'.
 set use-telnet-banner 0
-
-# If stealth-telnets is 1, this setting will define the telnet prompt.
-set stealth-prompt "login: "
 
 # This setting defines a time in seconds that the bot should wait before
 # a dcc chat, telnet, or relay connection times out.

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -351,6 +351,7 @@ set stealth-telnets 0
 # to 1. The telnet banner is set by 'set telnet-banner'.
 set use-telnet-banner 0
 
+# If stealth-telnets is 1, this setting will define the telnet prompt.
 set stealth-prompt "login: "
 
 # This setting defines a time in seconds that the bot should wait before

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -351,6 +351,8 @@ set stealth-telnets 0
 # to 1. The telnet banner is set by 'set telnet-banner'.
 set use-telnet-banner 0
 
+set stealth-prompt "login: "
+
 # This setting defines a time in seconds that the bot should wait before
 # a dcc chat, telnet, or relay connection times out.
 set connect-timeout 15

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -349,9 +349,9 @@ set open-telnets 0
 set stealth-telnets 0
 
 # If stealth-telnets is 1, the string in this setting will replace the
-# traditional Eggdrop traditional banner. Two common choices are listed.
-# set stealth-prompt "login: "
-set stealth-prompt "Nickname: "
+# traditional Eggdrop banner. Two common choices are listed.
+#set stealth-prompt "login: "
+#set stealth-prompt "Nickname: "
 
 # If you want Eggdrop to display a banner when telneting in, set this setting
 # to 1. The telnet banner is set by 'set telnet-banner'.

--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -127,7 +127,7 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0x53c,Brugerfil mangler!
 0x53e,%B  (%E)\n\nSkriv venligst dit nick.\n
 0x53f,Skifter logfil %s, over max-logsize (%d)
-0x540,\nNick.\n
+# 0x540  unused / ubrugt
 0x541,Sidste besked gentaget %d gange\n
 0x542,juped
 0x543,Ingen ledige sockets tilgængelig.

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -127,7 +127,7 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0x53c,User file is missing!
 0x53e,%B  (%E)\n\nPlease enter your nickname.\n
 0x53f,Cycling logfile %s, over max-logsize (%d)
-0x540,\nNickname.\n
+# 0x540 - unused
 0x541,Last message repeated %d time(s).\n
 0x542,juped
 0x543,No free sockets available.

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -127,7 +127,7 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0x53c,Käyttäjätiedosto hukassa!
 0x53e,%B  (%E)\n\nSyötä tähän sinun nickkisi.\n
 0x53f,Kierrätetään logitiedostoa %s, maksimi-logikoko (%d)
-0x540,\nNickki.\n
+# 0x540 - unused / käyttämätön
 0x541,Viimeinen viesti toistettu %d aika(a).\n
 0x542,juped
 0x543,Ei vapaita kohtia saatavilla.

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -128,7 +128,7 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x53c,La liste utilisateurs est innexistante!
 0x53e,%B  (%E)\n\nEntrez votre surnom.\n
 0x53f,Rotation du fichier log %s, taille maximale depassée (%d)
-0x540,\nSurnom.\n
+# 0x540 - unused / inutilisé
 0x541,Dernier message repété %d fois.\n
 0x542,bloqué
 0x543,No free sockets available.

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -135,7 +135,7 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0x53c,Benutzerdatei fehlt!
 0x53e,%B  (%E)\n\nBitte gib Deinen Nickname ein:\n
 0x53f,Rotiere Logdatei %s da groesser als max-logsize (%d)
-0x540,\nNickname.\n
+# 0x540 - unused / Unbenutzt
 0x541,Die letzte Meldung wiederholte sich %d mal.\n
 0x543,Keine freien Sockets verfuegbar.
 0x544,Tcl version:

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -127,7 +127,7 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0x53c,Ficheiro de utilizador em falta!
 0x53e,%B (%E)\n\nPor favor introduza o seu nick.\n
 0x53f,Rodando ficheiro de log %s, acima do máximo do tamanho (%d)
-0x540,\nNick.\n
+# 0x540 - unused / não utilizado
 0x541,Ultima mensagem repetida %d vez(s).\n
 0x542,bloqueado
 0x543,Sem sockets livres disponíveis.

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -65,11 +65,11 @@ int protect_telnet = 1;         /* Even bother with ident lookups :)          */
 int flood_telnet_thr = 5;       /* Number of telnet connections to be
                                  * considered a flood                         */
 int flood_telnet_time = 60;     /* In how many seconds?                       */
-char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
-char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
-char stealth_prompt[81] = "login: ";   /* If stealth-telnets is 1, this
-                                        * setting will define the telnet
-                                        * prompt.                             */
+char network[41] = "unknown-net";       /* Name of the IRC network you're on  */
+char bannerfile[121] = "text/banner";   /* File displayed on telnet login     */
+char stealth_prompt[81] = "Nickname: "; /* If stealth-telnets is 1, this
+                                         * setting will define the telnet
+                                         * prompt.                            */
 
 static void dcc_telnet_hostresolved(int);
 static void dcc_telnet_got_ident(int, char *);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -141,8 +141,9 @@ static void strip_telnet(int sock, char *buf, int *len)
           safe_write(sock, p + 1, 1);
         }
       } else if (*p == TLN_AYT) {
-        /* When we get an AYT (Are You There) just send back "[Yes]". */
-        static unsigned char sb[] = "\r\n[Yes]\r\n";
+        /* "Are You There?" */
+        /* response is: "Hell, yes!" */
+        static unsigned char sb[] = "\r\n[Hell, yes!]\r\n";
         safe_write(sock, sb, sizeof sb);
       } else if (*p == TLN_IAC) {
         /* IAC character in data, escaped with another IAC */

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -67,6 +67,7 @@ int flood_telnet_thr = 5;       /* Number of telnet connections to be
 int flood_telnet_time = 60;     /* In how many seconds?                       */
 char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
 char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
+char stealth_prompt[121] = "login: ";
 
 static void dcc_telnet_hostresolved(int);
 static void dcc_telnet_got_ident(int, char *);
@@ -2409,7 +2410,7 @@ static void dcc_telnet_got_ident(int i, char *host)
    * about ourselves. <cybah>
    */
   if (stealth_telnets)
-    sub_lang(i, MISC_BANNER_STEALTH);
+    dprintf(i, stealth_prompt);
   else {
     dprintf(i, "\n\n");
     sub_lang(i, MISC_BANNER);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -67,8 +67,7 @@ int flood_telnet_thr = 5;       /* Number of telnet connections to be
 int flood_telnet_time = 60;     /* In how many seconds?                       */
 char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
 char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
-/* If stealth-telnets is 1, this setting will define the telnet prompt. */
-char stealth_prompt[81] = "\n\nNickname.\n";
+char stealth_prompt[81] = "\n\nNickname.\n"; /* stealth_telnet prompt string  */
 
 static void dcc_telnet_hostresolved(int);
 static void dcc_telnet_got_ident(int, char *);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -65,11 +65,10 @@ int protect_telnet = 1;         /* Even bother with ident lookups :)          */
 int flood_telnet_thr = 5;       /* Number of telnet connections to be
                                  * considered a flood                         */
 int flood_telnet_time = 60;     /* In how many seconds?                       */
-char network[41] = "unknown-net";       /* Name of the IRC network you're on  */
-char bannerfile[121] = "text/banner";   /* File displayed on telnet login     */
-char stealth_prompt[81] = "Nickname: "; /* If stealth-telnets is 1, this
-                                         * setting will define the telnet
-                                         * prompt.                            */
+char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
+char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
+/* If stealth-telnets is 1, this setting will define the telnetprompt. */
+char stealth_prompt[81] = "\n\nNickname.\n";
 
 static void dcc_telnet_hostresolved(int);
 static void dcc_telnet_got_ident(int, char *);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -139,9 +139,9 @@ static void strip_telnet(int sock, char *buf, int *len)
           safe_write(sock, p + 1, 1);
         }
       } else if (*p == TLN_AYT) {
-        /* "Are You There?" */
-        /* response is: "Hell, yes!" */
-        safe_write(sock, "\r\nHell, yes!\r\n", 14);
+        /* When we get an AYT (Are You There) just send back "[Yes]". */
+        static unsigned char sb[] = "\r\n[Yes]\r\n";
+        safe_write(sock, sb, sizeof sb);
       } else if (*p == TLN_IAC) {
         /* IAC character in data, escaped with another IAC */
         *o++ = *p++;

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2391,7 +2391,7 @@ static void dcc_telnet_got_ident(int i, char *host)
   /* Note: we don't really care about telnet status here. We use the
    * STATUS option as a hopefully harmless way to detect if the other
    * side is a telnet client or not. */
-  dprintf(i, TLN_IAC_C TLN_WILL_C TLN_STATUS_C "\n");
+  dprintf(i, TLN_IAC_C TLN_WILL_C TLN_STATUS_C);
 
   /* Copy acceptable-nick/host mask */
   dcc[i].status = STAT_TELNET | STAT_ECHO;

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -67,7 +67,7 @@ int flood_telnet_thr = 5;       /* Number of telnet connections to be
 int flood_telnet_time = 60;     /* In how many seconds?                       */
 char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
 char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
-char stealth_prompt[121] = "login: ";  /* If stealth-telnets is 1, this
+char stealth_prompt[81] = "login: ";   /* If stealth-telnets is 1, this
                                         * setting will define the telnet
                                         * prompt.                             */
 

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -67,7 +67,9 @@ int flood_telnet_thr = 5;       /* Number of telnet connections to be
 int flood_telnet_time = 60;     /* In how many seconds?                       */
 char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
 char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
-char stealth_prompt[121] = "login: ";
+char stealth_prompt[121] = "login: ";  /* If stealth-telnets is 1, this
+                                        * setting will define the telnet
+                                        * prompt.                             */
 
 static void dcc_telnet_hostresolved(int);
 static void dcc_telnet_got_ident(int, char *);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -67,7 +67,7 @@ int flood_telnet_thr = 5;       /* Number of telnet connections to be
 int flood_telnet_time = 60;     /* In how many seconds?                       */
 char network[41] = "unknown-net";      /* Name of the IRC network you're on   */
 char bannerfile[121] = "text/banner";  /* File displayed on telnet login      */
-/* If stealth-telnets is 1, this setting will define the telnetprompt. */
+/* If stealth-telnets is 1, this setting will define the telnet prompt. */
 char stealth_prompt[81] = "\n\nNickname.\n";
 
 static void dcc_telnet_hostresolved(int);

--- a/src/lang.h
+++ b/src/lang.h
@@ -117,7 +117,7 @@
 /* was: MISC_BOTSCONNECTED      0x53d            */
 #define MISC_BANNER             get_language(0x53e)
 #define MISC_CLOGS              get_language(0x53f)
-#define MISC_BANNER_STEALTH     get_language(0x540)
+/* was: MISC_BANNER_STEALTH     0x540            */
 #define MISC_LOGREPEAT          get_language(0x541)
 #define MISC_JUPED              get_language(0x542)
 #define MISC_NOFREESOCK         get_language(0x543)

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -47,7 +47,7 @@ extern char origbotname[], botuser[], motdfile[], admin[], userfile[],
             firewall[], helpdir[], notify_new[], vhost[], moddir[], owner[],
             network[], botnetnick[], bannerfile[], egg_version[], natip[],
             configfile[], logfile_suffix[], log_ts[], textdir[], pid_file[],
-            listen_ip[];
+            listen_ip[], stealth_prompt[];
 
 
 extern int flood_telnet_thr, flood_telnet_time, shtime, share_greet,
@@ -404,6 +404,7 @@ static tcl_strings def_tcl_strings[] = {
   {"timestamp-format",log_ts,         32,                      0},
   {"pidfile",         pid_file,       120,           STR_PROTECT},
   {"configureargs",   EGG_AC_ARGS,    0,             STR_PROTECT},
+  {"stealth-prompt",  stealth_prompt, 120,           STR_PROTECT},
   {NULL,              NULL,           0,                       0}
 };
 

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -404,7 +404,7 @@ static tcl_strings def_tcl_strings[] = {
   {"timestamp-format",log_ts,         32,                      0},
   {"pidfile",         pid_file,       120,           STR_PROTECT},
   {"configureargs",   EGG_AC_ARGS,    0,             STR_PROTECT},
-  {"stealth-prompt",  stealth_prompt, 120,           STR_PROTECT},
+  {"stealth-prompt",  stealth_prompt, 80,                      0},
   {NULL,              NULL,           0,                       0}
 };
 


### PR DESCRIPTION
Found by:
(1) and (2) of Additional description found by **jack3** and **simple**
(3) and (4) of Additional description found by michaelortmann
Patch by: michaelortmann
Fixes: #607 

**One-line summary:**
Enhance stealth-telnets with new eggdrop.conf variable "stealth-prompt"

**Additional description (if needed):**

1. added a new eggdrop.conf variable "stealth-prompt" with documentation and example(s)

2. ripped out language 0x540, because it was replaced by this new variable.

3. tiny change to eggdrop's response to telnet control function ayt (are you there). Hell, yes -> [Hell, yes]. the code was made more robust, the size of that string is now handled dynamically. eggdrop's response to telnet control functions is undocumented and therefore backward compatibility does not matter here.

4. eggdrop was printing an unnecessary \n before telnet banner and/or prompt. this \n was ripped out to mimic a normal telnetd server.

5. set stealth-prompt "\n\nNickname.\n" == 100% traditional eggdrop behaviour, every \n is fine.

**Test cases demonstrating functionality (if applicable):**

before patch (branch develop):

eggdrop.conf: set stealth-telnets 1

```
$ telnet 127.0.0.1 2513
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.


Nickname.
^]
telnet> send ayt


Hell, yes!
```

after patch (branch telnet):

eggdrop.conf: set stealth-telnets 1

```
$ telnet 127.0.0.1 2513
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.


Nickname.
^]
telnet> send ayt


[Hell, yes!]
```

after patch (branch telnet):

eggdrop.conf: set stealth-telnets 1
eggdrop.conf: set stealth-prompt "login: "

```
$ telnet 127.0.0.1 2513
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
login: 
```