### PR TITLE
Fix typo: ecactly -> exactly

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -27,7 +27,7 @@
 #define QUOTE '\\' /* quoting character (overrides wildcards) */
 #define WILDS '*'  /* matches 0 or more characters (including spaces) */
 #define WILDP '%'  /* matches 0 or more non-space characters */
-#define WILDQ '?'  /* matches ecactly one character */
+#define WILDQ '?'  /* matches exactly one character */
 #define WILDT '~'  /* matches 1 or more spaces */
 
 #define NOMATCH 0


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix typo: ecactly -> exactly

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
