### PR TITLE
Don't call gethostbyname2() if unnecessary

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -151,7 +151,7 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
          !egg_inet_aton(src, &addr->addr.s4.sin_addr)))
       af = AF_UNSPEC;
 
-  if (af == AF_UNSPEC && allowres) {
+  if (af == AF_UNSPEC && allowres && *src) {
     /* src is a hostname. Attempt to resolve it.. */
     if (!sigsetjmp(alarmret, 1)) {
       alarm(resolve_timeout);


### PR DESCRIPTION
Found by: maimizuno
Patch by: michaelortmann
Fixes: #518

One-line summary:
Don't call gethostbyname2() if unnecessary

Additional description (if needed):
1. Calling gethostbyname2() for an empty name is unnecessary because we know the result will be NULL.
2. The segmentation fault occurred in gethostbyname2(), so #518 will be fixed by this patch.
3. Before gethostbyname2() there is alarm(resolve_timeout). So it could be that the segmentation fault was triggered by a SIGALRM while in gethostbyname2(). This is only a special case of (1), so #518 will be fixed by this patch anyway.


Test cases demonstrating functionality (if applicable):
quick compile, run, connect, ok.