### PR TITLE
Fix forgoten #include <signal.h> (make error OpenIndiana)

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -26,6 +26,7 @@
 #include "tandem.h"
 #include "modules.h"
 #include <ctype.h>
+#include <signal.h>
 
 extern struct chanset_t *chanset;
 extern struct dcc_t *dcc;

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -24,6 +24,7 @@
 #define _EGG_MOD_MODULE_H
 
 /* Just include *all* the include files...it's slower but EASIER */
+#include <signal.h>
 #include "src/main.h"
 #include "modvals.h"
 #include "src/tandem.h"

--- a/src/modules.c
+++ b/src/modules.c
@@ -24,6 +24,7 @@
  */
 
 #include <ctype.h>
+#include <signal.h>
 #include "main.h"
 #include "modules.h"
 #include "tandem.h"

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -25,6 +25,7 @@
 #include "tandem.h"
 #include "modules.h"
 #include <errno.h>
+#include <signal.h>
 
 extern Tcl_Interp *interp;
 extern tcl_timer_t *timer, *utimer;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes:  #732 

One-line summary:
Fix forgoten #include <signal.h> (make error OpenIndiana)

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
