### PR TITLE
Fix mmap() return value handling (Silence Sun C compiler warning)

### DIFF
--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -200,7 +200,7 @@ static int compress_to_file_mmap(gzFile fout, FILE *fin)
 
   /* mmap file contents to memory */
   buf = mmap(0, st.st_size, PROT_READ, MAP_SHARED, ifd, 0);
-  if (buf < 0)
+  if (buf == MAP_FAILED)
     return COMPF_ERROR;
 
   /* Compress the whole file in one go */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes:

One-line summary:
Fix mmap() return value handling

Additional description (if needed):
Found under SunOS 5.11 with Sun C 5.13

Test cases demonstrating functionality (if applicable):
compiling eggdrop under SunOS with Sun C compiler shows the following warning:
".././compress.mod/compress.c", line 203: warning: improper pointer/integer combination: op "<"
this patch silences this warning
i also did a tiny compile/run test which was fine.