### PR TITLE
Cleanup extracthostname

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1354,17 +1354,6 @@ void sub_lang(int idx, char *text)
     dprintf(idx, "%s\n", s);
 }
 
-/* This will return a pointer to the first character after the @ in the
- * string given it.  Possibly it's time to think about a regexp library
- * for eggdrop...
- */
-char *extracthostname(char *hostmask)
-{
-  char *p = strrchr(hostmask, '@');
-
-  return p ? p + 1 : "";
-}
-
 /* Show motd to dcc chatter
  */
 void show_motd(int idx)

--- a/src/net.c
+++ b/src/net.c
@@ -1469,6 +1469,17 @@ int sanitycheck_dcc(char *nick, char *from, char *ipaddy, char *port)
   return 1;
 }
 
+/* This will return a pointer to the first character after the @ in the
+ * string given it.  Possibly it's time to think about a regexp library
+ * for eggdrop...
+ */
+static char *extracthostname(const char *hostmask)
+{
+  char *p = strrchr(hostmask, '@');
+
+  return p ? p + 1 : "";
+}
+
 int hostsanitycheck_dcc(char *nick, char *from, sockname_t *ip, char *dnsname,
                         char *prt)
 {

--- a/src/proto.h
+++ b/src/proto.h
@@ -248,7 +248,6 @@ void rem_help_reference(char *);
 void add_help_reference(char *);
 void debug_help(int);
 void reload_help_data(void);
-char *extracthostname(char *);
 void show_banner(int i);
 void make_rand_str(char *, int);
 int oatoi(const char *);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup extracthostname

Additional description (if needed):
extracthostname() was used only once and it not part of module api, so it was moved from misc.c to its user net.c, deleted from proto.h and made static.

**Test cases demonstrating functionality (if applicable):**
IRC Client:
```
/dcc chat linux
*** Sent DCC CHAT [127.0.0.1:41057] request to linux
*** DCC chat connection to linux[127.0.0.1:57385] established
=linux= Enter your password.
```

Eggdrop:
```
.console +d
[...]
[13:38:56] DNS information for submitted IP checks out.
[13:38:57] DCC connection: CHAT (michael!~michael@localhost)
[...]
```