### PR TITLE
Fix links

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AC_FUNC_MMAP
 # Tcl version to recommend if no Tcl is found, and the site where it can be
 # found for download.
 tclrecommendver="8.6.X"
-tclrecommendsite="ftp://tcl.activestate.com/pub/tcl/tcl8_6/"
+tclrecommendsite="ftp://ftp.tcl.tk/pub/tcl/tcl8_6/"
 
 # Tcl header filenames.
 tclheadernames="tcl.h"

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -249,7 +249,7 @@ Last revised: September 4, 2018
              cd /
              tar -zxf tcl-8.5.9.tar.gz
 
-        3. Download Eggdrop from geteggdrop.com to your home directory.
+        3. Download Eggdrop from https://geteggdrop.com/ to your home directory.
            This is usually something like 'C:\cygwin\home\<username>\'. After
            downloading, extract the Eggdrop tarball:
 

--- a/doc/sphinx_source/installAndSetup/readme.rst
+++ b/doc/sphinx_source/installAndSetup/readme.rst
@@ -67,8 +67,11 @@ HOW TO GET EGGDROP
     trying the command "tclsh". If it works, you will be given a "%" prompt
     and you can type "exit" to exit the program. This means Tcl is installed
     on your system. If tclsh doesn't load, then Tcl probably isn't on your
-    system, and you will need to install it. The website for Tcl is
-    https://tcl.tk/.
+    system, and you will need to install it. The website to download Tcl is
+    https://www.tcl.tk/software/tcltk/download.html and most OS distros have
+    a binary installation available. If installing via an OS package manager,
+    make sure to install the development library as well, usually called
+    something similar to 'tcl-dev'.
 
     Currently, the 1.8 tree of Eggdrop is developed at eggheads.org. You can
     get the latest STABLE version of Eggdrop from the following url:

--- a/doc/sphinx_source/installAndSetup/readme.rst
+++ b/doc/sphinx_source/installAndSetup/readme.rst
@@ -67,13 +67,13 @@ HOW TO GET EGGDROP
     trying the command "tclsh". If it works, you will be given a "%" prompt
     and you can type "exit" to exit the program. This means Tcl is installed
     on your system. If tclsh doesn't load, then Tcl probably isn't on your
-    system, and you will need to install it. The best ftp site for Tcl is
-    ftp://tcl.activestate.com/pub/tcl/.
+    system, and you will need to install it. The website for Tcl is
+    https://tcl.tk/.
 
     Currently, the 1.8 tree of Eggdrop is developed at eggheads.org. You can
     get the latest STABLE version of Eggdrop from the following url:
 
-      http://geteggdrop.com/
+      https://geteggdrop.com/
 
     You might try www.eggheads.org for help and information.
 

--- a/help/core.help
+++ b/help/core.help
@@ -132,7 +132,7 @@ See also: +lang, -lang, +lsec, -lsec, lstat
    Executes the specified Tcl command.
 
    See doc/tcl-commands.doc for details on Tcl commands added to Eggdrop, and
-   visit http://tcl.activestate.com/ for more information on Tcl.
+   visit https://tcl.tk/ for more information on Tcl.
 %{help=set}%{+n}
 ###  %bset%b <variable> [value]
    Changes the values of config-file settings of the bot, or, if used without


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
replace some links
activestate -> tcl.tk website
geteggdrop.com -> https://geteggdrop.com/
**there was even a dead link in help/core.help:
http://tcl.activestate.com/**

Additional description (if needed):
docs must be regenerated when merging

Test cases demonstrating functionality (if applicable):
