### PR TITLE
Fix 354 whox with workaround until 005 support

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1100,7 +1100,7 @@ static int got352(char *from, char *msg)
   return 0;
 }
 
-/* got a 354: who info! - iru style
+/* got a 354: who info! - ircu style whox
  */
 static int got354(char *from, char *msg)
 {
@@ -1116,6 +1116,10 @@ static int got354(char *from, char *msg)
         user = newsplit(&msg);  /* Grab the user */
         host = newsplit(&msg);  /* Grab the host */
         nick = newsplit(&msg);  /* Grab the nick */
+        if (strchr(nick, '.')) { /* FIXME: Use 005 WHOX instead */
+          host = nick;
+          nick = newsplit(&msg);
+        }
         flags = newsplit(&msg); /* Grab the flags */
         got352or4(chan, user, host, nick, flags);
       }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1116,7 +1116,7 @@ static int got354(char *from, char *msg)
         user = newsplit(&msg);  /* Grab the user */
         host = newsplit(&msg);  /* Grab the host */
         nick = newsplit(&msg);  /* Grab the nick */
-        if (strchr(nick, '.')) { /* FIXME: Use 005 WHOX instead */
+        if (strchr(nick, '.') || strchr(nick, ':')) { /* FIXME: Use 005 WHOX instead */
           host = nick;
           nick = newsplit(&msg);
         }


### PR DESCRIPTION
Found by: key2peace
Patch by: michaelortmann
Fixes: #739

One-line summary:
Fix 354 whox with workaround until 005 support

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.console +drv
[...]
.set use-354
[20:28:14] tcl: builtin dcc call: *dcc:set -HQ 1 use-354
[20:28:14] #-HQ# set use-354
Currently: 1
.set net-type
[20:28:20] tcl: builtin dcc call: *dcc:set -HQ 1 net-type
[20:28:20] #-HQ# set net-type
Currently: 2
.server
[20:28:28] tcl: builtin dcc call: *dcc:servers -HQ 1 
[20:28:28] #-HQ# servers
Server list:
  [Ashburn.Va.Us.UnderNet.org]:6667 (Chicago.IL.US.Undernet.Org) <- I am here
End of server list.
```
Before:
```
.channel
[15:09:27] tcl: builtin dcc call: *dcc:channel -HQ 1 
[15:09:27] #-HQ# (#chan739) channel
Channel #chan739, 1 member, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME  HANDLE     JOIN  IDLE  USER@HOST
@bot739    *          ---        <- it's me!
End of channel info.
.tcl putserv "WHO #chan739 %xcnihurf"
[15:09:39] tcl: builtin dcc call: *dcc:tcl -HQ 1 putserv "WHO #chan739 %xcnihurf"
[15:09:39] tcl: evaluate (.tcl): putserv "WHO #chan739 %xcnihurf"
[15:09:39] [!s] WHO #chan739 %xcnihurf
Tcl: 
[15:09:40] [s->] WHO #chan739 %xcnihurf
[15:09:40] [@] Chicago.IL.US.Undernet.Org 354 bot739 #chan739 ~bot739 93.194.1.1 foo.dip0.t-ipconnect.de bot739 H@ :/msg bot739 hello
[15:09:40] [@] Chicago.IL.US.Undernet.Org 315 bot739 #chan739 :End of /WHO list.
.channel
[15:09:44] tcl: builtin dcc call: *dcc:channel -HQ 1 
[15:09:44] #-HQ# (#chan739) channel
Channel #chan739, 2 members, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME                      HANDLE     JOIN  IDLE  USER@HOST
@bot739                        *          ---        <- it's me!
 foo.dip0.t-ipconnect.de *          ---         ~bot739@93.194.1.1
End of channel info.
```
After (this test with a second user in the channel):
```
.channel
[17:05:56] tcl: builtin dcc call: *dcc:channel -HQ 1 
[17:05:56] #-HQ# (#chan739) channel
Channel #chan739, 2 members, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME  HANDLE     JOIN  IDLE  USER@HOST
 bot739    *          ---        <- it's me!
 user739   *          ---         ~michael@foo.dip0.t-ipconnect.de
End of channel info.
.tcl putserv "WHO #chan739 %xcnihurf"
[17:06:00] tcl: builtin dcc call: *dcc:tcl -HQ 1 putserv "WHO #chan739 %xcnihurf"
[17:06:00] tcl: evaluate (.tcl): putserv "WHO #chan739 %xcnihurf"
[17:06:00] [!s] WHO #chan739 %xcnihurf
Tcl: 
[17:06:00] [s->] WHO #chan739 %xcnihurf
[17:06:00] [@] tulip.eu.ix.undernet.org 354 bot739 #chan739 ~bot739 93.194.1.1 foo.dip0.t-ipconnect.de bot739 H :/msg bot739 hello
[17:06:00] [@] tulip.eu.ix.undernet.org 354 bot739 #chan739 ~michael 93.194.1.1 foo.dip0.t-ipconnect.de user739 H :*Unknown*
[17:06:00] [@] tulip.eu.ix.undernet.org 315 bot739 #chan739 :End of /WHO list.
.channel
[17:06:02] tcl: builtin dcc call: *dcc:channel -HQ 1 
[17:06:02] #-HQ# (#chan739) channel
Channel #chan739, 2 members, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME  HANDLE     JOIN  IDLE  USER@HOST
 bot739    *          ---        <- it's me!
 user739   *          ---         ~michael@foo.dip0.t-ipconnect.de
End of channel info.
```