### PR TITLE
Fix ipv4 only eggdrop

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -491,7 +491,11 @@ static int proxy_connect(int sock, sockname_t *addr)
  */
 static int get_port_from_addr(const sockname_t *addr)
 {
+#ifdef IPV6
   return ntohs((addr->family == AF_INET) ? addr->addr.s4.sin_port : addr->addr.s6.sin6_port);
+#else
+  return addr->addr.s4.sin_port;
+#endif
 }
 
 /* Starts a connection attempt through a socket


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix ipv4 only eggdrop

Additional description (if needed):
I broke it with commit 89a3fd0543d80a54a5c9a2fa0cc324749a9afcf2


Test cases demonstrating functionality (if applicable):
