### PR TITLE
Fix misaligned address in coredns.c

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -169,13 +169,6 @@ typedef struct {
 #define getheader_pr(x) ((x->databyte_b >> 6) & 1)
 #define getheader_ra(x) (x->databyte_b >> 7)
 
-#define sucknetword(x)  ((x)+=2,((uint16_t)  (((x)[-2] <<  8) | ((x)[-1] <<  0))))
-#define sucknetshort(x) ((x)+=2,((short) (((x)[-2] <<  8) | ((x)[-1] <<  0))))
-#define sucknetdword(x) ((x)+=4,((dword) (((x)[-4] << 24) | ((x)[-3] << 16) | \
-                                          ((x)[-2] <<  8) | ((x)[-1] <<  0))))
-#define sucknetlong(x)  ((x)+=4,((long)  (((x)[-4] << 24) | ((x)[-3] << 16) | \
-                                          ((x)[-2] <<  8) | ((x)[-1] <<  0))))
-
 static uint32_t resrecvbuf[(MAX_PACKETSIZE + 7) >> 2]; /* MUST BE DWORD ALIGNED */
 
 static struct resolve *idbash[BASH_SIZE];
@@ -900,8 +893,8 @@ void parserespacket(uint8_t *response, int len)
     ddebug0(RES_ERR "Query resource record truncated.");
     return;
   }
