### PR TITLE
(Fix #679) Fix "openssl s_client" fails with "invalid handle: 1;2c" under rxvt-unicode

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1561,6 +1561,9 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
     lostdcc(idx);
     return;
   }
+  /* rxvt-unicode */
+  if (!strncmp(buf, "\e[?1;2c", 7))
+    buf += 7;
   dcc[idx].user = get_user_by_handle(userlist, buf);
   get_user_flagrec(dcc[idx].user, &fr, NULL);
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #679

One-line summary:
Fix "openssl s_client" fails with "invalid handle: 1;2c" under rxvt-unicode

Additional description (if needed):
If Nickname starts with "\e[?1;2c", skip those chars.
This looks like a (too) quick solution to _my_ problem.
So maybe there is more to this and you can provide more detail / intel.
Else, please just merge this in for i dont think im the only one who sufferes from this bug.


Test cases demonstrating functionality (if applicable):
