### PR TITLE
Cleanup src/net.c

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1039,8 +1039,10 @@ int sockgets(char *s, int *len)
             strcpy(px, p);
             nfree(socklist[i].handler.sock.inbuf);
             socklist[i].handler.sock.inbuf = px;
-          } else
+          } else {
+            nfree(socklist[i].handler.sock.inbuf);
             socklist[i].handler.sock.inbuf = NULL;
+          }
           *len = strlen(s);
           return socklist[i].sock;
         }

--- a/src/net.c
+++ b/src/net.c
@@ -1019,6 +1019,7 @@ int sockgets(char *s, int *len)
 {
   char xx[514], *p, *px;
   int ret, i, data = 0;
+  size_t len2;
 
   for (i = 0; i < threaddata()->MAXSOCKS; i++) {
     /* Check for stored-up data waiting to be processed */
@@ -1035,8 +1036,9 @@ int sockgets(char *s, int *len)
             p++;
           strlcpy(s, socklist[i].handler.sock.inbuf, 511);
           if (*p) {
-            px = nmalloc(strlen(p) + 1);
-            strcpy(px, p);
+            len2 = strlen(p) + 1;
+            px = nmalloc(len2);
+            memcpy(px, p, len2);
             nfree(socklist[i].handler.sock.inbuf);
             socklist[i].handler.sock.inbuf = px;
           } else {
@@ -1177,8 +1179,9 @@ int sockgets(char *s, int *len)
     nfree(p);
   } else {
     socklist[ret].handler.sock.inbuflen = strlen(xx);
-    socklist[ret].handler.sock.inbuf = nmalloc(socklist[ret].handler.sock.inbuflen + 1);
-    strcpy(socklist[ret].handler.sock.inbuf, xx);
+    len2 = socklist[ret].handler.sock.inbuflen + 1;
+    socklist[ret].handler.sock.inbuf = nmalloc(len2);
+    memcpy(socklist[ret].handler.sock.inbuf, xx, len2);
   }
   if (data)
     return socklist[ret].sock;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup src/net.c

Additional description (if needed):
1. sizeof "255.255.255.255" -> INET_ADDRSTRLEN
2. The comment "look for \r too cos windows can't follow RFCs" was wrong, was the opposite of what the RFC says
3. Fix leak, thanks Cizzle!
4. Enhanced strdup like code 
5. Misc. cleanup


Test cases demonstrating functionality (if applicable):
A tiny compile, run, connect and share test was fine.