### PR TITLE
Fix 1 Wformat-overflow

### DIFF
--- a/src/userrec.c
+++ b/src/userrec.c
@@ -635,17 +635,15 @@ struct userrec *adduser(struct userrec *bu, char *handle, char *host,
   }
   set_user(&USERENTRY_PASS, u, pass);
   if (!noxtra) {
-    char *now2;
+    int l;
     xk = nmalloc(sizeof *xk);
     xk->key = nmalloc(8);
     strcpy(xk->key, "created");
-    now2 = nmalloc(15);
     tv = now;
-    sprintf(now2, "%li", tv);
-    xk->data = nmalloc(strlen(now2) + 1);
+    l = snprintf(NULL, 0, "%li", tv);
+    xk->data = nmalloc(l + 1);
     sprintf(xk->data, "%li", tv);
     set_user(&USERENTRY_XTRA, u, xk);
-    nfree(now2);
   }
   /* Strip out commas -- they're illegal */
   if (host && host[0]) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix 1 Wformat-overflow with gcc 8.2.1 and CFLAGS -fsanitize=undefined

Additional description (if needed):
First i thought we should replace nmalloc(size) with buffer[size] because nmalloc(size) was called with a constant size of 15.
Then i understood that the code block wants to find out the size of the final string to allocate and put in a structure.
So i recoded that part, to clearly show the intention by using the pattern
```
len = snprintf(null, 0, ...)
s = malloc(len + 1)
sprintf(s, ...)
```


Test cases demonstrating functionality (if applicable):
```
userrec.c: In function ‘adduser’:
userrec.c:644:5: warning: null destination pointer [-Wformat-overflow=]
     sprintf(now2, "%li", tv);
     ^~~~~~~~~~~~~~~~~~~~~~~~
```