### PR TITLE
(Cleanup) Delete unused functions

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -139,16 +139,6 @@ void null_func()
 {
 }
 
-char *charp_func()
-{
-  return NULL;
-}
-
-int minus_func()
-{
-  return -1;
-}
-
 int false_func()
 {
   return 0;
@@ -1141,21 +1131,6 @@ void del_hook(int hook_num, Function func)
         dns_ipbyhost = block_dns_ipbyhost;
       break;
     }
-}
-
-int call_hook_cccc(int hooknum, char *a, char *b, char *c, char *d)
-{
-  struct hook_entry *p, *pn;
-  int f = 0;
-
-  if (hooknum >= REAL_HOOKS)
-    return 0;
-  p = hook_list[hooknum];
-  for (p = hook_list[hooknum]; p && !f; p = pn) {
-    pn = p->next;
-    f = p->func(a, b, c, d);
-  }
-  return f;
 }
 
 void do_module_report(int idx, int details, char *which)

--- a/src/modules.h
+++ b/src/modules.h
@@ -61,8 +61,6 @@ extern struct hook_entry {
         }                                                       \
 } while (0)
 
-int call_hook_cccc(int, char *, char *, char *, char *);
-
 #endif
 
 typedef struct _dependancy {

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -328,14 +328,6 @@ void rem_tcl_commands(tcl_cmds *table)
     Tcl_DeleteCommand(interp, table[i].name);
 }
 
-void rem_cd_tcl_cmds(cd_tcl_cmd *table)
-{
-  while (table->name) {
-    Tcl_DeleteCommand(interp, table->name);
-    table++;
-  }
-}
-
 void add_tcl_objcommands(tcl_cmds *table)
 {
   int i;

--- a/src/tclegg.h
+++ b/src/tclegg.h
@@ -169,7 +169,6 @@ typedef struct _cd_tcl_cmd {
 void add_tcl_commands(tcl_cmds *);
 void add_cd_tcl_cmds(cd_tcl_cmd *);
 void rem_tcl_commands(tcl_cmds *);
-void rem_cd_tcl_cmds(cd_tcl_cmd *);
 void add_tcl_strings(tcl_strings *);
 void rem_tcl_strings(tcl_strings *);
 void add_tcl_coups(tcl_coups *);

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -340,20 +340,6 @@ struct userrec *get_user_by_host(char *host)
   return ret;
 }
 
-/* use fixfrom() or dont? (drummer)
- */
-struct userrec *get_user_by_equal_host(char *host)
-{
-  struct userrec *u;
-  struct list_type *q;
-
-  for (u = userlist; u; u = u->next)
-    for (q = get_user(&USERENTRY_HOSTS, u); q; q = q->next)
-      if (!rfc_casecmp(q->extra, host))
-        return u;
-  return NULL;
-}
-
 /* Try: pass_match_by_host("-",host)
  * If a '-' is sent as the password, it denotes the intent
  *   to merely check if a password is set for that user.

--- a/src/users.c
+++ b/src/users.c
@@ -60,20 +60,6 @@ int match_ignore(char *uhost)
   return 0;
 }
 
-int equals_ignore(char *uhost)
-{
-  struct igrec *u = global_ign;
-
-  for (; u; u = u->next)
-    if (!rfc_casecmp(u->igmask, uhost)) {
-      if (u->flags & IGREC_PERM)
-        return 2;
-      else
-        return 1;
-    }
-  return 0;
-}
-
 int delignore(char *ign)
 {
   int i, j;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Delete unused functions

Additional description (if needed):
charp_func()
minus_func()
call_hook_cccc()
rem_cd_tcl_cmds()
get_user_by_equal_host()
equals_ignore()

Test cases demonstrating functionality (if applicable):