### PR TITLE
Change ssl.conf default bits from 2048 to 4096

### DIFF
--- a/ssl.conf
+++ b/ssl.conf
@@ -16,7 +16,7 @@ default_md			= sha1		# which md to use.
 
 ####################################################################
 [ req ]
-default_bits			= 2048
+default_bits			= 4096
 default_keyfile 		= eggdrop.key
 distinguished_name		= req_dn
 req_extensions			= v3_req


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Change ssl.conf default bits from 2048 to 4096

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
$ make sslcert
Generating a RSA private key
[...]
$ openssl x509 -text -noout -in eggdrop.crt |grep bit
                RSA Public-Key: (4096 bit)
$ openssl rsa -text -noout -in eggdrop.key | grep bit
RSA Private-Key: (4096 bit, 2 primes)
```