### PR TITLE
Fix build from another directory

### DIFF
--- a/src/compat/strlcpy.c
+++ b/src/compat/strlcpy.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include "../../config.h"
+#include <config.h>
 
 #ifndef HAVE_STRLCPY
 /*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/


### PR DESCRIPTION
Found by: Harekiet
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix build from another directory

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
$ mkdir build
$ cd build/
$ ../configure
[...]
$ make config
[...]
$ make
[...]
$ make install
[...]
$ nm eggdrop|grep strlcpy
000000000005a470 T strlcpy
```