### PR TITLE
(Fix #94) Fix nickchange mode tracking

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -755,7 +755,6 @@ static void check_this_member(struct chanset_t *chan, char *nick,
   if (!m || match_my_nick(nick) || (!me_op(chan) && !me_halfop(chan)))
     return;
 
-
 #ifdef NO_HALFOP_CHANMODES
   if (me_op(chan)) {
 #else
@@ -764,14 +763,16 @@ static void check_this_member(struct chanset_t *chan, char *nick,
     if (HALFOP_CANDOMODE('o')) {
       if (chan_hasop(m) && ((chan_deop(*fr) || (glob_deop(*fr) &&
           !chan_op(*fr))) || (channel_bitch(chan) && (!chan_op(*fr) &&
-          !(glob_op(*fr) && !chan_deop(*fr)))))) {
+          !(glob_op(*fr) && !chan_deop(*fr))))) && !chan_stopcheck(m)) {
         add_mode(chan, '-', 'o', m->nick);
       }
       if (!chan_hasop(m) && (chan_op(*fr) || (glob_op(*fr) &&
           !chan_deop(*fr))) && (channel_autoop(chan) || glob_autoop(*fr) ||
           chan_autoop(*fr))) {
-        if (!chan->aop_min)
-          add_mode(chan, '+', 'o', m->nick);
+        if (!chan->aop_min) {
+          if (!chan_stopcheck(m))
+            add_mode(chan, '+', 'o', m->nick);
+        }
         else {
           set_delay(chan, m->nick);
           m->flags |= SENTOP;
@@ -782,14 +783,16 @@ static void check_this_member(struct chanset_t *chan, char *nick,
     if (HALFOP_CANDOMODE('h')) {
       if (chan_hashalfop(m) && ((chan_dehalfop(*fr) || (glob_dehalfop(*fr) &&
           !chan_halfop(*fr)) || (channel_bitch(chan) && (!chan_halfop(*fr) &&
-          !(glob_halfop(*fr) && !chan_dehalfop(*fr)))))))
+          !(glob_halfop(*fr) && !chan_dehalfop(*fr)))))) && !chan_stopcheck(m))
         add_mode(chan, '-', 'h', m->nick);
       if (!chan_sentop(m) && !chan_hasop(m) && !chan_hashalfop(m) &&
           (chan_halfop(*fr) || (glob_halfop(*fr) && !chan_dehalfop(*fr))) &&
           (channel_autohalfop(chan) || glob_autohalfop(*fr) ||
           chan_autohalfop(*fr))) {
-        if (!chan->aop_min)
-          add_mode(chan, '+', 'h', m->nick);
+        if (!chan->aop_min) {
+          if (!chan_stopcheck(m))
+            add_mode(chan, '+', 'h', m->nick);
+        }
         else {
           set_delay(chan, m->nick);
           m->flags |= SENTHALFOP;
@@ -799,13 +802,15 @@ static void check_this_member(struct chanset_t *chan, char *nick,
 
     if (HALFOP_CANDOMODE('v')) {
       if (chan_hasvoice(m) && (chan_quiet(*fr) || (glob_quiet(*fr) &&
-          !chan_voice(*fr))))
+          !chan_voice(*fr))) && !chan_stopcheck(m))
         add_mode(chan, '-', 'v', m->nick);
       if (!chan_hasvoice(m) && !chan_hasop(m) && !chan_hashalfop(m) &&
           (chan_voice(*fr) || (glob_voice(*fr) && !chan_quiet(*fr))) &&
           (channel_autovoice(chan) || glob_gvoice(*fr) || chan_gvoice(*fr))) {
-        if (!chan->aop_min)
-          add_mode(chan, '+', 'v', m->nick);
+        if (!chan->aop_min) {
+          if (!chan_stopcheck(m))
+            add_mode(chan, '+', 'v', m->nick);
+        }
         else {
           set_delay(chan, m->nick);
           m->flags |= SENTVOICE;
@@ -814,28 +819,30 @@ static void check_this_member(struct chanset_t *chan, char *nick,
     }
   }
 
-  if (!me_op(chan) && (!me_halfop(chan) ||
-      (strchr(NOHALFOPS_MODES, 'b') != NULL) ||
-      (strchr(NOHALFOPS_MODES, 'e') != NULL) ||
-      (strchr(NOHALFOPS_MODES, 'I') != NULL)))
-    return;
+  if (!chan_stopcheck(m)) {
+    if (!me_op(chan) && (!me_halfop(chan) ||
+        (strchr(NOHALFOPS_MODES, 'b') != NULL) ||
+        (strchr(NOHALFOPS_MODES, 'e') != NULL) ||
+        (strchr(NOHALFOPS_MODES, 'I') != NULL)))
+      return;
 
-  sprintf(s, "%s!%s", m->nick, m->userhost);
-  if (use_invites && (u_match_mask(global_invites, s) ||
-      u_match_mask(chan->invites, s)))
-    refresh_invite(chan, s);
-  if (!(use_exempts && (u_match_mask(global_exempts, s) ||
-      u_match_mask(chan->exempts, s)))) {
-    if (u_match_mask(global_bans, s) || u_match_mask(chan->bans, s))
-      refresh_ban_kick(chan, s, m->nick);
-    if (!chan_sentkick(m) && (chan_kick(*fr) || glob_kick(*fr)) &&
-        (me_op(chan) || (me_halfop(chan) && !chan_hasop(m)))) {
-      check_exemptlist(chan, s);
-      quickban(chan, m->userhost);
-      p = get_user(&USERENTRY_COMMENT, m->user);
-      dprintf(DP_SERVER, "KICK %s %s :%s\n", chan->name, m->nick,
-              p ? p : IRC_POLITEKICK);
-      m->flags |= SENTKICK;
+    sprintf(s, "%s!%s", m->nick, m->userhost);
+    if (use_invites && (u_match_mask(global_invites, s) ||
+        u_match_mask(chan->invites, s)))
+      refresh_invite(chan, s);
+    if (!(use_exempts && (u_match_mask(global_exempts, s) ||
+        u_match_mask(chan->exempts, s)))) {
+      if (u_match_mask(global_bans, s) || u_match_mask(chan->bans, s))
+        refresh_ban_kick(chan, s, m->nick);
+      if (!chan_sentkick(m) && (chan_kick(*fr) || glob_kick(*fr)) &&
+          (me_op(chan) || (me_halfop(chan) && !chan_hasop(m)))) {
+        check_exemptlist(chan, s);
+        quickban(chan, m->userhost);
+        p = get_user(&USERENTRY_COMMENT, m->user);
+        dprintf(DP_SERVER, "KICK %s %s :%s\n", chan->name, m->nick,
+                p ? p : IRC_POLITEKICK);
+        m->flags |= SENTKICK;
+      }
     }
   }
 }
@@ -2166,11 +2173,9 @@ static int gotnick(char *from, char *msg)
       m->flags &= ~(SENTKICK | SENTDEOP | SENTOP | SENTDEHALFOP | SENTHALFOP |
                     SENTVOICE | SENTDEVOICE);
       /* nick-ban or nick is +k or something? */
-      if (!chan_stopcheck(m)) {
-        get_user_flagrec(m->user ? m->user : get_user_by_host(s1), &fr,
-                         chan->dname);
-        check_this_member(chan, m->nick, &fr);
-      }
+      get_user_flagrec(m->user ? m->user : get_user_by_host(s1), &fr,
+                       chan->dname);
+      check_this_member(chan, m->nick, &fr);
       /* Make sure this is in the loop, someone could have changed the record
        * in an earlier iteration of the loop. */
       u = get_user_by_host(from);


### PR DESCRIPTION
Found by: assassin
Patch by: michaelortmann
Fixes: #94 

One-line summary:
Fix nickchange mode tracking

Additional description (if needed):


Test cases demonstrating functionality (if applicable):

.chanset #testchan +autoop
.chattr n1 +a

**test1: before this patch:**

.chanset #testchan aop-delay 5:30

```
*** n1 (~michael@localhost) has joined channel #testchan
*** n1 is now known as n2
```

eggdrop failes to autoop after nickchange

**test 2 after this patch:**

.chanset #testchan aop-delay 5:30

```
*** n1 (~michael@localhost) has joined channel #testchan
*** n1 is now known as n2
*** Mode change "+o n2" on channel #testchan by eggdrop
*** n2 is now known as n3
*** n3 is now known as n4
*** n4 is now known as n5
```

tcpdump shows eggdrop sends exactly one +o for n2 to the server. ok.

**test 3: after this patch: join channel before eggdrop did set channel mode:**

.chanset #testchan aop-delay 0

```
*** n1 (~michael@localhost) has joined channel #testchan
*** n1 is now known as n2
*** Mode change "+nt+o n2" on channel #testchan by eggdrop
*** n2 is now known as n3
*** n3 is now known as n4
*** n4 is now known as n5
```

**test 4: after this patch: join channel after eggdrop did set channel mode:**

.chanset #testchan aop-delay 0

```
*** n1 (~michael@localhost) has joined channel #testchan
*** n1 is now known as n2
*** Mode change "+o n2" on channel #testchan by eggdrop
*** n2 is now known as n3
*** n3 is now known as n4
*** n4 is now known as n5
```

tcpdump shows eggdrop sends exactly one +o for n1 to the server and the server tracks the nickchange and sets +o n2. this is with an ircd 2.11.2p3. ok.