### PR TITLE
Rewrote dcc relay filter

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1488,13 +1488,12 @@ static void dcc_relay(int idx, char *buf, int j)
         }
         else if (*src)
           src++;
-      } else if (*src == '\033') { /* ESC */
+      } else if (*src == ESC) {
         src++;
         if (*src == '[') { /* CSI */
           src++;
           /* Search for the end of the escape sequence. */
-          while (*src && *src != 'm')
-            src++;
+          while (*src && *src++ != 'm');
         }
       } else if (*src == '\r') /* CR */
         src++;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1479,9 +1479,9 @@ static void dcc_relay(int idx, char *buf, int j)
     dst = (unsigned char *) buf;
     while (*src) {
       /* Search for IAC, escape sequences and CR. */
-      if (*src == 255) { /* IAC */
+      if (*src == TLN_IAC) {
         src++;
-        if ((*src >= 251) && (*src <= 254)) /* 251 = WILL, 254 = DON'T */
+        if ((*src >= TLN_WILL) && (*src <= TLN_DONT))
           src++;
           if (*src)
             src++;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1481,10 +1481,11 @@ static void dcc_relay(int idx, char *buf, int j)
       /* Search for IAC, escape sequences and CR. */
       if (*src == TLN_IAC) {
         src++;
-        if ((*src >= TLN_WILL) && (*src <= TLN_DONT))
+        if ((*src >= TLN_WILL) && (*src <= TLN_DONT)) {
           src++;
           if (*src)
             src++;
+        }
         else if (*src)
           src++;
       } else if (*src == '\033') { /* ESC */

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -753,6 +753,13 @@ enum {
   EGG_OPTION_UNSET = 2          /* Unset option(s).             */
 };
 
+#define ESC             27      /* Oct              033
+                                 * Hex              1B
+                                 * Caret notation   ^[
+                                 * Escape sequences \e
+                                 * \e is not supported in all compilers
+                                 */
+
 /* Telnet codes.  See "TELNET Protocol Specification" (RFC 854) and
  * "TELNET Echo Option" (RFC 875) for details. */
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Rewrote dcc relay filter

Additional description (if needed):
Bogus filter code in dcc_relay was rewritten.
First only the strcpy()s were rewritten as memmove()s, then the whole filter code was rewritten.
Also fixes ancient bug, see http://lists.eggheads.org/pipermail/eggheads/2014-January/012719.html.


Test cases demonstrating functionality (if applicable):
I successfully tested:
1. A 'normal' relay from BotA to BotB.
2. Filtering of (multiple) ESC.
3. Filtering of Esc sequences of form _ESC_[...m
  Python test program line was `conn.sendall(b'1 abc abc abc def\x1b[ghimjkl abc abc abc\n')`
  Result (debug printf() only inserted for this test) was `1 abc abc abc defjkl abc abc abc`