-  qdatatype = sucknetword(c);
-  qclass = sucknetword(c);
+  NS_GET16(qdatatype, c);
+  NS_GET16(qclass, c);
   if (qclass != C_IN) {
     ddebug2(RES_ERR "Received unsupported query class: %u (%s)",
             qclass, (qclass < CLASSTYPES_COUNT) ?

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -41,6 +41,13 @@
 #include <resolv.h>
 #include <errno.h>
 
+/* OpenBSD */
+#ifndef NS_GET16
+#define NS_GET16 GETSHORT
+#endif
+#ifndef NS_GET32
+#define NS_GET32 GETLONG
+#endif
 
 /* Defines */
 

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -146,14 +146,6 @@ typedef struct {
   uint16_t arcount;            /* Resource reference record count */
 } packetheader;
 
-typedef struct {
-  uint16_t datatype;
-  uint16_t class;
-  uint32_t ttl;
-  uint16_t datalength;
-  uint8_t data[FLEXIBLE_ARRAY_MEMBER];
-} res_record;
-
 #ifndef HFIXEDSZ
 #define HFIXEDSZ (sizeof(packetheader))
 #endif
@@ -823,7 +815,6 @@ void parserespacket(uint8_t *response, int len)
   int ready = 0;
 #endif
   int r, rcount;
-  res_record *rr;
   packetheader *hdr;
   struct resolve *rp;
   uint8_t rc, *c = response;
@@ -958,74 +949,77 @@ void parserespacket(uint8_t *response, int len)
       ddebug0(RES_ERR "Resource record truncated.");
       return;
     }
-    rr = ((res_record *) c);
-    rr->datatype = ntohs(rr->datatype);
-    rr->class = ntohs(rr->class);
-    rr->ttl = ntohl(rr->ttl);
-    rr->datalength = ntohs(rr->datalength);
-    if (rr->class != qclass) {
+    int datatype, class, ttl, datalength;
+    datatype = ns_get16(c);
+    c += INT16SZ;
+    class = ns_get16(c);
+    c += INT16SZ;
+    ttl = ns_get32(c);
+    c += INT32SZ;
+    datalength = ns_get16(c);
+    c += INT16SZ;
+    if (class != qclass) {
       ddebug2(RES_ERR "Answered class (%s) does not match queried class (%s).",
-              (rr->class < CLASSTYPES_COUNT) ?
-              classtypes[rr->class] : classtypes[CLASSTYPES_COUNT],
+              (class < CLASSTYPES_COUNT) ?
+              classtypes[class] : classtypes[CLASSTYPES_COUNT],
               (qclass < CLASSTYPES_COUNT) ?
               classtypes[qclass] : classtypes[CLASSTYPES_COUNT]);
       return;
     }
-    c += 10 + rr->datalength;
-    if (c > response + len) {
+    if ((c + datalength) > (response + len)) {
       ddebug0(RES_ERR "Specified rdata length exceeds packet size.");
       return;
     }
     if (egg_strcasecmp(stackstring, namestring))
       continue;
-    if (rr->datatype != qdatatype && rr->datatype != T_CNAME) {
+    if (datatype != qdatatype && datatype != T_CNAME) {
       ddebug2(RES_MSG "Ignoring resource type %u. (%s)",
-              rr->datatype, (rr->datatype < RESOURCETYPES_COUNT) ?
-              resourcetypes[rr->datatype] :
+              datatype, (datatype < RESOURCETYPES_COUNT) ?
+              resourcetypes[datatype] :
               resourcetypes[RESOURCETYPES_COUNT]);
       continue;
     }
-    ddebug1(RES_MSG "TTL: %s", strtdiff(sendstring, rr->ttl));
-    ddebug1(RES_MSG "TYPE: %s", (rr->datatype < RESOURCETYPES_COUNT) ?
-            resourcetypes[rr->datatype] : resourcetypes[RESOURCETYPES_COUNT]);
-    switch (rr->datatype) {
+    ddebug1(RES_MSG "TTL: %s", strtdiff(sendstring, ttl));
+    ddebug1(RES_MSG "TYPE: %s", (datatype < RESOURCETYPES_COUNT) ?
+            resourcetypes[datatype] : resourcetypes[RESOURCETYPES_COUNT]);
+    switch (datatype) {
       case T_A:
-        if (rr->datalength != 4) {
+        if (datalength != 4) {
           ddebug1(RES_ERR "Unsupported rdata format for \"A\" type. "
-                  "(%u bytes)", rr->datalength);
+                  "(%u bytes)", datalength);
           return;
         }
-        rp->ttl = rr->ttl;
+        rp->ttl = ttl;
         rp->sockname.addrlen = sizeof(struct sockaddr_in);
         rp->sockname.addr.sa.sa_family = AF_INET;
-        memcpy(&rp->sockname.addr.s4.sin_addr, rr->data, 4);
+        memcpy(&rp->sockname.addr.s4.sin_addr, c, 4);
 #ifndef IPV6
-        passrp(rp, rr->ttl, T_A);
+        passrp(rp, ttl, T_A);
         return;
 #else
         if (ready || !pref_af) {
-          passrp(rp, rr->ttl, T_A);
+          passrp(rp, ttl, T_A);
           return;
         }
         break;
       case T_AAAA:
-        if (rr->datalength != 16) {
+        if (datalength != 16) {
           ddebug1(RES_ERR "Unsupported rdata format for \"AAAA\" type. "
-                  "(%u bytes)", rr->datalength);
+                  "(%u bytes)", datalength);
           return;
         }
-        rp->ttl = rr->ttl;
+        rp->ttl = ttl;
         rp->sockname.addrlen = sizeof(struct sockaddr_in6);
         rp->sockname.addr.sa.sa_family = AF_INET6;
-        memcpy(&rp->sockname.addr.s6.sin6_addr, rr->data, 16);
+        memcpy(&rp->sockname.addr.s6.sin6_addr, c, 16);
         if (ready || pref_af) {
-          passrp(rp, rr->ttl, T_A);
+          passrp(rp, ttl, T_A);
           return;
         }
         break;
 #endif
       case T_PTR:
-        r = dn_expand(response, response + len, rr->data, namestring, MAXDNAME);
+        r = dn_expand(response, response + len, c, namestring, MAXDNAME);
         if (r == -1) {
           ddebug0(RES_ERR "dn_expand() failed while expanding domain in "
                   "rdata.");
@@ -1041,12 +1035,12 @@ void parserespacket(uint8_t *response, int len)
           rp->hostn = nmalloc(strlen(namestring) + 1);
           strcpy(rp->hostn, namestring);
           linkresolvehost(rp);
-          passrp(rp, rr->ttl, T_PTR);
+          passrp(rp, ttl, T_PTR);
           return;
         }
         break;
       case T_CNAME:
-        r = dn_expand(response, response + len, rr->data, namestring, MAXDNAME);
+        r = dn_expand(response, response + len, c, namestring, MAXDNAME);
         if (r == -1) {
           ddebug0(RES_ERR "dn_expand() failed while expanding domain in "
                   "rdata.");
@@ -1057,8 +1051,8 @@ void parserespacket(uint8_t *response, int len)
         break;
       default:
         ddebug2(RES_ERR "Received unimplemented data type: %u (%s)",
-                rr->datatype, (rr->datatype < RESOURCETYPES_COUNT) ?
-                resourcetypes[rr->datatype] :
+                datatype, (datatype < RESOURCETYPES_COUNT) ?
+                resourcetypes[datatype] :
                 resourcetypes[RESOURCETYPES_COUNT]);
     }
   }

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -818,7 +818,9 @@ void parserespacket(uint8_t *response, int len)
   packetheader *hdr;
   struct resolve *rp;
   uint8_t rc, *c = response;
-  uint16_t qdatatype, qclass;
+  uint16_t qdatatype, qclass, datatype, class, datalength;
+  uint32_t ttl;
+
   if (len < sizeof(packetheader)) {
     debug1(RES_ERR "Packet smaller than standard header size: %d bytes.", len);
     return;
@@ -949,15 +951,10 @@ void parserespacket(uint8_t *response, int len)
       ddebug0(RES_ERR "Resource record truncated.");
       return;
     }
-    int datatype, class, ttl, datalength;
-    datatype = ns_get16(c);
-    c += INT16SZ;
-    class = ns_get16(c);
-    c += INT16SZ;
-    ttl = ns_get32(c);
-    c += INT32SZ;
-    datalength = ns_get16(c);
-    c += INT16SZ;
+    NS_GET16(datatype, c);
+    NS_GET16(class, c);
+    NS_GET32(ttl, c);
+    NS_GET16(datalength, c);
     if (class != qclass) {
       ddebug2(RES_ERR "Answered class (%s) does not match queried class (%s).",
               (class < CLASSTYPES_COUNT) ?


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #780

One-line summary:
Fix misaligned address in coredns.c

Additional description (if needed):
I don't know of any _real_ issue from the misaligned address, but recently there was an freebsd alignment issue with _real_ impact, see https://github.com/freebsd/freebsd/commit/a9fb9d9a3082845e55798950d85fe93a61a8630a, so better safe than sorry.
**Meanwhile i demoed a _real_issue, a bus error core dump, from the misaligned address, see #780.**

Found with clang 7.0.0
```
$ CC="clang -O2 -fsanitize=address,undefined" ./configure
[...]
$ ./eggdrop -nt
[...]
.console +d
[...]
.tcl dnslookup 127.0.0.1 foo
[22:58:01] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup 127.0.0.1 foo
[22:58:01] tcl: evaluate (.tcl): dnslookup 127.0.0.1 foo
[22:58:01] DNS Resolver: Creating new record
[22:58:01] DNS Resolver: Sent domain lookup request for "127.0.0.1".
Tcl: 
[22:58:01] DNS Resolver: Received nameserver reply. (qd:1 an:1 ns:0 ar:0)
e4b8daec e4b8dae0 c 0 0 0
[22:58:01] DNS Resolver: answered domain query: "1.0.0.127.in-addr.arpa"
coredns.c:963:20: runtime error: member access within misaligned address 0x7fcee4b8db0a for type 'res_record', which requires 4 byte alignment
0x7fcee4b8db0a: note: pointer points here
 00 01  c0 0c 00 0c 00 01 00 00  2a 30 00 0b 09 6c 6f 63  61 6c 68 6f 73 74 00 00  00 00 00 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior coredns.c:963:20 in
[...]
[22:58:01] DNS Resolver: Lookup successful: localhost
[22:58:01] DNS resolved 127.0.0.1 to localhost
[22:58:01] Tcl error [foo]: invalid command name "foo"
invalid command name "foo"
    while executing
"foo 127.0.0.1 localhost 1"
```

In this test we pushed the dummy function name `foo` into .tcl dnslookup, so `invalid command name "foo"` is expected and fine here.


Test cases demonstrating functionality (if applicable):
```
$ ./eggdrop -nt
[...]
.console +d
[...]
.tcl dnslookup 127.0.0.1 foo
[05:44:38] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup 127.0.0.1 foo
[05:44:38] tcl: evaluate (.tcl): dnslookup 127.0.0.1 foo
[05:44:38] DNS Resolver: Creating new record
[05:44:38] DNS Resolver: Sent domain lookup request for "127.0.0.1".
Tcl: 
[05:44:38] DNS Resolver: Received nameserver reply. (qd:1 an:1 ns:0 ar:0)
[05:44:38] DNS Resolver: answered domain query: "1.0.0.127.in-addr.arpa"
[05:44:38] DNS Resolver: TTL: 3h
[05:44:38] DNS Resolver: TYPE: PTR: domain name pointer
[05:44:38] DNS Resolver: Answered domain: "localhost"
[05:44:38] DNS Resolver: Lookup successful: localhost
[05:44:38] DNS resolved 127.0.0.1 to localhost
[05:44:39] Tcl error [foo]: invalid command name "foo"
invalid command name "foo"
    while executing
"foo 127.0.0.1 localhost 1"
```

Additionally clean compilation of dns.mod was verified for:
Linux 4.18.16 glibc 2.28
FreeBSD 11.2-RELEASE
NetBSD 8.0
OpenBSD 6.4
Cygwin