### PR TITLE
Fix parentheses-equality compiler warning in server.c

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1691,15 +1691,12 @@ static void server_postrehash()
   strncpyz(botname, origbotname, NICKLEN);
   if (!botname[0])
     fatal("NO BOT NAME.", 0);
-  if ((serverlist == NULL)
 #ifndef TLS
-  && (sslserver)) {
+  if ((serverlist == NULL) && sslserver)
     fatal("NO NON-SSL SERVERS ADDED (TLS IS DISABLED).", 0);
-  } else if (serverlist == NULL
 #endif
-  ) {
+  if (serverlist == NULL)
     fatal("NO SERVERS ADDED.", 0);
-  }
   if (oldnick[0] && !rfc_casecmp(oldnick, botname) &&
       !rfc_casecmp(oldnick, get_altbotnick())) {
     /* Change botname back, don't be premature. */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix parentheses-equality compiler warning in server.c

Additional description (if needed):

Found with FreeBSD 11.2 / clang 6.0.1

Fix commit https://github.com/eggheads/eggdrop/commit/b2789f3c4aee584395af952549c552756beb8dfa#diff-2dcc2e1dfabc93d976b9ab85e3b9f41f

Test cases demonstrating functionality (if applicable):

under FreeBSD 11.2 / clang 6.0.1
$ make

before:

```
[...]
cc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
.././server.mod/server.c:1694:19: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  if ((serverlist == NULL)
       ~~~~~~~~~~~^~~~~~~
.././server.mod/server.c:1694:19: note: remove extraneous parentheses around the comparison to silence this warning
  if ((serverlist == NULL)
      ~           ^      ~
.././server.mod/server.c:1694:19: note: use '=' to turn this equality comparison into an assignment
  if ((serverlist == NULL)
                  ^~
                  =
1 warning generated.
[...]
```

after: clean