### PR TITLE
(Cleanup) cost -> sizeof, equalize code of compress.c / filesys.c

### DIFF
--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -296,14 +296,14 @@ static int compress_to_file(char *f_src, char *f_target, int mode_num)
  */
 static int compress_file(char *filename, int mode_num)
 {
-  char *temp_fn, randstr[5];
+  char *temp_fn, rands[8];
   int ret;
 
   /* Create temporary filename. */
-  temp_fn = nmalloc(strlen(filename) + 5);
-  make_rand_str(randstr, 4);
+  temp_fn = nmalloc(strlen(filename) + sizeof rands);
+  make_rand_str(rands, sizeof rands - 1);
   strcpy(temp_fn, filename);
-  strcat(temp_fn, randstr);
+  strcat(temp_fn, rands);
 
   /* Compress file. */
   ret = compress_to_file(filename, temp_fn, mode_num);
@@ -322,14 +322,14 @@ static int compress_file(char *filename, int mode_num)
  */
 static int uncompress_file(char *filename)
 {
-  char *temp_fn, randstr[5];
+  char *temp_fn, rands[8];
   int ret;
 
   /* Create temporary filename. */
-  temp_fn = nmalloc(strlen(filename) + 5);
-  make_rand_str(randstr, 4);
+  temp_fn = nmalloc(strlen(filename) + sizeof rands);
+  make_rand_str(rands, sizeof rands - 1);
   strcpy(temp_fn, filename);
-  strcat(temp_fn, randstr);
+  strcat(temp_fn, rands);
 
   /* Uncompress file. */
   ret = uncompress_to_file(filename, temp_fn);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
(Cleanup) cost -> sizeof, equalize code / buffer size / variable name of compress.c / filesys.c

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
quick compile, run, link to anotherbot, share userfile, ok