### PR TITLE
Fix make distclean

### DIFF
--- a/src/mod/compress.mod/Makefile.in
+++ b/src/mod/compress.mod/Makefile.in
@@ -28,7 +28,8 @@ clean:
 	@rm -f .depend *.o *.$(MOD_EXT) *~
 
 distclean: clean
-	@rm -f Makefile config.cache config.log config.status config.h
+	@rm -f Makefile config.cache config.log config.status
+	@rm -rf autom4te.cache
 
 #safety hash
 ../compress.o: .././compress.mod/compress.c ../../../src/mod/module.h \

--- a/src/mod/dns.mod/Makefile.in
+++ b/src/mod/dns.mod/Makefile.in
@@ -30,6 +30,7 @@ clean:
 
 distclean: clean
 	@rm -f Makefile config.cache config.log config.status
+	@rm -rf autom4te.cache
 
 #safety hash
 ../dns.o: .././dns.mod/dns.c ../../../src/mod/module.h \


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix make distclean

Additional description (if needed):
`make distclean`
didn't remove:
`src/mod/compress.mod/autom4te.cache`
and
`src/mod/dns.mod/autom4te.cache`
and tried to remove non existent
`src/mod/compress.mod/config.h`
**Please misc/runautotools after merge.**

Test cases demonstrating functionality (if applicable):
