### PR TITLE
Fix 1 Wstringop-truncation; Optimize remove_crlf()

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -260,14 +260,16 @@ char *splitnick(char **blah)
 
 void remove_crlf(char **line)
 {
-  char *p;
+  char *p = *line;
 
-  p = strchr(*line, '\n');
-  if (p != NULL)
-    *p = 0;
-  p = strchr(*line, '\r');
-  if (p != NULL)
-    *p = 0;
+  while (*p) {
+    if (*p == '\r' || *p == '\n')
+    {
+      *p = 0;
+      break;
+    }
+    p++;
+  }
 }
 
 char *newsplit(char **rest)

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -810,10 +810,9 @@ static void queue_server(int which, char *msg, int len)
   /* Remove \r\n. We will add these back when we send the text to the server.
    * - Wcc [01/09/2004]
    */
-  strncpy(buf, msg, sizeof buf);
+  strlcpy(buf, msg, sizeof buf);
   msg = buf;
   remove_crlf(&msg);
-  buf[510] = 0;
   len = strlen(buf);
 
   /* No queue for PING and PONG - drummer */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix 1 Wstringop-truncation; Optimize remove_crlf()

Additional description (if needed):
Fixes 1 of the compiler warnings (8) in #703

Test cases demonstrating functionality (if applicable):
