### PR TITLE
Fix starttls or passreq being on same line as stealth-prompt

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1787,7 +1787,8 @@ static void dcc_telnet_pass(int idx, int atr)
       struct threaddata *td = threaddata();
       /* mark socket to read next incoming at reduced len */
       td->socklist[i].flags |= SOCK_SENTTLS;
-      dprintf(idx, "starttls\n");
+      /* Prefix with \n in case of newline-less ending stealth_prompt */
+      dprintf(idx, "\nstarttls\n");
       putlog(LOG_BOTS, "*", "Sent STARTTLS to %s...", dcc[idx].nick);
     }
 #endif
@@ -1802,7 +1803,8 @@ static void dcc_telnet_pass(int idx, int atr)
      * <Cybah>
      */
     putlog(LOG_BOTS, "*", "Challenging %s...", dcc[idx].nick);
-    dprintf(idx, "passreq <%x%x@%s>\n", getpid(), dcc[idx].timeval, botnetnick);
+    /* Prefix with \n in case of newline-less ending stealth_prompt */
+    dprintf(idx, "\npassreq <%x%x@%s>\n", getpid(), dcc[idx].timeval, botnetnick);
     dcc[idx].type = old;
   } else {
     /* NOTE: The MD5 digest used above to prevent cleartext passwords being
@@ -2414,12 +2416,16 @@ static void dcc_telnet_got_ident(int i, char *host)
   /* This is so we don't tell someone doing a portscan anything
    * about ourselves. <cybah>
    */
-  if (stealth_telnets)
+  if (stealth_telnets) {
+    /* Show here so it doesn't interfere with newline-less stealth_prompt */
+    if (allow_new_telnets)
+      dprintf(i, "(If you are new, enter 'NEW' here.)\n");
     dprintf(i, stealth_prompt);
-  else {
+  } else {
     dprintf(i, "\n\n");
     sub_lang(i, MISC_BANNER);
+    /* Show here so it doesn't get lost before the banner */
+    if (allow_new_telnets)
+      dprintf(i, "(If you are new, enter 'NEW' here.)\n");
   }
-  if (allow_new_telnets)
-    dprintf(i, "(If you are new, enter 'NEW' here.)\n");
 }


### PR DESCRIPTION
Found by: Geo & Cizzle
Patch by: Cizzle
Fixes: 

One-line summary: When a stealth-prompt in conf (with stealth-telnets set to 1) or 0x53e in a language file (with stealth-telnets set to 0) is used without a trailing newline ("\n"), no upgrade to TLS of a botlink or no link at all when TLS is not compiled in happens.

Additional description (if needed): When open-telnets was set to 1 in conf, linking and upgrading happened as expected.
