### PR TITLE
Fix forgotten include for some systems like ~8 year old OpenBSD 4.7

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -26,6 +26,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <sys/time.h>
 #include <sys/resource.h>
 #include "main.h"
 #include "chan.h"


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #718

One-line summary:
Fix forgotten include for some systems like ~8 year old OpenBSD 4.7

Additional description (if needed):
commit 160734f broke `make` for some systems
including <sys/time.h> before <sys/resource.h> fixes this

Test cases demonstrating functionality (if applicable):
