### PR TITLE
Cleanup dead store / dead assignment

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -252,7 +252,7 @@ int addr_match(char *m, char *n, int user, int cmp)
     return wild_match(mu, nu);
 
   *r++ = *s++ = 0;
-  tmpscore = wild_match(mu, nu);
+  wild_match(mu, nu);
   if (!(tmpscore = wild_match(mu, nu)))
     return NOMATCH; /* nick!ident parts don't match */
   score += tmpscore;
@@ -386,7 +386,7 @@ static int cron_matchfld(char *mask, int match)
   int skip = 0, f, t;
   char *p, *q;
 
-  for (p = mask; mask && *mask; mask = p) {
+  for (; mask && *mask; mask = p) {
     /* loop through a list of values, if such is given */
     if ((p = strchr(mask, ',')))
       *p++ = 0;

--- a/src/mod/assoc.mod/assoc.c
+++ b/src/mod/assoc.mod/assoc.c
@@ -334,7 +334,6 @@ static void zapf_assoc(char *botnick, char *code, char *par)
         chanout_but(-1, chan, ASSOC_CHNAME_REM, botnick, nick);
       } else if (get_assoc(par) != chan) {
         /* New one i didn't know about -- pass it on */
-        s1 = get_assoc_name(chan);
         add_assoc(par, chan);
         chanout_but(-1, chan, ASSOC_CHNAME_NAMED2, botnick, nick, par);
       }

--- a/src/mod/console.mod/console.c
+++ b/src/mod/console.mod/console.c
@@ -127,7 +127,7 @@ static int console_set(struct userrec *u, struct user_entry *e, void *buf)
       nfree(ci->channel);
       nfree(ci);
     }
-    ci = e->u.extra = buf;
+    e->u.extra = buf;
   }
 
   /* Note: Do not share console info */

--- a/src/mod/filesys.mod/filedb3.c
+++ b/src/mod/filesys.mod/filedb3.c
@@ -511,7 +511,7 @@ static void filedb_cleanup(FILE *fdb)
   filedb_entry *fdbe = NULL;
 
   filedb_readtop(fdb, NULL);    /* Skip DB header  */
-  newpos = temppos = oldpos = ftell(fdb);
+  oldpos = ftell(fdb);
   fseek(fdb, oldpos, SEEK_SET); /* Go to beginning */
   while (!feof(fdb)) {          /* Loop until EOF  */
     fdbe = filedb_getfile(fdb, oldpos, GET_HEADER);     /* Read header     */

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2204,7 +2204,6 @@ static int gotquit(char *from, char *msg)
   struct userrec *u;
 
   strcpy(from2, from);
-  u = get_user_by_host(from2);
   nick = splitnick(&from);
   fixcolon(msg);
   /* Fred1: Instead of expensive wild_match on signoff, quicker method.

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -687,7 +687,6 @@ static void check_expired_chanstuff()
                  "%s (%s) got lost in the net-split.", m->nick, m->userhost);
           killmember(chan, m->nick);
         }
-        m = n;
       }
       check_lonely_channel(chan);
     } else if (!channel_inactive(chan) && !channel_pending(chan)) {

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -453,7 +453,6 @@ static int fast_deq(int which)
       }
   }
   to = newsplit(&msg);
-  len = strlen(to);
   simple_sprintf(victims, "%s", to);
   while (m) {
     nm = m->next;
@@ -463,7 +462,6 @@ static int fast_deq(int which)
     nextmsg = nextmsgstr;
     nextcmd = newsplit(&nextmsg);
     nextto = newsplit(&nextmsg);
-    len = strlen(nextto);
     if (strcmp(to, nextto) && !strcmp(cmd, nextcmd) && !strcmp(msg, nextmsg) &&
         ((strlen(cmd) + strlen(victims) + strlen(nextto) + strlen(msg) + 2) <
         510) && (!stack_limit || cmd_count < stack_limit - 1)) {
@@ -984,7 +982,6 @@ Eggdrop was not compiled with SSL libraries. Skipping...");
     z->next = x;
   else
     serverlist = x;
-  z = x;
 
   x->name = nmalloc(strlen(name) + 1);
   strcpy(x->name, name);

--- a/src/userent.c
+++ b/src/userent.c
@@ -364,7 +364,7 @@ static int laston_set(struct userrec *u, struct user_entry *e, void *buf)
       nfree(li);
     }
 
-    li = e->u.extra = buf;
+    e->u.extra = buf;
   }
   /* donut share laston info */
   return 1;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup dead store / dead assignment found by clang static analyzer

Additional description (if needed):
I only cleaned up what i could fully analyze and for that reason i left 5 more possible dead assignments untouched.

Test cases demonstrating functionality (if applicable):
tiny test was fine: compile, run, connect, join #test