### PR TITLE
Enhance error log for ssl

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1103,8 +1103,13 @@ static void botlink_resolve_success(int i)
    * failed_link() try the next ports
    * FIXME: if we can break compatibility for 1.9 or 2.0, we can replace this
    * workaround
+   * could be a non ssl bot connecting to a ssl only port.
+   * but we can't log that error here, because we didn't get that error yet.
+   * and when we get this error in the future, we won't know we have been here.
+   * that is aniother ugly problem, yet to be fixed.
    */
-  dcc[i].port += 3;
+  else if (!dcc[i].ssl)
+    dcc[i].port += 3;
 
 #endif
 }

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1106,7 +1106,7 @@ static void botlink_resolve_success(int i)
    * could be a non ssl bot connecting to a ssl only port.
    * but we can't log that error here, because we didn't get that error yet.
    * and when we get this error in the future, we won't know we have been here.
-   * that is aniother ugly problem, yet to be fixed.
+   * that is another ugly problem, yet to be fixed.
    */
   else if (!dcc[i].ssl)
     dcc[i].port += 3;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1098,14 +1098,6 @@ static void botlink_resolve_success(int i)
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
     failed_link(i);
-
-  /* we got a connect and we dont want to connect with ssl so don't let
-   * failed_link() try the next ports
-   * FIXME: if we can break compatibility for 1.9 or 2.0, we can replace this
-   * workaround
-   */
-  dcc[i].port += 3;
-
 #endif
 }
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1098,6 +1098,14 @@ static void botlink_resolve_success(int i)
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
     failed_link(i);
+
+  /* we got a connect and we dont want to connect with ssl so don't let
+   * failed_link() try the next ports
+   * FIXME: if we can break compatibility for 1.9 or 2.0, we can replace this
+   * workaround
+   */
+  dcc[i].port += 3;
+
 #endif
 }
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1106,7 +1106,7 @@ static void botlink_resolve_success(int i)
    * could be a non ssl bot connecting to a ssl only port.
    * but we can't log that error here, because we didn't get that error yet.
    * and when we get this error in the future, we won't know we have been here.
-   * that is another ugly problem, yet to be fixed.
+   * that is aniother ugly problem, yet to be fixed.
    */
   else if (!dcc[i].ssl)
     dcc[i].port += 3;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1103,13 +1103,8 @@ static void botlink_resolve_success(int i)
    * failed_link() try the next ports
    * FIXME: if we can break compatibility for 1.9 or 2.0, we can replace this
    * workaround
-   * could be a non ssl bot connecting to a ssl only port.
-   * but we can't log that error here, because we didn't get that error yet.
-   * and when we get this error in the future, we won't know we have been here.
-   * that is aniother ugly problem, yet to be fixed.
    */
-  else if (!dcc[i].ssl)
-    dcc[i].port += 3;
+  dcc[i].port += 3;
 
 #endif
 }

--- a/src/net.c
+++ b/src/net.c
@@ -542,10 +542,6 @@ int open_telnet_raw(int sock, sockname_t *addr)
         debug1("net: getsockopt error %d", res);
         return -1;
       }
-      /*
-      debug2("net: attempted socket connection success: ip = %s port = %i",
-             iptostr(&addr->addr.sa), get_port_from_addr(addr));
-      */
       return sock; /* async success! */
     }
     else {

--- a/src/net.c
+++ b/src/net.c
@@ -889,8 +889,12 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
             int err = SSL_get_error(slist[i].ssl, x);
             if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
               errno = EAGAIN;
+            else if (err == SSL_ERROR_SYSCALL) {
+              debug0("net: sockread(): SSL_read() SSL_ERROR_SYSCALL");
+              putlog(LOG_MISC, "*", "NET: SSL read failed. Could have been a non ssl bot or telnet connecting to a ssl only port.");
+            }
             else
-              debug1("sockread(): SSL error = %s",
+              debug2("net: sockread(): SSL_read() err = %i error = %s", err,
                      ERR_error_string(ERR_get_error(), 0));
             x = -1;
           }

--- a/src/net.c
+++ b/src/net.c
@@ -534,7 +534,7 @@ int open_telnet_raw(int sock, sockname_t *addr)
       if (res == EINPROGRESS) /* Operation now in progress */
         return sock; /* This could probably fail somewhere */
       if (res == ECONNREFUSED) { /* Connection refused */
-        debug2("net: attempted socket connection refused: ip = %s port = %i",
+        debug2("net: attempted socket connection refused: %s:%i",
                iptostr(&addr->addr.sa), get_port_from_addr(addr));
         return -4;
       }
@@ -900,11 +900,11 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
               errno = EAGAIN;
             else if (err == SSL_ERROR_SYSCALL) {
               debug0("net: sockread(): SSL_read() SSL_ERROR_SYSCALL");
-              putlog(LOG_MISC, "*", "NET: SSL read failed. Could have been a non ssl bot or telnet connecting to a ssl only port.");
+              putlog(LOG_MISC, "*", "NET: SSL read failed. Non-SSL connection?");
             }
             else
-              debug2("net: sockread(): SSL_read() err = %i error = %s", err,
-                     ERR_error_string(ERR_get_error(), 0));
+              debug2("net: sockread(): SSL_read() error = %s (%i)",
+                     ERR_error_string(ERR_get_error(), 0), err);
             x = -1;
           }
         } else

