### PR TITLE
Space and wording fix

### DIFF
--- a/src/mod/blowfish.mod/blowfish.c
+++ b/src/mod/blowfish.mod/blowfish.c
@@ -147,12 +147,16 @@ static void blowfish_report(int idx, int details)
         tot++;
 
     dprintf(idx, "    Blowfish encryption module:\n");
-    dprintf(idx, "      %d of %d boxes in use: ", tot, BOXES);
-    for (i = 0; i < BOXES; i++)
-      if (box[i].P != NULL) {
-        dprintf(idx, "(age: %d) ", now - box[i].lastuse);
-      }
-    dprintf(idx, "\n");
+    if (!tot)
+      dprintf(idx, "      0 of %d boxes in use\n", BOXES);
+    else {
+      dprintf(idx, "      %d of %d boxes in use:", tot, BOXES);
+      for (i = 0; i < BOXES; i++)
+        if (box[i].P != NULL) {
+          dprintf(idx, " (age: %d)", now - box[i].lastuse);
+        }
+      dprintf(idx, "\n");
+    }
     dprintf(idx, "      Using %d byte%s of memory\n", size,
             (size != 1) ? "s" : "");
   }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Space and wording fix

Additional description (if needed):


**Test cases demonstrating functionality (if applicable):**
Before:
```
.status all
[...]
  Module: encryption, v 2.2
    Blowfish encryption module:
      0 of 3 boxes in use: 
      Using 0 bytes of memory
[...]
```

After:
```
.status all
[...]
  Module: encryption, v 2.2
    Blowfish encryption module:
      0 of 3 boxes in use
      Using 0 bytes of memory
[...]
```
