### PR TITLE
Cleanup logic error / use of identical expressions

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -2282,7 +2282,6 @@ static int tcl_chansettype STDVAR
              !strcmp(argv[1], "flood-kick") ||
              !strcmp(argv[1], "flood-deop") ||
              !strcmp(argv[1], "flood-nick") ||
-             !strcmp(argv[1], "flood-nick") ||
              !strcmp(argv[1], "aop-delay")) {
     Tcl_AppendResult(irp, "pair", NULL);
   /* Integers now */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup logic error / use of identical expressions found by clang static analyzer

Additional description (if needed):
I only cleaned up what i could fully analyze and for that reason i left 1 more possible dead assignment untouched.

Test cases demonstrating functionality (if applicable):
tiny test was fine: compile, run, connect, join #test