### PR TITLE
(Cleanup) const -> sizeof

### DIFF
--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -714,7 +714,7 @@ static char *mktempfile(char *filename)
   char rands[8], *tempname, *fn = filename;
   int l;
 
-  make_rand_str(rands, 7);
+  make_rand_str(rands, sizeof rands - 1);
   l = strlen(filename);
   if ((l + MKTEMPFILE_TOT) > NAME_MAX) {
     fn[NAME_MAX - MKTEMPFILE_TOT] = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
(Cleanup) const -> sizeof

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
quick compile, run, link to anotherbot, share userfile, ok