### PR TITLE
(Cleanup) Made 2 char arrays in blowfish.c const

### DIFF
--- a/src/mod/blowfish.mod/blowfish.c
+++ b/src/mod/blowfish.mod/blowfish.c
@@ -265,9 +265,9 @@ static void blowfish_init(uint8_t *key, int keybytes)
 #define SALT2  0x23f6b095
 
 /* Convert 64-bit encrypted password to text for userfile */
-static char *base64 =
+static const char *base64 =
             "./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static char *cbcbase64 =
+static const char *cbcbase64 =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
 static int base64dec(char c)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
(Cleanup) Made 2 char arrays in blowfish.c const

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
quick compile, run, link to anotherbot, share userfile, ok