### PR TITLE
Fix (shrink) buffer size, which will fix 4 Wformat-overflow warnings

### DIFF
--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -638,7 +638,7 @@ static void display_ban(int idx, int number, maskrec *ban,
   if (ban->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[30];
+    char s1[29];
 
     days(ban->expire, now, s1);
     sprintf(s, "(expires %s)", s1);
@@ -683,7 +683,7 @@ static void display_exempt(int idx, int number, maskrec *exempt,
   if (exempt->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[30];
+    char s1[29];
 
     days(exempt->expire, now, s1);
     sprintf(s, "(expires %s)", s1);
@@ -728,7 +728,7 @@ static void display_invite(int idx, int number, maskrec *invite,
   if (invite->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[30];
+    char s1[29];
 
     days(invite->expire, now, s1);
     sprintf(s, "(expires %s)", s1);

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -638,7 +638,7 @@ static void display_ban(int idx, int number, maskrec *ban,
   if (ban->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[41];
+    char s1[30];
 
     days(ban->expire, now, s1);
     sprintf(s, "(expires %s)", s1);
@@ -683,7 +683,7 @@ static void display_exempt(int idx, int number, maskrec *exempt,
   if (exempt->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[41];
+    char s1[30];
 
     days(exempt->expire, now, s1);
     sprintf(s, "(expires %s)", s1);
@@ -728,7 +728,7 @@ static void display_invite(int idx, int number, maskrec *invite,
   if (invite->flags & MASKREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[41];
+    char s1[30];
 
     days(invite->expire, now, s1);
     sprintf(s, "(expires %s)", s1);

--- a/src/users.c
+++ b/src/users.c
@@ -157,7 +157,7 @@ void display_ignore(int idx, int number, struct igrec *ignore)
   if (ignore->flags & IGREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[30];
+    char s1[29];
 
     days(ignore->expire, now, s1);
     sprintf(s, "(expires %s)", s1);

--- a/src/users.c
+++ b/src/users.c
@@ -157,7 +157,7 @@ void display_ignore(int idx, int number, struct igrec *ignore)
   if (ignore->flags & IGREC_PERM)
     strcpy(s, "(perm)");
   else {
-    char s1[41];
+    char s1[30];
 
     days(ignore->expire, now, s1);
     sprintf(s, "(expires %s)", s1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix (shrink) buffer size, which will fix 4 Wformat-overflow warnings

Additional description (if needed):
The buffer must be big enough for the output of misc.c:days():
`sprintf(out, "in %d day%s", days, (days == 1) ? "" : "s");`
Python comes to rescue ;):
```
>>> s = "in %s days" % (2 ** 64 - 1)
>>> s, len(s) + 1
('in 18446744073709551615 days', 29)
```
Maybe we could shrink it more, because the day count wont probably go that high (2**64 - 1)
But why take any risk.
The real problem here is of course, that we have to hardcode buffer size due to bad API, but we don't wanna break it here, maybe 1.9+.


Test cases demonstrating functionality (if applicable):
The following 4 gcc 8.2 compiler warnings go away:
```
users.c: In function ‘display_ignore’:
users.c:163:26: warning: ‘%s’ directive writing up to 40 bytes into a region of size 32 [-Wformat-overflow=]
     sprintf(s, "(expires %s)", s1);
                          ^~    ~~
users.c:163:5: note: ‘sprintf’ output between 11 and 51 bytes into a destination of size 41
     sprintf(s, "(expires %s)", s1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
.././channels.mod/userchan.c:734:26: warning: ‘%s’ directive writing up to 40 bytes into a region of size 32 [-Wformat-overflow=]
     sprintf(s, "(expires %s)", s1);
                          ^~    ~~
.././channels.mod/userchan.c:734:5: note: ‘sprintf’ output between 11 and 51 bytes into a destination of size 41
     sprintf(s, "(expires %s)", s1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
.././channels.mod/userchan.c:689:26: warning: ‘%s’ directive writing up to 40 bytes into a region of size 32 [-Wformat-overflow=]
     sprintf(s, "(expires %s)", s1);
                          ^~    ~~
.././channels.mod/userchan.c:689:5: note: ‘sprintf’ output between 11 and 51 bytes into a destination of size 41
     sprintf(s, "(expires %s)", s1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
.././channels.mod/userchan.c:644:26: warning: ‘%s’ directive writing up to 40 bytes into a region of size 32 [-Wformat-overflow=]
     sprintf(s, "(expires %s)", s1);
                          ^~    ~~
.././channels.mod/userchan.c:644:5: note: ‘sprintf’ output between 11 and 51 bytes into a destination of size 41
     sprintf(s, "(expires %s)", s1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```