### PR TITLE
Fix buffer size to avoid a gcc Wformat-overflow warning

### DIFF
--- a/src/botmsg.c
+++ b/src/botmsg.c
@@ -757,8 +757,9 @@ void botnet_send_nkch_part(int butidx, int useridx, char *oldnick)
  */
 int add_note(char *to, char *from, char *msg, int idx, int echo)
 {
+  #define FROMLEN 40
   int status, i, iaway, sock;
-  char *p, botf[81], ss[81], ssf[81];
+  char *p, botf[FROMLEN + 1 + HANDLEN + 1], ss[81], ssf[81];
   struct userrec *u;
 
   /* Notes have a length limit. Note + PRIVMSG header + nick + date must
@@ -783,8 +784,8 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
       return add_note(x, from, msg, idx, echo); /* Start over, dimwit. */
 
     if (egg_strcasecmp(from, botnetnick)) {
-      if (strlen(from) > 40)
-        from[40] = 0;
+      if (strlen(from) > FROMLEN)
+        from[FROMLEN] = 0;
 
       if (strchr(from, '@')) {
         strcpy(botf, from);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix buffer size to avoid a gcc Wformat-overflow warning

Additional description (if needed):
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c botmsg.c
botmsg.c: In function ‘add_note’:
botmsg.c:809:25: warning: ‘%s’ directive writing up to 80 bytes into a region of size between 60 and 79 [-Wformat-overflow=
       sprintf(ssf, "%lu:%s", dcc[idx].sock, botf);
                         ^~                  ~~~~
botmsg.c:809:7: note: ‘sprintf’ output between 3 and 102 bytes into a destination of size 81
       sprintf(ssf, "%lu:%s", dcc[idx].sock, botf);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
Test cases demonstrating functionality (if applicable):
`make` no longer shows the warning above. I did a small test, linked 2 share bots, watched them share the userfile. So far, so good.
For this patch temporarily there were some length information included to make the compiler check the exact max length needed for array `botf`.
botmsg.c:add_note() could also be tested in real life, but the string truncation and concatenation of "from@botnetnick" is not sane anyway. I mean, `from` is an input of unknown length. It will be truncated to 40 chars. Then it will be checked if it contains "@". If yes, it is used as "from@botnetnick". If no, @botnetnick is appended. Now imagine 2 `from`s. 1st `from` is having the @ late bun in those first 40 chars, so that "from@botnetnick" will end up with a truncated botnetnick. 2nd from is having the @ even later, so that "from@botnetnick" will end up longer and with full @botnetnick appended. This is not sane but may work fine in real life for reasons i didn't consider here. If you want to check and fix this or even come up with a real life demo of this problem, pls open a new issue to let this one quickly pass into 1.8.4.