### PR TITLE
 \e isn't C standard so we use \x1B instead (make error)

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1558,7 +1558,7 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
     return;
   }
   /* rxvt-unicode */
-  if (!strncmp(buf, "\e[?1;2c", 7))
+  if (!strncmp(buf, "\x1B[?1;2c", 7)) /* \e isn't C standard so we use \x1B instead */
     buf += 7;
   dcc[idx].user = get_user_by_handle(userlist, buf);
   get_user_flagrec(dcc[idx].user, &fr, NULL);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
 \e isn't C standard so we use \x1B instead


Additional description (if needed):
commit 1e28068f4d1c00d5e9114b27c36ee15fdf96a494 **broke some compilers**
gcc, clang and tcc are fine, but others like nwcc are not.
see https://en.wikipedia.org/wiki/Escape_sequences_in_C#Non-standard_escape_sequences


Test cases demonstrating functionality (if applicable):
```
$ CC=nwcc make
[...]
nwcc -march=native -O2 -pipe -fstack-protector-strong -fno-plt -fomit-frame-pointer -I.. -I..  -DHAVE_CONFIG_H -I/usr/include  -c dcc.c
dcc.c:1561: Error: Invalid escape sequence.
  if (!strncmp(buf, "\e[?1;2c", 7))
                      ^ here
make[1]: *** [Makefile:82: dcc.o] Error 1
```