### PR TITLE
Enhance resolve-timeout default to RES_TIMEOUT

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -375,9 +375,11 @@ set telnet-flood 5:60
 # If you want telnet-flood to apply even to +f users, set this setting to 1.
 set paranoid-telnet-flood 1
 
-# Set here the amount of seconds before giving up on hostname/address
-# lookup (you might want to increase this if you are on a slow network).
-set resolve-timeout 7
+# Set here the amount of seconds before giving up on hostname/address lookup
+# (you might want to increase this if you are on a slow network). The default is
+# RES_TIMEOUT, which is generally 5, the allowed maximum is RES_MAXRETRANS (see
+# <resolv.h>).
+#set resolve-timeout 5
 
 
 ##### SSL SETTINGS #####

--- a/help/set/cmds1.help
+++ b/help/set/cmds1.help
@@ -126,6 +126,8 @@
 ###  %bset resolve-timeout%b <seconds>
    Set here the amount of seconds before giving up on hostname/address
    lookup (you might want to increase this if you are on a slow network).
+   The default is RES_TIMEOUT, which is generally 5, the allowed maximum is
+   RES_MAXRETRANS (see <resolv.h>).
 %{help=set dupwait-timeout}%{+n}
 ###  %bset dupwait-timeout%b <seconds>
    If your Eggdrop rejects bots that actually have already

--- a/src/main.c
+++ b/src/main.c
@@ -47,11 +47,11 @@
 
 #include "main.h"
 
-#include <fcntl.h>
 #include <errno.h>
-#include <signal.h>
-#include <netdb.h>
+#include <fcntl.h>
+#include <resolv.h>
 #include <setjmp.h>
+#include <signal.h>
 
 #ifdef TIME_WITH_SYS_TIME
 #  include <sys/time.h>
@@ -141,9 +141,9 @@ int notify_users_at = 0; /* Minutes past the hour to notify users of notes? */
 char version[81];    /* Version info (long form)  */
 char ver[41];        /* Version info (short form) */
 
-int do_restart = 0;       /* .restart has been called, restart ASAP */
-int resolve_timeout = 15; /* Hostname/address lookup timeout        */
-char quit_msg[1024];      /* Quit message                           */
+int do_restart = 0;                /* .restart has been called, restart ASAP */
+int resolve_timeout = RES_TIMEOUT; /* Hostname/address lookup timeout        */
+char quit_msg[1024];               /* Quit message                           */
 
 /* Traffic stats */
 unsigned long otraffic_irc = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance resolve-timeout default to RES_TIMEOUT

Additional description (if needed):
Default resolve-timeout was 7 in eggdrop.conf and 15 in source (used if it were commented out in eggdrop.conf)
This was inconsistant
This patch changes the default setting to RES_TIMEOUT (generally 5)

Test cases demonstrating functionality (if applicable):
I testet compile and `./eggdrop -nt` 6 times:
1. Linux 4.18.9 with default CFLAGS
2. FreeBSD 11.2-STABLE with default CFLAGS
3. OpenBSD 6.3 with default CFLAGS
4. NetBSD 6.1.5 with default CFLAGS
5. Linux with the following CFLAGS:
`-std=c89 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=500 -D_DEFAULT_SOURCE -Wall`
6. FreeBSD with default CFLAGS:
`-std=c89 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600 -D__BSD_VISIBLE -Wall`

Additionally i checked, that the new default is used and indeed 5 on those systems and that eggdrop.conf setting resolve-timeout works as expected when commented out or set to another value.