### PR TITLE
Compress mod: add zlib version info to status report

### DIFF
--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -394,6 +394,7 @@ static int compress_report(int idx, int details)
   if (details) {
     int size = compress_expmem();
 
+    dprintf(idx, "    zlib version %s\n", ZLIB_VERSION);
     dprintf(idx, "    %u file%s compressed\n", compressed_files,
             (compressed_files != 1) ? "s" : "");
     dprintf(idx, "    %u file%s uncompressed\n", uncompressed_files,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Compress mod: add zlib version info to status report

Additional description (if needed):
Small feature enhancement

Test cases demonstrating functionality (if applicable):
```
.status all
[...]
  Module: compress, v 1.2
    zlib version 1.2.11
[...]
```