### PR TITLE
Make 2 functions in dns.c static

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -47,12 +47,12 @@ devent_t *dns_events = NULL;
  *   DCC functions
  */
 
-void dcc_dnswait(int idx, char *buf, int len)
+static void dcc_dnswait(int idx, char *buf, int len)
 {
   /* Ignore anything now. */
 }
 
-void eof_dcc_dnswait(int idx)
+static void eof_dcc_dnswait(int idx)
 {
   putlog(LOG_MISC, "*", "Lost connection while resolving hostname [%s/%d]",
          iptostr(&dcc[idx].sockname.addr.sa), dcc[idx].port);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Make 2 functions in dns.c static

Additional description (if needed):
yes we can

Test cases demonstrating functionality (if applicable):
quick compile / run / ok