### PR TITLE
Fix #589: Fix aclocal.m4 grep under SunOS / OpenIndiana

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1043,7 +1043,7 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCL_BIN_DIR}/tclConfig.sh; then
       . ${TCL_BIN_DIR}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)" != ""; then
+      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)"; then
         TCL_PTHREAD_LDFLAG="-pthread"
       else
         TCL_PTHREAD_LDFLAG=""
@@ -1061,7 +1061,7 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCLLIB}/tclConfig.sh; then
       . ${TCLLIB}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)" != ""; then
+      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)"; then
         TCL_PTHREAD_LDFLAG="-pthread"
       else
         TCL_PTHREAD_LDFLAG=""

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1040,7 +1040,11 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCL_BIN_DIR}/tclConfig.sh; then
       . ${TCL_BIN_DIR}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      TCL_PTHREAD_LDFLAG=`echo $TCL_EXTRA_CFLAGS | grep -o -- '-pthread'`
+      if [[ "$(echo $TCL_EXTRA_CFLAGS | grep -- "-pthread")" != "" ]]; then
+        TCL_PTHREAD_LDFLAG="-pthread"
+      else
+        TCL_PTHREAD_LDFLAG=""
+      fi
       AC_SUBST(SHLIB_LD, $TCL_SHLIB_LD)
       AC_MSG_CHECKING([for Tcl linker])
       AC_MSG_RESULT([$SHLIB_LD])
@@ -1054,7 +1058,11 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCLLIB}/tclConfig.sh; then
       . ${TCLLIB}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      TCL_PTHREAD_LDFLAG=`echo $TCL_EXTRA_CFLAGS | grep -o -- '-pthread'`
+      if [[ "$(echo $TCL_EXTRA_CFLAGS | grep -- "-pthread")" != "" ]]; then
+        TCL_PTHREAD_LDFLAG="-pthread"
+      else
+        TCL_PTHREAD_LDFLAG=""
+      fi
       AC_SUBST(SHLIB_LD, $TCL_SHLIB_LD)
       AC_MSG_CHECKING([for Tcl linker])
       AC_MSG_RESULT([$SHLIB_LD])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1040,7 +1040,7 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCL_BIN_DIR}/tclConfig.sh; then
       . ${TCL_BIN_DIR}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      if [[ "$(echo $TCL_EXTRA_CFLAGS | grep -- "-pthread")" != "" ]]; then
+      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)" != ""; then
         TCL_PTHREAD_LDFLAG="-pthread"
       else
         TCL_PTHREAD_LDFLAG=""
