### PR TITLE
Fix plain-to-TLS botlinks to try TLS and try for ports+1 etc too

### DIFF
--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -76,7 +76,9 @@ Eggdrop can use TLS connections to protect botnet links if it is compiled with T
 | +port                        | listen +port               | connect with TLS             |
 +------------------------------+----------------------------+------------------------------+
 
-To explicitly require all links to a hub be SSL-only (ie, prevent any plain text connection from being allowed), prefix the listen port in the hub configuration file with a plus (+) sign. Conversely, to force a leaf to only allow SSL (not plain text) connections with a hub, you must prefix the hub's listen port with a plus when adding it to the leaf via +bot/chaddr commands. The nickname and password are sent before SSL negotiation takes place (the password is not sent in plain text anyway). If SSL negotiation fails and either the hub or leaf is set to require SSL, the connection is deliberately aborted and no clear text is ever sent.
+* Currently, adding a bot with +port and connecting to a hub listening on port does not work
+
+To explicitly require all links to a hub be TLS-only (ie, prevent any plain text connection from being allowed), prefix the listen port in the hub configuration file with a plus (+) sign. Conversely, to force a leaf to only allow TLS (not plain text) connections with a hub, you must prefix the hub's listen port with a plus when adding it to the leaf via +bot/chaddr commands. The nickname and password are sent before TLS negotiation takes place (the password is not sent in plain text anyway). If TLS negotiation fails and either the hub or leaf is set to require TLS, the connection is deliberately aborted and no clear text is ever sent.
 
 ^^^^^^^^^^
 Secure DCC
@@ -92,10 +94,10 @@ from the bot with /ctcp bot chat), consult the KVIrc documentation.
 Scripts
 ^^^^^^^
 
-Scripts can open or connect to SSL ports the usual way specifying the
+Scripts can open or connect to TLS ports the usual way specifying the
 port with a plus sign. Alternatively, the connection could be
 established as plaintext and later switched on with the starttls Tcl
