### PR TITLE
Small Cleanup / Static keyword

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -388,7 +388,7 @@ static int calc_penalty(char *msg)
   return penalty;
 }
 
-char *splitnicks(char **rest)
+static char *splitnicks(char **rest)
 {
   char *o, *r;
 

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -2311,7 +2311,7 @@ char *share_start(Function *global_funcs)
   return NULL;
 }
 
-int private_globals_bitmask()
+static int private_globals_bitmask()
 {
   struct flag_record fr = { FR_GLOBAL, 0, 0, 0, 0, 0 };
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Small Cleanup / Static keyword

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
