### PR TITLE
Fix struct hack / flexible array member

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h locale.h netdb.h netinet/in.h std
 AC_C_CONST
 AC_C_BIGENDIAN
 AC_C_INLINE
+AC_C_FLEXIBLE_ARRAY_MEMBER
 AC_TYPE_INTPTR_T
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -151,7 +151,7 @@ typedef struct {
   uint16_t class;
   uint32_t ttl;
   uint16_t datalength;
-  uint8_t data[];
+  uint8_t data[FLEXIBLE_ARRAY_MEMBER];
 } res_record;
 
 #ifndef HFIXEDSZ


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix struct hack / flexible array member

Additional description (if needed):
The struct hack code is "new" in eggdrop and it fails on systems like Haiku alpha1/gcc 2.93.3:
`Fix coredns.c:154: field data has incomplete type`
This general fix uses Macro AC_C_FLEXIBLE_ARRAY_MEMBER, see:
https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html
This fix also helps eggdrop to be C89 compatible.
**#548 now also requires this patch, due to it also does struct hack.
please run misc/runautotools after merge**

Test cases demonstrating functionality (if applicable):
a quick compile and run was fine