-command. (Note that the other side should also switch to SSL at the same
+command. (Note that the other side should also switch to TLS at the same
 time - the synchronization is the script's job, not eggdrop's.)
 
 -------------------------------------
@@ -104,7 +106,7 @@ Keys, certificates and authentication
 
 You need a private key and a digital certificate whenever your bot will
 act as a server in a connection of any type. Common examples are hub
-bots and SSL listening ports. General information about certificates and
+bots and TLS listening ports. General information about certificates and
 public key infrastructure can be obtained from Internet. This document
 only contains eggdrop-specific information on the subject.
 The easy way to create a key and a certificate is to type 'make sslcert'
@@ -115,7 +117,7 @@ you fill in therequired fields.
 
 To authenticate with a certificate instead of using password, you should
 make a ssl certificate for yourself and enable ssl-cert-auth in the config
-file. Then either connect to the bot using SSL and type ".fprint +" or
+file. Then either connect to the bot using TLS and type ".fprint +" or
 enter your certificate fingerprint with .fprint SHA1-FINGERPRINT.
 To generate a ssl certificate for yourself, you can run the following
 command from the eggdrop source directory::
@@ -130,7 +132,7 @@ ssl client::
   openssl s_client -cert my.crt -key my.key -connect host:sslport 
     
 ------------
-SSL Settings
+SSL/TLS Settings
 ------------
  
 There are some new settings allowing control over certificate

--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -62,18 +62,21 @@ ssl-certificate for authentication.
 Botnet
 ^^^^^^
 
-By default, eggdrop now automatically attempts to protect botnet links
-with SSL if it is compiled with TLS support. If one of the bots linking 
-does not have TLS support enabled, the connection will fall back to plain 
-text. To explicitly require all links to a hub be SSL-only (ie, prevent 
-plain text connections from being allowed), prefix the listen port in the
-hub configuration file with a plus (+) sign. Conversely, to force a leaf 
-to only allow SSL (not plain text) connections with a hub, you must 
-prefix the hub's listen port with a plus when adding it to the leaf via 
-+bot/chaddr commands. The nickname and password are sent before SSL 
-negotiation takes place (the password is not sent in plain text anyway).
-If SSL negotiation fails and either the hub or leaf is set to require SSL,
-the connection is deliberately aborted and no clear text is ever sent.
+Eggdrop can use TLS connections to protect botnet links if it is compiled with TLS support. TLS-enabled 1.8 bots are backwards compatible with bots that do not have TLS, whether because they are an earlier version or they were not compiled with TLS libraries. Depending on how the user configures the botnet, Eggdrop will use one of two methods to create a TLS connection: raw TLS sockets, and starttls. By prefixing a listen port in the Eggdrop configuration with a plus (+), that specifies that port as a TLS-enabled port, and will only accept TLS connections (no plain text connections will be allowed). Additionally, Eggdrop 1.8 has starttls functionality, where a plain text connection can first be made to a non-TLS port (ie, one that is not prefixed with a plus) and then upgraded to a TLS connection. Currently, Eggdrop automatically attempts a starttls upgrade on all botnet connections. With two TLS-enabled Eggdrops, it graphically looks like this:
+
++------------------------------+----------------------------+------------------------------+
+| Leaf bot sets hub port as... | and Hub bot config uses... | the connection will...       |
++------------------------------+----------------------------+------------------------------+
+| port                         | listen port                | upgrade to TLS with starttls |
++------------------------------+----------------------------+------------------------------+
+| port                         | listen +port               | connect with TLS             |
++------------------------------+----------------------------+------------------------------+
+| +port                        | listen port                | fail. This is a known issue. |
++------------------------------+----------------------------+------------------------------+
+| +port                        | listen +port               | connect with TLS             |
++------------------------------+----------------------------+------------------------------+
+
+To explicitly require all links to a hub be SSL-only (ie, prevent any plain text connection from being allowed), prefix the listen port in the hub configuration file with a plus (+) sign. Conversely, to force a leaf to only allow SSL (not plain text) connections with a hub, you must prefix the hub's listen port with a plus when adding it to the leaf via +bot/chaddr commands. The nickname and password are sent before SSL negotiation takes place (the password is not sent in plain text anyway). If SSL negotiation fails and either the hub or leaf is set to require SSL, the connection is deliberately aborted and no clear text is ever sent.
 
 ^^^^^^^^^^
 Secure DCC

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1041,8 +1041,10 @@ int botlink(char *linker, int idx, char *nick)
       i = new_dcc(&DCC_DNSWAIT, sizeof(struct dns_info));
       dcc[i].timeval = now;
       dcc[i].port = bi->telnet_port;
+/* By default, eggdrop now automatically attempts to protect botnet links with
+ * SSL if it is compiled with TLS support. */
 #ifdef TLS
-      dcc[i].ssl = (bi->ssl & TLS_BOT);
+      dcc[i].ssl = 1;
 #endif
       dcc[i].user = u;
       strcpy(dcc[i].nick, nick);

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1095,7 +1095,7 @@ static void botlink_resolve_success(int i)
   if (ret < 0)
     failed_link(i);
 #ifdef TLS
-  else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
+  else if (ssl_handshake(dcc[i].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[i].host, NULL))
     failed_link(i);
 #endif

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1041,8 +1041,6 @@ int botlink(char *linker, int idx, char *nick)
       i = new_dcc(&DCC_DNSWAIT, sizeof(struct dns_info));
       dcc[i].timeval = now;
       dcc[i].port = bi->telnet_port;
-/* By default, eggdrop now automatically attempts to protect botnet links with
- * SSL if it is compiled with TLS support. */
 #ifdef TLS
       dcc[i].ssl = (bi->ssl & TLS_BOT);
 #endif

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1076,7 +1076,6 @@ static void botlink_resolve_failure(int i)
 
 static void botlink_resolve_success(int i)
 {
-  int ret;
   int idx = dcc[i].u.dns->ibuf;
   char *linker = dcc[i].u.dns->cptr;
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1094,12 +1094,12 @@ static void botlink_resolve_success(int i)
   dcc[i].sock = getsock(dcc[i].sockname.family, SOCK_STRONGCONN);
   if (dcc[i].sock < 0 || open_telnet_raw(dcc[i].sock, &dcc[i].sockname) < 0) {
     failed_link(i);
-}
+  }
 #ifdef TLS
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[i].host, NULL)) {
     failed_link(i);
-}
+  }
 #endif
 }
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1044,7 +1044,7 @@ int botlink(char *linker, int idx, char *nick)
 /* By default, eggdrop now automatically attempts to protect botnet links with
  * SSL if it is compiled with TLS support. */
 #ifdef TLS
