### PR TITLE
Fix format compiler warning in dns.c

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -62,7 +62,7 @@ void eof_dcc_dnswait(int idx)
 
 static void display_dcc_dnswait(int idx, char *buf)
 {
-  sprintf(buf, "dns   waited %lis", (long) now - dcc[idx].timeval);
+  sprintf(buf, "dns   waited %lis", (long) (now - dcc[idx].timeval));
 }
 
 static int expmem_dcc_dnswait(void *x)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format compiler warning in dns.c

Additional description (if needed):
Found with OpenBSD 6.3 / gcc 4.2.1 20070719

Fixes commit https://github.com/eggheads/eggdrop/commit/fef45d9ef321a53aa4655040439a2ba4fbd4eadf#diff-b2ddf457bc423779995466f7d8b9d147

Test cases demonstrating functionality (if applicable):

under openbsd 6.3 / gcc 4.2.1 20070719:
$ make

before:

```
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c dns.c
dns.c: In function 'display_dcc_dnswait':
dns.c:65: warning: format '%li' expects type 'long int', but argument 3 has type 'long long int'
[...]
```

after: clean