### PR TITLE
Fix eggdrop to compile and run under Haiku

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -797,9 +797,6 @@ AC_DEFUN([EGG_CHECK_OS],
       SHLIB_LD="ld -bundle -undefined error"
       AC_DEFINE(BIND_8_COMPAT, 1, [Define if running on Mac OS X with dns.mod.])
     ;;
-    Haiku)
-      AC_DEFINE(HAIKU_HACKS, 1, [Define if running under Haiku.])
-    ;;
     *)
       if test -r /mach; then
         # At this point, we're guessing this is NeXT Step.

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -609,6 +609,9 @@ AC_DEFUN([EGG_CHECK_MODULE_SUPPORT],
       EGG_DARWIN_BUNDLE
       EGG_APPEND_VAR(MODULE_XLIBS, $BUNDLE)
     ;;
+    Haiku)
+      WEIRD_OS="no"
+    ;;
     *)
       if test -r /mach; then
         # At this point, we're guessing this is NeXT Step. We support rld, so

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -797,6 +797,9 @@ AC_DEFUN([EGG_CHECK_OS],
       SHLIB_LD="ld -bundle -undefined error"
       AC_DEFINE(BIND_8_COMPAT, 1, [Define if running on Mac OS X with dns.mod.])
     ;;
+    Haiku)
+      AC_DEFINE(HAIKU_HACKS, 1, [Define if running under Haiku.])
+    ;;
     *)
       if test -r /mach; then
         # At this point, we're guessing this is NeXT Step.

--- a/doc/BUG-REPORT
+++ b/doc/BUG-REPORT
@@ -68,6 +68,7 @@ DO NOT SEND HTML E-MAIL TO THE LISTS.
      ( ) Dell SVR4
      ( ) DragonFly BSD
      ( ) FreeBSD/TrueOS
+     ( ) Haiku
      ( ) HP-UX
      ( ) IRIX
      ( ) Linux

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -1,5 +1,5 @@
 Eggdrop Compile Guide and FAQ
-Last revised: September 4, 2018
+Last revised: September 20, 2018
     _____________________________________________________________________
 
                         Eggdrop Compile Guide and FAQ
@@ -25,7 +25,8 @@ Last revised: September 4, 2018
       F. IRIX
       G. Solaris / SunOS
       H. Cygwin / Windows
-      I. Tcl Detection and Installation
+      I. Haiku
+      J. Tcl Detection and Installation
 
     Frequently Asked Questions:
       1. I get a lot of warnings.
@@ -301,7 +302,19 @@ Last revised: September 4, 2018
              cp /bin/cygz.dll 'C:/eggdrop' (if you selected compress.mod)
 
 
-    I. Tcl Detection and Installation
+    I. Haiku
+        If you compile tcl and it breaks with thread error and --disable-threads
+        doesnt help you can workaround with removal of directory
+        pkgs/thread<VERSION>.
+
+        Follow the standard compile process in Section A. To compile dynamically
+        (with module support), use 'make eggdrop' instead of 'make'.
+
+        Note that on Haiku, the LIBRARY_PATH environment variable must be used
+        instead of LD_LIBRARY_PATH.
+
+
+    J. Tcl Detection and Installation
         If ./configure does not correctly detect the location of your Tcl
         library and header file, or if you experience errors related to Tcl
         during linking, perform these steps:

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -307,9 +307,6 @@ Last revised: September 20, 2018
         doesn't help you can workaround with removal of directory
         pkgs/thread<VERSION>.
 
-        Follow the standard compile process in Section A. To compile dynamically
-        (with module support), use 'make eggdrop' instead of 'make'.
-
         Note that on Haiku, the LIBRARY_PATH environment variable must be used
         instead of LD_LIBRARY_PATH.
 

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -303,8 +303,8 @@ Last revised: September 20, 2018
 
 
     I. Haiku
-        If you compile tcl and it breaks with thread error and --disable-threads
-        doesn't help you can workaround with removal of directory
+        If you compile Tcl and it breaks with thread error and --disable-threads
+        doesn't help, you can workaround with removal of directory
         pkgs/thread<VERSION>.
 
         Note that on Haiku, the LIBRARY_PATH environment variable must be used

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -303,39 +303,39 @@ Last revised: September 20, 2018
 
 
     I. Haiku
