### PR TITLE
Fix clang compiler warning -Wstrlcpy-strlcat-size

### DIFF
--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -112,7 +112,7 @@ static void add_delay(struct chanset_t *chan, int plsmns, int mode, char *mask)
   d->seconds = now + randint(30);
 
   d->mask = nmalloc(strlen(mask) + 1);
-  strlcpy(d->mask, mask, strlen(mask) + 1);
+  strcpy(d->mask, mask);
 
   if (!delay_head)
     delay_head = d;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix clang compiler warning -Wstrlcpy-strlcat-size

Additional description (if needed):
Eggdrop current git version (20181012)
FreeBSD 12.0-ALPHA8
clang 6.0.1


Test cases demonstrating functionality (if applicable):
```
$ make
[...]
cc -shared -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod -I/usr/local/include -DHAVE_CONFIG_H -I/usr/local/include/tcl8.7 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../../../server.so ../server.o -L/usr/local/lib  -L/usr/local/lib -ltcl8.7  -lz -lpthread -lm -lssl -lcrypto -ldl  && touch ../../../server.so
cc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod -I/usr/local/include -DHAVE_CONFIG_H -I/usr/local/include/tcl8.7 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././share.mod/share.c && mv -f share.o ../
.././share.mod/share.c:115:33: warning: size argument in 'strlcpy' call appears to be size of the source; expected the
      size of the destination [-Wstrlcpy-strlcat-size]
  strlcpy(d->mask, mask, strlen(mask) + 1);
                         ~~~~~~~^~~~~~~~~
1 warning generated.
[...]
```