@@ -1058,7 +1058,7 @@ AC_DEFUN([EGG_TCL_TCLCONFIG],
     if test -r ${TCLLIB}/tclConfig.sh; then
       . ${TCLLIB}/tclConfig.sh
       # OpenBSD uses -pthread, but tclConfig.sh provides that flag in EXTRA_CFLAGS
-      if [[ "$(echo $TCL_EXTRA_CFLAGS | grep -- "-pthread")" != "" ]]; then
+      if test "$(echo $TCL_EXTRA_CFLAGS | grep -- -pthread)" != ""; then
         TCL_PTHREAD_LDFLAG="-pthread"
       else
         TCL_PTHREAD_LDFLAG=""

--- a/doc/BUG-REPORT
+++ b/doc/BUG-REPORT
@@ -78,7 +78,7 @@ DO NOT SEND HTML E-MAIL TO THE LISTS.
      ( ) OSF/Tru64
      ( ) QNX
      ( ) SINIX
-     ( ) Solaris/SunOS
+     ( ) Solaris/SunOS/OpenIndiana
      ( ) Ultrix
      ( ) Other - Which? _____________
 

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -36,10 +36,12 @@ Last revised: September 4, 2018
       5. Unresolved or undefined symbols: ldclose, ldopen, ldnshread (AIX 3)
       6. Unsatisfied symbols 'shl_findsym' and 'shl_load' (HP-UX 9)
       7. Compile stops at the last minute with "ld fatal signal 11"! (Linux)
-      8. Undefined references in net.o (Sun OS)
+      8. Undefined references in net.o (SunOS)
       9. I experience problems starting the configure script (AIX/various)
      10. I get a 'make: Permission denied' error when I type 'make config'
          or 'make' (FreeBSD / *BSD)
+     11. I get a 'make: Fatal error in reader: Makefile, line 21: Badly formed
+         macro assignment' error when I type 'make config' (SunOS / OpenIndiana)
 
 
   Compile Guide
@@ -528,6 +530,13 @@ Last revised: September 4, 2018
       This is caused by a bug in FreeBSD (and possibly other BSDs as well).
       A simple 'cd .', or changing to a different directory and then changing
       back, usually fixes this.
+
+    11. I get a 'make: Fatal error in reader: Makefile, line 21: Badly formed
+        macro assignment' error when I type 'make config' (SunOS / OpenIndiana)
+
+      SunOS / OpenIndiana does not use GNU make. Eggdrop uses a GNU make
+      extension in it's Makefile. Install and use GNU make on SunOS /
+      OpenIndiana.
     _____________________________________________________________________
 
    Copyright (C) 1997 Robey Pointer

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -41,7 +41,9 @@ Last revised: September 4, 2018
      10. I get a 'make: Permission denied' error when I type 'make config'
          or 'make' (FreeBSD / *BSD)
      11. I get a 'make: Fatal error in reader: Makefile, line 21: Badly formed
-         macro assignment' error when I type 'make config' (SunOS / OpenIndiana)
+         macro assignment' error when I type 'make config' (OpenIndiana)
+     12. I get a 'gmake: readlink: Command not found' error when I type 'gmake
+         install' (OpenIndiana)
 
 
   Compile Guide
@@ -532,11 +534,15 @@ Last revised: September 4, 2018
       back, usually fixes this.
 
     11. I get a 'make: Fatal error in reader: Makefile, line 21: Badly formed
-        macro assignment' error when I type 'make config' (SunOS / OpenIndiana)
+        macro assignment' error when I type 'make config' (OpenIndiana)
 
-      SunOS / OpenIndiana does not use GNU make. Eggdrop uses a GNU make
-      extension in it's Makefile. Install and use GNU make on SunOS /
-      OpenIndiana.
+      OpenIndiana does not use GNU make. Eggdrop uses a GNU make extension in
+      it's Makefile. Install and use GNU make on OpenIndiana.
+
+    12. I get a 'gmake: readlink: Command not found' error when I type 'gmake
+        install' (OpenIndiana)
+
+      Install gnu-coreutils on OpenIndiana.
     _____________________________________________________________________
 
    Copyright (C) 1997 Robey Pointer


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #589

One-line summary:
Fix #589: Fix aclocal.m4 grep under SunOS / OpenIndiana

Additional description (if needed):
Also update BUG-REPORT and COMPILE-GUIDE for SunOS / OpenIndiana

Test cases demonstrating functionality (if applicable):

1. SunOS / OpenIndiana 5.11:

before:
```
$ ./configure
[...]
grep: illegal option -- o
usage:  grep [-E|-F] [-bchHilnqrRsvx] [-A num] [-B num] [-C num|-num]
             [-e pattern_list]... [-f pattern_file]... [pattern_list] [file]...
[...]
```

after:

```
$ ./configure
[...]
checking for Tcl library flags...  -L/usr/lib -ltcl8.6 -ldl -lz  -lsocket -lnsl -lpthread -lm
[...]
```

-pthread was not found via grep in $TCL_EXTRA_CFLAGS, ok

2. OpenBSD 6.3:

This is a test case for another operating system to demonstrate, the Fix shows no regression there

```
$ ./configure
[...]
checking for Tcl library flags... -pthread -L/usr/local/lib -ltcl86  -lz  -lm
[...]
```

-pthread was found via grep in $TCL_EXTRA_CFLAGS, ok

3. Other and/oder older non-gnu-grep Systems also show show this bug fixed with this patch

Example: OpenBSD 4.9:

grep: unknown option -- o
usage: grep [-abcEFGhIiLlnqRsUVvwxZ] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--context[=num]]
        [--line-buffered] [pattern] [file ...]