### PR TITLE
Fix buffer size in channels.c:write_channel()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -87,7 +87,8 @@
 #  define _POSIX_SOURCE 1               /* Solaris needs this */
 #endif
 
-extern char origbotname[], userfile[121], botnetnick[];
+extern char origbotname[], botnetnick[]; 
+extern char userfile[121];        /* 121 = sizeof userfile from users.c */
 extern int dcc_total, conmask, cache_hit, cache_miss, max_logs, quick_logs,
            quiet_save;
 extern struct dcc_t *dcc;

--- a/src/main.c
+++ b/src/main.c
@@ -87,7 +87,7 @@
 #  define _POSIX_SOURCE 1               /* Solaris needs this */
 #endif
 
-extern char origbotname[], userfile[], botnetnick[];
+extern char origbotname[], userfile[121], botnetnick[];
 extern int dcc_total, conmask, cache_hit, cache_miss, max_logs, quick_logs,
            quiet_save;
 extern struct dcc_t *dcc;
@@ -608,7 +608,7 @@ static void do_arg()
 
 void backup_userfile(void)
 {
-  char s[125];
+  char s[sizeof userfile + 4];
 
   if (quiet_save < 2)
     putlog(LOG_MISC, "*", USERF_BACKUP);

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -392,7 +392,7 @@ static void write_channels()
 
   if (!chanfile[0])
     return;
-  sprintf(s, "%s~new", chanfile);
+  egg_snprintf(s, sizeof s, "%s~new", chanfile);
   f = fopen(s, "w");
   chmod(s, userfile_perm);
   if (f == NULL) {
@@ -528,7 +528,7 @@ static void read_channels(int create, int reload)
 
 static void backup_chanfile()
 {
-  char s[125];
+  char s[sizeof chanfile + 4];
 
   if (quiet_save < 2)
     putlog(LOG_MISC, "*", "Backing up channel file...");

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -385,7 +385,7 @@ static char *convert_element(char *src, char *dst)
 static void write_channels()
 {
   FILE *f;
-  char s[121], w[1024], w2[1024], name[163];
+  char s[sizeof chanfile + 4], w[1024], w2[1024], name[163];
   char need1[242], need2[242], need3[242], need4[242], need5[242];
   struct chanset_t *chan;
   struct udef_struct *ul;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix buffer size in channels.c:write_channel()

Additional description (if needed):
1. No security problem, because chanfile can only be set in eggdrop.conf and is STR_PROTECT, and because ~new is probably only written into buffers which are overwritten anyway, and because ~new is hardcoded and cant be altered by mallory.
2. With this patch comes some cleanup/unification

Test cases demonstrating functionality (if applicable):
eggdrop.conf:
set chanfile "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
CFLAGS="-g3 -O2 -D_FORTIFY_SOURCE=2" ./configure
$ ./eggdrop -nt
[...]
Aborted (core dumped)