-        If you compile Tcl and it breaks with thread error and --disable-threads
-        doesn't help, you can workaround with removal of directory
-        pkgs/thread<VERSION>.
+      If you compile Tcl from source and it breaks with a thread error 
+      (and --disable-threads doesn't help), you can workaround this by
+      removing the 'pkgs/thread<VERSION>' directory.
 
-        Note that on Haiku, the LIBRARY_PATH environment variable must be used
-        instead of LD_LIBRARY_PATH.
+      Note that on Haiku, the LIBRARY_PATH environment variable must be used
+      instead of LD_LIBRARY_PATH.
 
 
     J. Tcl Detection and Installation
-        If ./configure does not correctly detect the location of your Tcl
-        library and header file, or if you experience errors related to Tcl
-        during linking, perform these steps:
+      If ./configure does not correctly detect the location of your Tcl
+      library and header file, or if you experience errors related to Tcl
+      during linking, perform these steps:
 
-          1. Depending on what shell your using:
+        1. Depending on what shell your using:
 
-            bash/ksh:
-              export LD_LIBRARY_PATH=<path to DIRECTORY containing Tcl library>:${LD_LIBRARY_PATH}
+          bash/ksh:
+            export LD_LIBRARY_PATH=<path to DIRECTORY containing Tcl library>:${LD_LIBRARY_PATH}
 
-            csh/tcsh/tclsh:
-              setenv LD_LIBRARY_PATH <path to DIRECTORY containing Tcl library>:${LD_LIBRARY_PATH}
+          csh/tcsh/tclsh:
+            setenv LD_LIBRARY_PATH <path to DIRECTORY containing Tcl library>:${LD_LIBRARY_PATH}
 
-            Note that some OS's use a different environment variable to tell
-            ld where to look for a library. See the notes for your specific OS
-            above (if applicable).
+          Note that some OS's use a different environment variable to tell
+          ld where to look for a library. See the notes for your specific OS
+          above (if applicable).
 
-          2. Run the following command from your Eggdrop compilation directory
-             (this is all one command):
+        2. Run the following command from your Eggdrop compilation directory
+           (this is all one command):
 
-            ./configure --with-tclinc='<full path to tcl.h>'
-            --with-tcllib='<full path to Tcl library>'
+          ./configure --with-tclinc='<full path to tcl.h>'
+          --with-tcllib='<full path to Tcl library>'
 
-          3. Continue compiling the bot as outlined in Section A., starting
-             with 'make config'.
+        3. Continue compiling the bot as outlined in Section A., starting
+           with 'make config'.
 
         If you do not have Tcl installed on your system, you can compile it in
         your /home directory. Download Tcl from Tcl's SourceForge project page

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -304,7 +304,7 @@ Last revised: September 20, 2018
 
     I. Haiku
         If you compile tcl and it breaks with thread error and --disable-threads
-        doesnt help you can workaround with removal of directory
+        doesn't help you can workaround with removal of directory
         pkgs/thread<VERSION>.
 
         Follow the standard compile process in Section A. To compile dynamically

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -29,9 +29,12 @@
 
 #include <string.h>
 #include <errno.h>
-#include <zlib.h>
 
 #include "src/mod/module.h"
+
+#include <zlib.h> /* after src/mod/module.h because it could collide with
+		     crypto.h free_func */
+
 #include "share.mod/share.h"
 
 #ifdef HAVE_MMAP

--- a/src/mod/dns.mod/configure.ac
+++ b/src/mod/dns.mod/configure.ac
@@ -16,7 +16,7 @@ dns_reslib_avail="false"
 
 AC_HEADER_RESOLV
 
-for lib in '' -lresolv -lbind -lsocket
+for lib in '' -lresolv -lbind -lsocket -lnetwork
 do
   LIBS="$lib"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -151,7 +151,11 @@ typedef struct {
   u_16bit_t class;
   u_32bit_t ttl;
   u_16bit_t datalength;
+#ifndef HAIKU_HACKS
   u_8bit_t data[];
+#else
+  u_8bit_t data[0];
+#endif
 } res_record;
 
 #ifndef HFIXEDSZ
@@ -1274,13 +1278,13 @@ static int init_dns_core(void)
 
   /* Initialise the resolv library. */
   res_init();
-  #ifdef NETBSD_HACKS
-    puts("netbsd found. if eggdrop crashes with\n"
-         "  _res is not supported for multi-threaded programs.\n"
-         "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
-         "dns.mod must be disabled by commenting out in eggdrop.conf\n"
-         "  #loadmodule dns");
-  #endif
+#ifdef NETBSD_HACKS
+  puts("netbsd found. if eggdrop crashes with\n"
+       "  _res is not supported for multi-threaded programs.\n"
+       "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
+       "dns.mod must be disabled by commenting out in eggdrop.conf\n"
+       "  #loadmodule dns");
+#endif
   _res.options |= RES_RECURSE | RES_DEFNAMES | RES_DNSRCH;
   for (i = 0; i < _res.nscount; i++)
     _res.nsaddr_list[i].sin_family = AF_INET;

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1274,13 +1274,13 @@ static int init_dns_core(void)
 
   /* Initialise the resolv library. */
   res_init();
-#ifdef NETBSD_HACKS
-  puts("netbsd found. if eggdrop crashes with\n"
-       "  _res is not supported for multi-threaded programs.\n"
-       "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
-       "dns.mod must be disabled by commenting out in eggdrop.conf\n"
-       "  #loadmodule dns");
-#endif
+  #ifdef NETBSD_HACKS
+    puts("netbsd found. if eggdrop crashes with\n"
+         "  _res is not supported for multi-threaded programs.\n"
+         "  [1]   Abort trap (core dumped) ./eggdrop -nt\n"
+         "dns.mod must be disabled by commenting out in eggdrop.conf\n"
+         "  #loadmodule dns");
+  #endif
   _res.options |= RES_RECURSE | RES_DEFNAMES | RES_DNSRCH;
   for (i = 0; i < _res.nscount; i++)
     _res.nsaddr_list[i].sin_family = AF_INET;

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -151,11 +151,7 @@ typedef struct {
   uint16_t class;
   uint32_t ttl;
   uint16_t datalength;
-#ifndef HAIKU_HACKS
   uint8_t data[];
-#else
-  uint8_t data[0];
-#endif
 } res_record;
 
 #ifndef HFIXEDSZ

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1461,14 +1461,14 @@ static void shareout_but EGG_VARARGS_DEF(struct chanset_t *, arg1)
  */
 static void new_tbuf(char *bot)
 {
-  tandbuf **old = &tbuf, *new;
+  tandbuf *new;
 
   new = nmalloc(sizeof(tandbuf));
   strncpyz(new->bot, bot, sizeof new->bot);
   new->q = NULL;
   new->timer = now;
-  new->next = *old;
-  *old = new;
+  new->next = tbuf;
+  tbuf = new;
   putlog(LOG_BOTS, "*", "Creating resync buffer for %s", bot);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix eggdrop to compile and run under Haiku

Additional description (if needed):
1. Fix parse error before free_func
zlib.h must be included after crypto.h
2. Fix Internal compiler error, output_operand_lossage invalid expression as operand
Unwitched unnecessary pointer magick
3. Enable shared build by default for Haiku
4. Fix checking for a working resolver library
Add check for -lnetwork
5. Fix coredns.c:154: field data has incomplete type
data[] is struct hack (or c99 flexible array member)
Haiku / gcc 2.95.3 complains but other systems may suffer also, esp. older systems, because the coredns.c struct hack code is "new" in eggdrop.
This (5) bug is fixed with #660.
6. Also update BUG-REPORT and COMPILE-GUIDE for Haiku

**Please run misc/runautotools after merge.**

Test cases demonstrating functionality (if applicable):

1. Tested unter Haiku R1 Alpha 4.1:
```
$ uname -a
Haiku shredder 1 hrevr1alpha4-44702 Nov 14 2012  BePC Haiku
$ gcc --version
2.95.3-haiku-121101
```

2. Tested unter Haiku R1 Beta 1:
```
$ uname -a
Haiku shredder 1 hrev52295+96 Sep 27 2018 18:48: x86_64 x86_64 Haiku
$ gcc --version
gcc version 7.3.0 (2018_05_01)
```

```
.status
[...]
OS: Haiku 1
[...]
```