### PR TITLE
Fix gcc 8 stringop-truncation warning

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1053,7 +1053,7 @@ void parserespacket(uint8_t *response, int len)
           return;
         }
         ddebug1(RES_MSG "answered domain is CNAME for: %s", namestring);
-        strncpy(stackstring, namestring, 1024);
+        strlcpy(stackstring, namestring, sizeof stackstring);
         break;
       default:
         ddebug2(RES_ERR "Received unimplemented data type: %u (%s)",


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix gcc 8 stringop-truncation warning

Additional description (if needed):
This fixes the following gcc8 warning:
```
.././dns.mod/coredns.c:1056:9: warning: ‘strncpy’ output may be truncated copying 1024 bytes from a string of length 1024 [-Wstringop-truncation]
         strncpy(stackstring, namestring, 1024);
```
Note: don't alter CFLAGS, or you may miss this compiler warning

Test cases demonstrating functionality (if applicable):
quick ./eggdrop -nt, was ok, but that didn't traverse the changed code. Still, im feeling fine about this patch.