-      dcc[i].ssl = 1;
+      dcc[i].ssl = (bi->ssl & TLS_BOT);
 #endif
       dcc[i].user = u;
       strcpy(dcc[i].nick, nick);

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1042,7 +1042,7 @@ int botlink(char *linker, int idx, char *nick)
       dcc[i].timeval = now;
       dcc[i].port = bi->telnet_port;
 #ifdef TLS
-      dcc[i].ssl = (bi->ssl & TLS_BOT);
+      dcc[i].ssl = TLS_BOT;
 #endif
       dcc[i].user = u;
       strcpy(dcc[i].nick, nick);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -252,15 +252,6 @@ static void bot_version(int idx, char *par)
   dprintf(idx, "el\n");
 }
 
-/* Order of attempts:
- * 1. port     ssl
- * 2. port     plain
- * 3. port + 1 ssl
- * 4. port + 1 plain
- * 5. port + 2 ssl
- * 6. port + 2 plain
- * ...
- */
 void failed_link(int idx)
 {
   char s[51], s1[512];
@@ -284,7 +275,26 @@ void failed_link(int idx)
   /* Try next port, if it makes sense (no AF_UNSPEC, ...) */
   killsock(dcc[idx].sock);
   dcc[idx].timeval = now;
+#ifdef TLS
+  /* Order of attempts:
+   * 1. port     ssl
+   * 2. port     plain
+   * 3. port + 1 ssl
+   * 4. port + 1 plain
+   * 5. port + 2 ssl
+   * 6. port + 2 plain
+   * ...
+   */
+  if (dcc[idx].ssl) {
+    dcc[idx].ssl = 0;
+  } else {
+    dcc[idx].port +=1;
+    dcc[idx].ssl = 1;
+  }
+#else
   dcc[idx].port += 1;
+#endif
+
   /* FIXME: Code duplication from botnet.c:botlink_resolve_success() */
   setsnport(dcc[idx].sockname, dcc[idx].port);
   dcc[idx].sock = getsock(dcc[idx].sockname.family, SOCK_STRONGCONN);
@@ -294,7 +304,7 @@ void failed_link(int idx)
   if (ret < 0)
     failed_link(idx);
 #ifdef TLS
-  else if (ssl_handshake(dcc[idx].sock, TLS_CONNECT,
+  else if (dcc[idx].ssl && ssl_handshake(dcc[idx].sock, TLS_CONNECT,
            tls_vfybots, LOG_BOTS, dcc[idx].host, NULL))
     failed_link(idx);
 #endif

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -466,6 +466,9 @@ struct bot_info {
   char linker[NOTENAMELEN + 1]; /* who requested this link              */
   int numver;
   int port;                     /* base port                            */
+#ifdef TLS
+  int ssl;                      /* base ssl                             */
+#endif
   int uff_flags;                /* user file feature flags              */
 };
 
@@ -652,6 +655,10 @@ typedef struct {
 #define SOCK_VIRTUAL    0x0200  /* not-connected socket (dont read it!) */
 #define SOCK_BUFFER     0x0400  /* buffer data; don't notify dcc funcs  */
 #define SOCK_TCL        0x0800  /* tcl socket, don't do anything on it  */
+#ifdef TLS
+#  define SOCK_SENTTLS  0x1000  /* Socket that awaits a starttls in the
+                                 * next read                            */
+#endif
 
 /* Flags to sock_has_data
  */

--- a/src/net.c
+++ b/src/net.c
@@ -521,6 +521,17 @@ int open_telnet_raw(int sock, sockname_t *addr)
   struct timeval tv;
   int i, rc, res;
 
+  for (i = 0; i < dcc_total; i++)
+    if (dcc[i].sock == sock) { /* Got idx from sock ? */
+#ifdef TLS
+      debug4("net: open_telnet_raw(): idx %i host %s port %i ssl %i",
+             i, dcc[i].host, dcc[i].port, dcc[i].ssl);
+#else
+      debug3("net: open_telnet_raw(): idx %i host %s port %i",
+             i, dcc[i].host, dcc[i].port);
+#endif
+      break;
+    }
   getvhost(&name, addr->family);
   if (bind(sock, &name.addr.sa, name.addrlen) < 0) {
     return -1;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #754

One-line summary:
Fix botlink to default to SSL and fallback to PLAIN taking into account PORT+1..n.

**Additional description (if needed):**
During fix and test i discovered an additional error:
If BotA is linked to BotB, and SSL is forced, it would only ssl link for PORT, but not for PORT+1..n, should BotB listen on PORT+1..n. You may try and set `listen +PORT+1` in BotA.conf.
This Additional bug also gets fixed here.


New order of botnet link attempt:
1. port ssl
2. port plain
3. port + 1 ssl
4. port + 1 plain
5. port + 2 ssl
6. port + 2 plain
...

We must always start the order with ssl, because ssl is default for new botlinks.

We must start a new port connect for plain from scratch for every port, because there is no recover from a failed handshake with a non-ssl bot.

Finally i fixed the PORT+n issue by using open_telnet_raw() and ssl_handshake() instead of open_telnet() in dcc.c:failed_link. Therefore i duplicated code from https://github.com/eggheads/eggdrop/blob/develop/src/botnet.c#L1090.

BTW:
1. Added debug log to https://github.com/eggheads/eggdrop/blob/develop/src/net.c#L516
2. Buffer char s in src.c:failed_link() could be reduced from 81 to 51 chars.

**Test cases demonstrating functionality (if applicable):**

**Test 1 - Demo fix of #754**

BotA = eggdrop 1.8.3 compiled without ssl
BotB = eggdrop git compiled with ssl
console +d

BotB:
```
[...]
Eggdrop v1.8.3+sendfprint (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[...]
.whois BotA
[03:34:49] triggering bind dcc:whois
[03:34:49] tcl: builtin dcc call: *dcc:whois -HQ 1 BotA
[03:34:49] #-HQ# whois BotA
HANDLE                           PASS NOTES FLAGS           LAST
BotA                             yes      0 b               23:55 (linked)
  ADDRESS: 127.0.0.1
     users: 3333, bots: 3333
[03:34:49] triggered bind dcc:whois, user 0.049ms sys 0.098ms
```

BotA:
```
[...]
Eggdrop v1.8.3 (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[...]
.status
[03:35:10] tcl: builtin dcc call: *dcc:status -HQ 1 
[03:35:10] #-HQ# status
I am BotA, running eggdrop v1.8.3: 2 users (mem: 91k).
Online for 00:00 (terminal mode) - CPU: 00:00.02 - Cache hit: 66.7%
Configured with: '--prefix=/home/michael/opt/eggdrop-1.8.3-nossl' '--disable-tls'
[...]
TLS support is not available.
```

BotB:
```
.link BotA
[04:55:46] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[04:55:46] #-HQ# link BotA
[04:55:46] Linking to BotA at 127.0.0.1:3333 ...
[04:55:46] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 3333 ssl 1
[04:55:46] TLS: attempting SSL negotiation...
[04:55:46] TLS: state change: before SSL initialization
[04:55:46] TLS: state change: before SSL initialization
[04:55:46] TLS: state change: SSLv3/TLS write client hello
[04:55:46] TLS: awaiting more writes
[04:55:46] TLS: handshake failed due to the following errors: 
[04:55:46] TLS: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
[04:55:46] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 3333 ssl 0
[04:55:46] Received challenge from BotA... sending response ...
[04:55:46] Linked to BotA.
```

BotA:
```
[04:55:46] net: connect! sock 5
[04:55:46] DNS resolved 127.0.0.1 to localhost
[04:55:46] Telnet connection: localhost/39291
[04:55:46] net: eof!(read) socket 11
[04:55:46] Timeout/EOF ident connection
[04:55:46] net: eof!(read) socket 9
[04:55:46] Lost telnet connection to telnet@localhost/39291
[04:55:46] net: connect! sock 5
[04:55:46] DNS resolved 127.0.0.1 to localhost
[04:55:46] Telnet connection: localhost/50267
[04:55:46] net: eof!(read) socket 11
[04:55:46] Timeout/EOF ident connection
[04:55:46] Challenging BotB...
[04:55:46] Linked to BotB.
```

**Test 2 - Demo fix for PORT+2**

sslbot and linux (BotA and BotB) = eggdrop git compiled with ssl
console +d

BotA.conf:
`listen +2500 all`
BotB.conf:
`listen +2512 all`

BotB:
```
[...]
Eggdrop v1.8.3+sendfprint (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[...]
.whois sslbot
[04:59:04] tcl: builtin dcc call: *dcc:whois -HQ 1 sslbot
[04:59:04] #-HQ# whois sslbot
HANDLE                           PASS NOTES FLAGS           LAST
sslbot                           yes      0 b               04:38 (linked)
  BOT FLAGS: p
  HOSTS: *!?sslbot@localhost
  ADDRESS: 127.0.0.1
     users: 2510, bots: 2510
```

BotB:
```
.link sslbot
[05:18:43] tcl: builtin dcc call: *dcc:link -HQ 1 sslbot
[05:18:43] #-HQ# link sslbot
[05:18:43] Linking to sslbot at 127.0.0.1:2510 ...
[05:18:43] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 2510 ssl 1
[05:18:43] net: attempted socket connection refused: 127.0.0.1:2510
[05:18:43] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 2510 ssl 0
[05:18:43] net: attempted socket connection refused: 127.0.0.1:2510
[05:18:43] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 2511 ssl 1
[05:18:43] net: attempted socket connection refused: 127.0.0.1:2511
[05:18:43] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 2511 ssl 0
[05:18:43] net: attempted socket connection refused: 127.0.0.1:2511
[05:18:43] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 2512 ssl 1
[05:18:44] TLS: attempting SSL negotiation...
[...]
[05:18:44] TLS: handshake successful. Secure connection established.
[...]
[05:18:44] Linked to sslbot.
```

BotA:
```
[05:18:43] Telnet connection: localhost.localdomain/41651
[05:18:43] Timeout/EOF ident connection
[05:18:44] TLS: handshake successful. Secure connection established.
[...]
[05:13:42] Linked to linux.
```

**Test 3 - Demo fix for +PORT -> stock eggdrop 1.8.3**

linux (BotA):
```
Eggdrop v1.8.3+sendfprint (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[...]
.link BotB
[05:21:51] tcl: builtin dcc call: *dcc:link -HQ 1 BotB
[05:21:51] #-HQ# link BotB
[05:21:51] Linking to BotB at 127.0.0.1:3343 ...
[05:21:51] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 3343 ssl 1
[05:21:52] TLS: attempting SSL negotiation..
[...]
[05:21:52] TLS: handshake successful. Secure connection established.
[...]
[05:21:52] Linked to BotB.
```

BotB:
```
Eggdrop v1.8.3 (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
[...]
[05:21:51] net: connect! sock 5
[05:21:51] DNS resolved 127.0.0.1 to localhost
[05:21:51] Telnet connection: localhost/48673
[05:21:51] TLS: attempting SSL negotiation...
[...]
[05:23:44] TLS: handshake successful. Secure connection established.
[...]
[05:23:44] Linked to linux.
[...]
.dcc list
[05:25:57] tcl: builtin dcc call: *dcc:dccstat -HQ 1 list
[05:25:57] #-HQ# dccstat
IDX ADDR                                     + PORT NICK      TYPE  INFO
--- ---------------------------------------- ------ --------- ----- ---------
5   0.0.0.0                                  + 3343 (telnet)  lstn  3343
6   192.168.0.4                                   0 (dns)     dns   (ready)
1   0.0.0.0                                       0 -HQ       chat  flags: cptEp/0
10  127.0.0.1                                  6667 (server)  serv  (lag: 0)
```

**Test 4 - stock eggdrop 1.8.3 -> +PORT was also successful, i spare the details.**

**Test 5 - link to a Bot with "listen 3343" (without "+") was also successful, i even send a text across the link and checked withn tcp dump for it is indeed encrypted, i spare the details.**