### PR TITLE
trigger_bind() wasted 4 bytes and was unreadable

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -715,7 +715,7 @@ static int trigger_bind(const char *proc, const char *param,
 {
   int x;
 #ifdef DEBUG_CONTEXT
-  const char *msg = "Tcl proc: %s, param: %s";
+  #define FORMAT "Tcl proc: %s, param: %s"
   char *buf;
 
   /* We now try to debug the Tcl_VarEval() call below by remembering both
@@ -723,9 +723,10 @@ static int trigger_bind(const char *proc, const char *param,
    * less helpless when we see context dumps.
    */
   Context;
-  buf = nmalloc(strlen(msg) + (proc ? strlen(proc) : 6)
-                + (param ? strlen(param) : 6) + 1);
-  sprintf(buf, msg, proc ? proc : "<null>", param ? param : "<null>");
+  /* reuse x */
+  x = snprintf(0, 0, FORMAT, proc ? proc : "<null>", param ? param : "<null>");
+  buf = nmalloc(x + 1);
+  sprintf(buf, FORMAT, proc ? proc : "<null>", param ? param : "<null>");
   ContextNote(buf);
   nfree(buf);
 #endif /* DEBUG_CONTEXT */

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -724,7 +724,7 @@ static int trigger_bind(const char *proc, const char *param,
    */
   Context;
   /* reuse x */
-  x = snprintf(0, 0, FORMAT, proc ? proc : "<null>", param ? param : "<null>");
+  x = snprintf(NULL, 0, FORMAT, proc ? proc : "<null>", param ? param : "<null>");
   buf = nmalloc(x + 1);
   sprintf(buf, FORMAT, proc ? proc : "<null>", param ? param : "<null>");
   ContextNote(buf);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
trigger_bind() wasted 4 bytes and was unreadable

Additional description (if needed):
The code was unreadable, so i guessed, if i was a bug, i would hide there. Eventually i lured the bug out. It was hiding in 4 bytes of memory over allocated but not used. A cozy plaze deep in DEBUG_CONTEXT territory. The bug told me the creator lost 2 earrings there `%s %s`. I let it free. It probably quickly found another software to hide in. Surprizingly, it left me a donut.

Test cases demonstrating functionality (if applicable):
