### PR TITLE
Fix truncation (partial write) of output to foreground STDOUT

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -366,7 +366,8 @@ void setsock(int sock, int options)
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *) &parm, sizeof(int));
   }
   /* Yay async i/o ! */
-  fcntl(sock, F_SETFL, O_NONBLOCK);
+  if ((sock != STDOUT) || backgrd)
+    fcntl(sock, F_SETFL, O_NONBLOCK);
 }
 
 int getsock(int af, int options)

--- a/src/net.c
+++ b/src/net.c
@@ -792,26 +792,17 @@ void safe_write(int fd, const void *buf, size_t count)
   ssize_t ret;
   static int inhere = 0;
 
-  while ((ret = write(fd, bytes, count)) == -1) {
-    switch(errno) {
-      case EINTR:
-        bytes += ret;
-        count -= ret;
-        continue;
-      case EAGAIN:
-        continue;
-      default:
-        if (!inhere) {
-          inhere = 1;
-          putlog(LOG_MISC, "*", "Unexpected write() failure on attempt to write %zd bytes to fd %d: %s.", count, fd, strerror(errno));
-          inhere = 0;
-        }
-        break;
+  do {
+    if ((ret = write(fd, bytes, count)) == -1 && errno != EINTR) {
+      if (!inhere) {
+        inhere = 1;
+        putlog(LOG_MISC, "*", "Unexpected write() failure on attempt to write %zd bytes to fd %d: %s.", count, fd, strerror(errno));
+        inhere = 0;
+      }
+      break;
     }
-  }
+  } while ((bytes += ret, count -= ret));
 }
-
-
 
 /* Attempts to read from all sockets in slist (upper array boundary slistmax-1)
  * fills s with up to 511 bytes if available, and returns the array index


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #665

One-line summary:
Fix foreground STDOUT must not be O_NONBLOCK which could break safe_write() / EAGAIN and truncate console output

Additional description (if needed):
I think this bug is serious and needs fixing for 1.8.4
My first fix was to let safe_write() support EAGAIN and loop / poll.
Then i thought about better solutions, like letting mainloop() select() handle the actual write() and let safe_write only write to an outbuf, like we seem to already do with sockets. Code in tput() and dequeue_sockets() seems also related. It looked very complicated.
In the end, this second uninvasive fix stops foreground STDOUT from being set into non blocking mode.


Test cases demonstrating functionality (if applicable):
