### PR TITLE
Convert some strncpy() to strlcpy()

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1066,22 +1066,17 @@ static int tcl_channel_get(Tcl_Interp *irp, struct chanset_t *chan,
 
   if (!strcmp(setting, "chanmode"))
     get_mode_protect(chan, s);
-  else if (!strcmp(setting, "need-op")) {
-    strncpy(s, chan->need_op, 120);
-    s[120] = 0;
-  } else if (!strcmp(setting, "need-invite")) {
-    strncpy(s, chan->need_invite, 120);
-    s[120] = 0;
-  } else if (!strcmp(setting, "need-key")) {
-    strncpy(s, chan->need_key, 120);
-    s[120] = 0;
-  } else if (!strcmp(setting, "need-unban")) {
-    strncpy(s, chan->need_unban, 120);
-    s[120] = 0;
-  } else if (!strcmp(setting, "need-limit")) {
-    strncpy(s, chan->need_limit, 120);
-    s[120] = 0;
-  } else if (!strcmp(setting, "idle-kick"))
+  else if (!strcmp(setting, "need-op"))
+    strlcpy(s, chan->need_op, sizeof s);
+  else if (!strcmp(setting, "need-invite"))
+    strlcpy(s, chan->need_invite, sizeof s);
+  else if (!strcmp(setting, "need-key"))
+    strlcpy(s, chan->need_key, sizeof s);
+  else if (!strcmp(setting, "need-unban"))
+    strlcpy(s, chan->need_unban, sizeof s);
+  else if (!strcmp(setting, "need-limit"))
+    strlcpy(s, chan->need_limit, sizeof s);
+  else if (!strcmp(setting, "idle-kick"))
     simple_sprintf(s, "%d", chan->idle_kick);
   else if (!strcmp(setting, "stopnethack-mode") || !strcmp(setting, "stop-net-hack"))
     simple_sprintf(s, "%d", chan->stopnethack_mode);
@@ -1258,8 +1253,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel need-op needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(chan->need_op, item[i], 120);
-      chan->need_op[120] = 0;
+      strlcpy(chan->need_op, item[i], sizeof chan->need_op);
     } else if (!strcmp(item[i], "need-invite")) {
       i++;
       if (i >= items) {
@@ -1267,8 +1261,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel need-invite needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(chan->need_invite, item[i], 120);
-      chan->need_invite[120] = 0;
+      strlcpy(chan->need_invite, item[i], sizeof chan->need_invite);
     } else if (!strcmp(item[i], "need-key")) {
       i++;
       if (i >= items) {
@@ -1276,8 +1269,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel need-key needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(chan->need_key, item[i], 120);
-      chan->need_key[120] = 0;
+      strlcpy(chan->need_key, item[i], sizeof chan->need_key);
     } else if (!strcmp(item[i], "need-limit")) {
       i++;
       if (i >= items) {
@@ -1285,8 +1277,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel need-limit needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(chan->need_limit, item[i], 120);
-      chan->need_limit[120] = 0;
+      strlcpy(chan->need_limit, item[i], sizeof chan->need_limit);
     } else if (!strcmp(item[i], "need-unban")) {
       i++;
       if (i >= items) {
@@ -1294,8 +1285,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel need-unban needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(chan->need_unban, item[i], 120);
-      chan->need_unban[120] = 0;
+      strlcpy(chan->need_unban, item[i], sizeof chan->need_unban);
     } else if (!strcmp(item[i], "chanmode")) {
       i++;
       if (i >= items) {
@@ -1303,8 +1293,7 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
           Tcl_AppendResult(irp, "channel chanmode needs argument", NULL);
         return TCL_ERROR;
       }
-      strncpy(s, item[i], 120);
-      s[120] = 0;
+      strlcpy(s, item[i], sizeof s);
       set_mode_protect(chan, s);
     } else if (!strcmp(item[i], "idle-kick")) {
       i++;

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -281,17 +281,11 @@ char *ctcp_start(Function *global_funcs)
   add_tcl_ints(myints);
   add_builtins(H_ctcp, myctcp);
   add_help_reference("ctcp.help");
-  if (!ctcp_version[0]) {
-    strncpy(ctcp_version, ver, 120);
-    ctcp_version[120] = 0;
-  }
-  if (!ctcp_finger[0]) {
-    strncpy(ctcp_finger, ver, 120);
-    ctcp_finger[120] = 0;
-  }
-  if (!ctcp_userinfo[0]) {
-    strncpy(ctcp_userinfo, ver, 120);
-    ctcp_userinfo[120] = 0;
-  }
+  if (!ctcp_version[0])
+    strlcpy(ctcp_version, ver, sizeof ctcp_version);
+  if (!ctcp_finger[0])
+    strlcpy(ctcp_finger, ver, sizeof ctcp_finger);
+  if (!ctcp_userinfo[0])
+    strlcpy(ctcp_userinfo, ver, sizeof ctcp_userinfo);
   return NULL;
 }

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -94,9 +94,8 @@ static int tcl_putquick STDVAR
                      "-normal -next", NULL);
     return TCL_ERROR;
   }
-  strncpy(s, argv[1], 510);
+  strlcpy(s, argv[1], sizeof s);
 
-  s[510] = 0;
   p = strchr(s, '\n');
   if (p != NULL)
     *p = 0;
@@ -122,9 +121,8 @@ static int tcl_putserv STDVAR
                      "-normal -next", NULL);
     return TCL_ERROR;
   }
-  strncpy(s, argv[1], 510);
+  strlcpy(s, argv[1], sizeof s);
 
-  s[510] = 0;
   p = strchr(s, '\n');
   if (p != NULL)
     *p = 0;
@@ -150,9 +148,8 @@ static int tcl_puthelp STDVAR
                      "-normal -next", NULL);
     return TCL_ERROR;
   }
-  strncpy(s, argv[1], 510);
+  strlcpy(s, argv[1], sizeof s);
 
-  s[510] = 0;
   p = strchr(s, '\n');
   if (p != NULL)
     *p = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Convert some strncpy() to strlcpy()

Additional description (if needed):
Also fixes compiler warning 14 in #703

Test cases demonstrating functionality (if applicable):
