### PR TITLE
(Fix #689) Don't send \r\n as an extra tcp packet

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -134,6 +134,16 @@ static int burst;
 #include "tclserv.c"
 
 
+static void write_to_server(char *s, unsigned int len) {
+  char *s2 = nmalloc(len + 2);
+
+  memcpy(s2, s, len);
+  s2[len] = '\r';
+  s2[len + 1] = '\n';
+  tputs(serv, s2, len + 2);
+  nfree(s2);
+}
+
 /*
  *     Bot server queues
  */

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -86,11 +86,6 @@
         ptr = NULL;                                     \
 } while (0)
 
-#define write_to_server(x,y) do {                       \
-        tputs(serv, (x), (y));                          \
-        tputs(serv, "\r\n", 2);                         \
-} while (0)
-
 #endif /* MAKING_SERVER */
 
 struct server_list {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #689

One-line summary:
Don't send \r\n as an extra tcp packet

Additional description (if needed):
This bug was sideeffect of fix commit be4573ed309b81623989dc652f131537e7be4534 for eggdrop 1.6.16 in 2004, see Changes1.6.:
```
[... ]
1.6.16 (May 31, 2004):
[...]
  - Fix text sent to the server being terminated with "\x00\x0d\x0a"             
    instead of just "\x0d\x0a".                                                  
    Patch by: Sven  
[...]
```

Test cases demonstrating functionality (if applicable):