--- a/src/net.c
+++ b/src/net.c
@@ -485,6 +485,14 @@ static int proxy_connect(int sock, sockname_t *addr)
   return sock;
 }
 
+/* FIXME: if we can break compatibility for 1.9 or 2.0, we can replace this
+ * workaround with an additional port parameter for functions in need
+ */
+static int get_port_from_addr(const sockname_t *addr)
+{
+  return ntohs((addr->family == AF_INET) ? addr->addr.s4.sin_port : addr->addr.s6.sin6_port);
+}
+
 /* Starts a connection attempt through a socket
  *
  * The server address should be filled in addr by setsockname() or by the
@@ -526,13 +534,18 @@ int open_telnet_raw(int sock, sockname_t *addr)
       if (res == EINPROGRESS) /* Operation now in progress */
         return sock; /* This could probably fail somewhere */
       if (res == ECONNREFUSED) { /* Connection refused */
-        debug1("net: attempted socket connection refused: %s", iptostr(&addr->addr.sa));
+        debug2("net: attempted socket connection refused: ip = %s port = %i",
+               iptostr(&addr->addr.sa), get_port_from_addr(addr));
         return -4;
       }
       if (res != 0) {
         debug1("net: getsockopt error %d", res);
         return -1;
       }
+      /*
+      debug2("net: attempted socket connection success: ip = %s port = %i",
+             iptostr(&addr->addr.sa), get_port_from_addr(addr));
+      */
       return sock; /* async success! */
     }
     else {


### PR DESCRIPTION
Found by: vanosg
Patch by: michaelortmann
Fixes: #458

One-line summary:
Enhance error log for ssl

Additional description (if needed):
1. Enhance log for non ssl bot trying to link to ssl bot. This fixes part of #458.
2. Enhance log for connection refused to also include the port. This fixes part of #458.

**After (1) and (2), which are good patches to merge for 1.8.4**, i did a 3rd patch (3). But i reverted (3) because it was too much of a hack and i could not trust it myself. That patch was: Stop failed_link() from trying the next ports if we got a connect (instead of connection refused) and was planned to fix #646. If we can break compatibility for 1.9+, we could do a proper patch.

Test cases demonstrating functionality (if applicable):

**Case 1 - Enhance log for non ssl bot trying to link to ssl bot**

The following test tries to link BotA (nick = linux)  to ssl only port of BotB (nick = sslbot, eggdrop.conf: listen +2514 all)

**BotA (non ssl):**
```
.+bot sslbot 127.0.0.1 2514
[...]
.console +b-d
[...]
.link sslbot
[01:53:49] #-HQ# link sslbot
[01:53:49] Linking to sslbot at 127.0.0.1:2514 ...
*** [linux] Couldn't link to sslbot.
[01:54:10] Failed link to sslbot.
```

**BotB (ssl only port):**
```
.console +b-d
[...]
[01:53:49] Telnet connection: localhost/41887
[01:53:49] Timeout/EOF ident connection
[01:54:10] NET: SSL read failed. Could have been a non ssl bot or telnet connecting to a ssl only port.
[01:54:10] Lost telnet connection to telnet@localhost/41887
```

Before this patch, the ssl bot was logging to DEBUG:
`[22:05:52] sockread(): SSL error = error:00000000:lib(0):func(0):reason(0)`
After this patch, the ssl bot is logging to MISC:
`[01:54:10] NET: SSL read failed. Could have been a non ssl bot or telnet connecting to a ssl only port.`

**Case 2 - Enhance log for connection refused to also include the port**

.console +d
Before:
`[02:37:08] net: attempted socket connection refused: 127.0.0.1`
After:
`[04:25:27] net: attempted socket connection refused: ip = 127.0.0.1 port = 2515`

**Extra Info**

If you see:

```
.link sslbot
[02:36:53] Linking to sslbot at 127.0.0.1:2514 ...
[02:37:08] net: attempted socket connection refused: 127.0.0.1
[02:37:08] net: attempted socket connection refused: 127.0.0.1
[02:37:08] net: attempted socket connection refused: 127.0.0.1
*** [linux] Couldn't link to sslbot.
```

What you see here isn't the bot trying 3 times to non ssl connect to the same ssl Port, but the bot trying to connect to Port+1..3. Now you see, why i add the port number to the debug output with this patch. The connect to the first ssl Port (Port+0) is silent, no debug log at all. This is another issue, but one to fix for 1.9.