### PR TITLE
Fix a gcc 8 stringop-truncation warning / Enhance code

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -570,7 +570,7 @@ void putlog EGG_VARARGS_DEF(int, arg1)
   }
   /* Place the timestamp in the string to be printed */
   if (out[0] && shtime) {
-    strncpy(s, stamp, tsl);
+    memcpy(s, stamp, tsl);
     out = s;
   }
   strcat(out, "\n");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix a gcc 8 stringop-truncation warning / Enhance code


Additional description (if needed):
Replaced strncpy with memcpy here. Its what the code really wants to do, so its more readable and fixes the following gcc 8 stringop-truncation warning:

`misc.c:573:5: warning: ‘strncpy’ output may be truncated copying between 0 and 33 bytes from a string of length 33 [-Wstringop-truncation]`

(dont alter your cflags, or you may miss this compiler warning)

Test cases demonstrating functionality (if applicable):

The changed code is part of putlog()s timestamp handling, so did a quick test which shows timestamp is still fine:

```
$ ./eggdrop -nt
[...]
[00:51:51] Trying server [127.0.0.1]:6667
[...]
```