### PR TITLE
Fix Wstringop-truncation and Wformat-overflow

### DIFF
--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -591,9 +591,8 @@ static void channels_report(int idx, int details)
       get_mode_protect(chan, s2);
 
       if (s2[0]) {
-        s1[0] = 0;
-        sprintf(s1, ", enforcing \"%s\"", s2);
-        strcat(s, s1);
+        int len = strlen(s);
+        egg_snprintf(s + len, (sizeof s) - len, ", enforcing \"%s\"", s2); /* Concatenation */
       }
 
       s2[0] = 0;
@@ -606,18 +605,15 @@ static void channels_report(int idx, int details)
         strcat(s2, "bitch, ");
 
       if (s2[0]) {
+        int len = strlen(s);
         s2[strlen(s2) - 2] = 0;
-
-        s1[0] = 0;
-        sprintf(s1, " (%s)", s2);
-        strcat(s, s1);
+        egg_snprintf(s + len, (sizeof s) - len, " (%s)", s2); /* Concatenation */
       }
 
       /* If it's a !chan, we want to display it's unique name too <cybah> */
       if (chan->dname[0] == '!') {
-        s1[0] = 0;
-        sprintf(s1, ", unique name %s", chan->name);
-        strcat(s, s1);
+        int len = strlen(s);
+        egg_snprintf(s + len, (sizeof s) - len, ", unique name %s", chan->name); /* Concatenation */
       }
     }
 

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1544,9 +1544,8 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
           strcpy(parcpy, par);
           irp = Tcl_CreateInterp();
           if (tcl_channel_modify(irp, chan, 2, list) == TCL_OK) {
-            char tocat[sizeof answers];
-            egg_snprintf(tocat, sizeof tocat, "%s { %s }", list[0], parcpy);
-            strncat(answers, tocat, sizeof answers - strlen(answers) - 1);
+            int len = strlen(answers);
+            egg_snprintf(answers + len, (sizeof answers) - len, "%s { %s }", list[0], parcpy); /* Concatenation */
           } else if (!all || !chan->next)
             dprintf(idx, "Error trying to set %s for %s, %s\n",
                     list[0], all ? "all channels" : chname, Tcl_GetStringResult(irp));

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -628,10 +628,9 @@ static void display_ban(int idx, int number, maskrec *ban,
     daysago(now, ban->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (ban->added < ban->lastactive) {
-      char tocat[sizeof dates];
+      int len = strlen(dates);
       daysago(now, ban->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + len, (sizeof dates) - len, ", %s %s", MODES_LASTUSED, s); /* Concatenation */
     }
   } else
     dates[0] = 0;
@@ -673,10 +672,9 @@ static void display_exempt(int idx, int number, maskrec *exempt,
     daysago(now, exempt->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (exempt->added < exempt->lastactive) {
-      char tocat[sizeof dates];
+      int len = strlen(dates);
       daysago(now, exempt->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + len, (sizeof dates) - len, ", %s %s", MODES_LASTUSED, s); /* Concatenation */
     }
   } else
     dates[0] = 0;
@@ -718,10 +716,9 @@ static void display_invite(int idx, int number, maskrec *invite,
     daysago(now, invite->added, s);
     sprintf(dates, "%s %s", MODES_CREATED, s);
     if (invite->added < invite->lastactive) {
-      char tocat[sizeof dates];
+      int len = strlen(dates);
       daysago(now, invite->lastactive, s);
-      egg_snprintf(tocat, sizeof tocat, ", %s %s", MODES_LASTUSED, s);
-      strncat(dates, tocat, sizeof dates - strlen(dates) - 1);
+      egg_snprintf(dates + len, (sizeof dates) - len, ", %s %s", MODES_LASTUSED, s); /* Concatenation */
     }
   } else
     dates[0] = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix Wstringop-truncation and Wformat-overflow

Additional description (if needed):
The compiler was noisy about a code pattern like
`[egg_]s[n]printf() + str[n]cat()"
that hereby is cleaned up and also more len and null termination safe.


Test cases demonstrating functionality (if applicable):
