### PR TITLE
Allow -HQ to be added when no userfile is present.

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -689,7 +689,7 @@ int isowner(char *name) {
  */
 void add_hq_user()
 {
-  if (!backgrd && term_z >= 0 && userlist) {
+  if (!backgrd && term_z >= 0) {
     /* HACK: Workaround using dcc[].nick not to pass literal "-HQ" as a non-const arg */
     dcc[term_z].user = get_user_by_handle(userlist, dcc[term_z].nick);
     /* Make sure there's an innocuous -HQ user if needed */


### PR DESCRIPTION
Found by: Geo
Patch by: Cizzle
Fixes: #727 

One-line summary: Fixes powerless -HQ user when eggdrop is started with -ntm.
