### PR TITLE
Fix nwcc compiler error

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -972,7 +972,7 @@ void parserespacket(uint8_t *response, int len)
       return;
     }
     c += 10 + rr->datalength;
-    if (0 > response + len) {
+    if (c > response + len) {
       ddebug0(RES_ERR "Specified rdata length exceeds packet size.");
       return;
     }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #729

One-line summary:
Fix nwcc compiler error

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
In my test, if a resolve was successful, c was equal to response + len.
So im confident this is the real solution.
I tested with additional debug print inside code that you won't see here.
What you could see is that the compiler error with nwcc is gone.