### PR TITLE
Typo fix: effecient -> efficient

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1079,7 +1079,7 @@ static int got352(char *from, char *msg)
   char *nick, *user, *host, *chname, *flags;
   struct chanset_t *chan;
 
-  newsplit(&msg);               /* Skip my nick - effeciently */
+  newsplit(&msg);               /* Skip my nick - efficiently */
   chname = newsplit(&msg);      /* Grab the channel */
   chan = findchan(chname);      /* See if I'm on channel */
   if (chan) {                   /* Am I? */
@@ -1101,7 +1101,7 @@ static int got354(char *from, char *msg)
   struct chanset_t *chan;
 
   if (use_354) {
-    newsplit(&msg);             /* Skip my nick - effeciently */
+    newsplit(&msg);             /* Skip my nick - efficiently */
     if (msg[0] && (strchr(CHANMETA, msg[0]) != NULL)) {
       chname = newsplit(&msg);  /* Grab the channel */
       chan = findchan(chname);  /* See if I'm on channel */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1072,7 +1072,7 @@ static void server_activity(int idx, char *msg, int len)
       putlog(LOG_RAW, "*", "[@] %s %s %s", from, code, msg);
   }
   /* This has GOT to go into the raw binding table, * merely because this
-   * is less effecient.
+   * is less efficient.
    */
   check_tcl_raw(from, code, msg);
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Typo fix: effecient -> efficient

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
