### PR TITLE
Fix name collision of answer()

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -38,6 +38,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
+#undef answer /* before resolv.h because it could collide with src/mod/module.h
+		 (dietlibc) */
 #include <resolv.h>
 #include <errno.h>
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #667

One-line summary:
Fix name collision 'answer' eggdrop:module.h vs. dietlibc:resolv.h

Additional description (if needed):
Maybe i found a related issue with stats.mod from https://www.tclscripts.net/files/file/29-logs2htmlmod-2431zip/

```
../module.h:185:17: error: too many arguments to function ‘(int (*)(int,  sockname_t *, uint16_t *, int))*(global + 608)’
 #define answer ((int (*) (int, sockname_t *, uint16_t *, int))global[76])
                ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./core/mini_httpd.c:621:9: note: in expansion of macro ‘answer’
     j = answer(dcc[idx].sock, s, &ip, &port, 0);
         ^~~~~~
```

**Meanwhile i think renaming eggdrops function answer into egg_answer would be a better solution that the undef woraround. This would break module api, so its for 1.9.**

Test cases demonstrating functionality (if applicable):
