### PR TITLE
Fix buffer size - fix 2 gcc 8 format-truncation warnings

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1470,7 +1470,7 @@ static void dcc_dupwait(int idx, char *buf, int i)
  */
 static void timeout_dupwait(int idx)
 {
-  char x[100];
+  char x[NICKLEN + UHOSTLEN];
 
   /* Still duplicate? */
   if (in_chain(dcc[idx].nick)) {

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -324,10 +324,10 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
       strcpy(ftype + 4, " flood");
       u_addban(chan, h, botnetnick, ftype, now + (60 * chan->ban_time), 0);
       if (!channel_enforcebans(chan) && (me_op(chan) || me_halfop(chan))) {
-        char s[UHOSTLEN];
+        char s[NICKLEN + UHOSTLEN];
 
         for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-          sprintf(s, "%s!%s", m->nick, m->userhost);
+          egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
           if (wild_match(h, s) && (m->joined >= chan->floodtime[which]) &&
               !chan_sentkick(m) && !match_my_nick(m->nick) && (me_op(chan) ||
               (me_halfop(chan) && !chan_hasop(m)))) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix buffer size - fix 2 gcc 8 format-truncation warnings

Additional description (if needed):
1. dcc.c:timeout_dupwait(): Replaced hardcoded buffer size 100 with NICKLEN + UHOSTLEN. That gcc warning was no false alarm.
2. chan.c:detect_chan_flood: Fixed buffer size analog (1).

Note1: don't alter CFLAGS, or you may miss this compiler warning

Note2: even gcc 7.3.0 under current cygwin (windrop) is reporting this warning, **in color!**


Test cases demonstrating functionality (if applicable):
quick ./eggdrop -nt, was ok, but that didn't traverse the changed code. Still, im feeling fine about this patch.