### PR TITLE
strncpyz() -> strlcpy() for one slipped in between the merges

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2033,7 +2033,7 @@ static int gotkick(char *from, char *origmsg)
   struct userrec *u;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
-  strncpyz(buf2, origmsg, sizeof buf2);
+  strlcpy(buf2, origmsg, sizeof buf2);
   msg = buf2;
   chname = newsplit(&msg);
   chan = findchan(chname);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
strncpyz() -> strlcpy() for one slipped in between the merges

Additional description (if needed):
it slipped in between commit
https://github.com/eggheads/eggdrop/commit/6338ef8c3312ec7ab65af6cf7ccd14ecb6a335e6#diff-7512d4ce76a9d7adc3e45ab1720cf18b
and
https://github.com/eggheads/eggdrop/commit/185a93d899a9a88740fbd46bf5a114aa884521df#diff-7512d4ce76a9d7adc3e45ab1720cf18b

Test cases demonstrating functionality (if applicable):
