### PR TITLE
Make userrec:expmem_mask() static

### DIFF
--- a/src/userrec.c
+++ b/src/userrec.c
@@ -74,7 +74,7 @@ void *_user_realloc(void *ptr, int size, const char *file, int line)
 #endif
 }
 
-int expmem_mask(struct maskrec *m)
+static int expmem_mask(struct maskrec *m)
 {
   int result = 0;
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Make userrec:expmem_mask() static

Additional description (if needed):
We should always use static if possible
Fix part of #176
http://www.sisyphus.ru/en/srpm/Sisyphus/eggdrop/patches/1
I know, that patch looks like one of the usual "remove inline keyword" patches,
but i also found the +static in there

Test cases demonstrating functionality (if applicable):
A small test compiling, starting, share linking, server joining, was successful.