### PR TITLE
Ryze strlen limit for ssl-ciphers from 120 to 140

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -370,7 +370,7 @@ static tcl_strings def_tcl_strings[] = {
 #ifdef TLS
   {"ssl-capath",      tls_capath,     120, STR_DIR | STR_PROTECT},
   {"ssl-cafile",      tls_cafile,     120,           STR_PROTECT},
-  {"ssl-ciphers",     tls_ciphers,    120,           STR_PROTECT},
+  {"ssl-ciphers",     tls_ciphers,    140,           STR_PROTECT},
   {"ssl-privatekey",  tls_keyfile,    120,           STR_PROTECT},
   {"ssl-certificate", tls_certfile,   120,           STR_PROTECT},
 #endif


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Ryze strlen limit for ssl-ciphers from 120 to 140

Additional description (if needed):
This patch is a decoupling of #613, to see this part of it merged sooner. It solves a real problem i had. Its no part of Robbys original Issue.

Test cases demonstrating functionality (if applicable):
```
$ python
len('ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384')
131
```