### PR TITLE
Fix: ./eggdrop -nt doesn't start if "listen" and "loadmodule dns" commented out

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -272,7 +272,7 @@ void tell_verbose_uptime(int idx)
   if (backgrd)
     strcpy(s1, MISC_BACKGROUND);
   else {
-    if (term_z)
+    if (term_z >= 0)
       strcpy(s1, MISC_TERMMODE);
     else if (con_chan)
       strcpy(s1, MISC_STATMODE);
@@ -327,7 +327,7 @@ void tell_verbose_status(int idx)
   if (backgrd)
     strncpyz(s1, MISC_BACKGROUND, sizeof s1);
   else {
-    if (term_z)
+    if (term_z >= 0)
       strncpyz(s1, MISC_TERMMODE, sizeof s1);
     else if (con_chan)
       strncpyz(s1, MISC_STATMODE, sizeof s1);
@@ -705,7 +705,7 @@ int isowner(char *name)
  */
 void add_hq_user()
 {
-  if (!backgrd && term_z > 0 && userlist) {
+  if (!backgrd && term_z >= 0 && userlist) {
     /* HACK: Workaround using dcc[].nick not to pass literal "-HQ" as a non-const arg */
     dcc[term_z].user = get_user_by_handle(userlist, dcc[term_z].nick);
     /* Make sure there's an innocuous -HQ user if needed */

--- a/src/main.c
+++ b/src/main.c
@@ -118,10 +118,10 @@ char notify_new[121] = "";      /* Person to send a note to for new users */
 int default_flags = 0;          /* Default user flags                     */
 int default_uflags = 0;         /* Default user-definied flags            */
 
-int backgrd = 1;        /* Run in the background?                        */
-int con_chan = 0;       /* Foreground: constantly display channel stats? */
-int term_z = 0;         /* Foreground: use the terminal as a partyline?  */
-int use_stderr = 1;     /* Send stuff to stderr instead of logfiles?     */
+int backgrd = 1;    /* Run in the background?                        */
+int con_chan = 0;   /* Foreground: constantly display channel stats? */
+int term_z = -1;    /* Foreground: use the terminal as a partyline?  */
+int use_stderr = 1; /* Send stuff to stderr instead of logfiles?     */
 
 char configfile[121] = "eggdrop.conf";  /* Default config file name */
 char pid_file[121];                     /* Name of the pid file     */
@@ -567,12 +567,12 @@ static void do_arg()
       case 'c':
         cliflags |= CLI_C;
         con_chan = 1;
-        term_z = 0;
+        term_z = -1;
         break;
       case 't':
         cliflags |= CLI_T;
         con_chan = 0;
-        term_z = 1;
+        term_z = 0;
         break;
       case 'm':
         cliflags |= CLI_M;
@@ -1239,12 +1239,12 @@ int main(int arg_c, char **arg_v)
   }
 
   /* Terminal emulating dcc chat */
-  if (!backgrd && term_z) {
+  if (!backgrd && term_z >= 0) {
     /* reuse term_z as glob var to pass it's index in the dcc table around */
     term_z = new_dcc(&DCC_CHAT, sizeof(struct chat_info));
 
-    /* new_dcc returns -1 on error, and 0 should always be taken by the listening socket */
-    if (term_z < 1)
+    /* new_dcc returns -1 on error */
+    if (term_z < 0)
       fatal("ERROR: Failed to initialize foreground chat.", 0);
 
     getvhost(&dcc[term_z].sockname, AF_INET);

--- a/src/misc.c
+++ b/src/misc.c
@@ -625,7 +625,7 @@ void putlog EGG_VARARGS_DEF(int, arg1)
       }
     }
   }
-  if (!backgrd && !con_chan && !term_z)
+  if (!backgrd && !con_chan && term_z < 0)
     dprintf(DP_STDOUT, "%s", out);
   else if ((type & LOG_MISC) && use_stderr) {
     if (shtime)


### PR DESCRIPTION
Found by: paigeadelethompson
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix: ./eggdrop -nt doesn't start if "listen" and "loadmodule dns" commented out

Additional description (if needed):
If eggdrop is started with `./eggdrop -nt`
Usually the first dcc idx will be set to TELNET (eggdrop.conf: listen)
Then the second dcc idx will be set to DNS (eggdrop.conf: loadmodule dns)
And the third dcc idx will be set to DCC_CHAT (as term_z for foreground user)

If the following 2 eggdrop.conf settings are commented out:
```
# loadmodule dns
# listen
```

eggdrop was fatal exiting with the following misleading error message:
```
[21:22:51] * ERROR: Failed to initialize foreground chat.
[21:22:51] Warning: Attempt to kill un-allocated socket 0!
```

This was due to the code assuming (and commenting) that the term_z / idx would be > 0.
But in this case it is 0.

Since commit https://github.com/eggheads/eggdrop/commit/1e7678c00d7361ce9b59907d39b999e90d49ca82 term_z is dualused as a flag and as an idx. This patch takes account of that and only fixes a corner case.

This fix is related to #402 and #627, but standalone and ready for review now.

So we can easily trigger the error when both settings are commented out in eggdrop.conf:


Test cases demonstrating functionality (if applicable):
eggdrop.conf:
```
# loadmodule dns
# listen
```
Before:
```
$ ./eggdrop -nt
[...]
[21:22:51] * ERROR: Failed to initialize foreground chat.
[21:22:51] Warning: Attempt to kill un-allocated socket 0!
```
After:
```
$ ./eggdrop -nt
*** -HQ joined the party line.
```