### PR TITLE
Fix ancient misc.c:putlog() bug / Fix dead increment

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -630,7 +630,7 @@ void putlog EGG_VARARGS_DEF(int, arg1)
   else if ((type & LOG_MISC) && use_stderr) {
     if (shtime)
       out += tsl;
-    dprintf(DP_STDERR, "%s", s);
+    dprintf(DP_STDERR, "%s", out);
   }
   va_end(va);
 }

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -678,7 +678,7 @@ static void channels_report(int idx, int details)
       if (channel_inactive(chan))
         i += my_strcpy(s + i, "inactive ");
       if (channel_nodesynch(chan))
-        i += my_strcpy(s + i, "nodesynch ");
+        my_strcpy(s + i, "nodesynch ");
 
       dprintf(idx, "      Options: %s\n", s);
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix misc.c:putlog() for foreground/LOG_MISC/use_stderr to not output timestamp and fix a dead increment in channels.c

Additional description (if needed):
There was a dead increment in misc.c:putlog() and in channels.c
The channels.c one could easily be resolved by deleting it
But the putlog() one looked like the original coder's intention was to output without timestamp for some case.
This case is when eggdrop is foreground (./eggdrop -nt) and output is LOG_MISC and use_stderr is set (This is the case for the start of eggdrop until a certain point.)
So i didnt remove the dead increment, but Fixed the original error.
The difference in output is shown below in "Test cases"...

Test cases demonstrating functionality (if applicable):

before:

```
$ ./eggdrop -nt

Eggdrop v1.8.3+acupdates (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[16:20:09] --- Loading eggdrop v1.8.3+acupdates (Tue Sep 11 2018)
[16:20:09] Listening for telnet connections on 0.0.0.0:2513 (all).
[16:20:09] Module loaded: blowfish        
[16:20:09] Module loaded: dns             
[16:20:09] Module loaded: channels        
[16:20:09] Module loaded: server          
[16:20:09] Module loaded: ctcp            
[16:20:09] Module loaded: irc             
[16:20:09] Module loaded: transfer         (with lang support)
[16:20:09] Module loaded: share           
[16:20:09] Module loaded: compress        
[16:20:09] Module loaded: filesys          (with lang support)
[16:20:09] Module loaded: notes            (with lang support)
[16:20:09] Module loaded: console          (with lang support)
[16:20:09] Module loaded: seen            
[16:20:09] Module loaded: assoc            (with lang support)
[16:20:09] Writing channel file...
[16:20:09] Userfile loaded, unpacking...
[16:20:09] === linux: 0 channels, 12 users.

### ENTERING DCC CHAT SIMULATION ###
[...]
```

after:

```
$ ./eggdrop -nt eggdrop.conf

Eggdrop v1.8.3+acupdates (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
--- Loading eggdrop v1.8.3+acupdates (Tue Sep 11 2018)
Listening for telnet connections on 0.0.0.0:2513 (all).
Module loaded: blowfish        
Module loaded: dns             
Module loaded: channels        
Module loaded: server          
Module loaded: ctcp            
Module loaded: irc             
Module loaded: transfer         (with lang support)
Module loaded: share           
Module loaded: compress        
Module loaded: filesys          (with lang support)
Module loaded: notes            (with lang support)
Module loaded: console          (with lang support)
Module loaded: seen            
Module loaded: assoc            (with lang support)
Writing channel file...
Userfile loaded, unpacking...
=== linux: 0 channels, 12 users.

### ENTERING DCC CHAT SIMULATION ###
[...]
```