### PR TITLE
Added a note regarding source path

### DIFF
--- a/README
+++ b/README
@@ -100,7 +100,7 @@ GIT USAGE
 
     https://github.com/eggheads/eggdrop/archive/develop.tar.gz
 
-  Please be carefule where you save your source code. Eggdrop installs to
+  Please be careful where you save your source code. Eggdrop installs to
   ~/eggdrop by default, and it can be confusing to have your source there as
   well.
 

--- a/README
+++ b/README
@@ -85,10 +85,7 @@ GIT USAGE
   to git. If you are interested in trying out the VERY LATEST updates to
   Eggdrop, you may want be interested in pulling the most recent code
   from there. BE WARNED, the development branch of Eggdrop is not to be
-  considered stable and may (haha) have some significant bugs in it. The
-  Eggheads Development Team will in NO WAY take any responsibility for
-  whatever might happen to you or your shell if you use the development
-  branch of Eggdrop!
+  considered stable and may (haha) have some significant bugs in it.
 
   To obtain Eggdrop via the git repository (hosted by GitHub), you can
   either clone the repository via git or download a development
@@ -102,6 +99,10 @@ GIT USAGE
   from:
 
     https://github.com/eggheads/eggdrop/archive/develop.tar.gz
+
+  Please be carefule where you save your source code. Eggdrop installs to
+  ~/eggdrop by default, and it can be confusing to have your source there as
+  well.
 
 
 QUICK STARTUP

--- a/README
+++ b/README
@@ -103,7 +103,7 @@ GIT USAGE
   ~/eggdrop by default, and it can be confusing to have your source there as
   well. You could specify a destination dir like this:
 
-      git clone https://github.com/eggheads/eggdrop.git <dir>
+      git clone https://github.com/eggheads/eggdrop.git [dir]
 
   Otherwise, you can download the development snapshot as a tar archive
   from:

--- a/README
+++ b/README
@@ -103,7 +103,7 @@ GIT USAGE
   ~/eggdrop by default, and it can be confusing to have your source there as
   well. You could specify a destination dir like this:
 
-      git clone git://github.com/eggheads/eggdrop.git <dir>
+      git clone https://github.com/eggheads/eggdrop.git <dir>
 
   Otherwise, you can download the development snapshot as a tar archive
   from:

--- a/README
+++ b/README
@@ -93,16 +93,22 @@ GIT USAGE
 
   To clone the repository, simply type:
 
-      git clone https://github.com/eggheads/eggdrop.git 
+      git clone https://github.com/eggheads/eggdrop.git
+
+  If https doesn't work for you, simply type:
+
+      git clone git://github.com/eggheads/eggdrop.git
+
+  Please be careful where you save your source code. Eggdrop installs to
+  ~/eggdrop by default, and it can be confusing to have your source there as
+  well. You could specify a destination dir like this:
+
+      git clone git://github.com/eggheads/eggdrop.git <dir>
 
   Otherwise, you can download the development snapshot as a tar archive
   from:
 
     https://github.com/eggheads/eggdrop/archive/develop.tar.gz
-
-  Please be careful where you save your source code. Eggdrop installs to
-  ~/eggdrop by default, and it can be confusing to have your source there as
-  well.
 
 
 QUICK STARTUP


### PR DESCRIPTION
Found by: jackal^
Patch by: simple, Robby, michaelortmann
Fixes: 

One-line summary:
Added a note regarding source path and removed too obvious time wasting statement

Additional description (if needed):
The issue was:
jackal^> so im in ~, if i git clone, i end up with ~/eggdrop. if i ./configure, i end up with eggdrop binary in source dir

Test cases demonstrating functionality (if applicable):

