### PR TITLE
Allow bots to remain linked when userfile sharing fails.

### DIFF
--- a/doc/sphinx_source/coreDocs/transfer.rst
+++ b/doc/sphinx_source/coreDocs/transfer.rst
@@ -38,7 +38,7 @@ There are also some variables you can set in your config file:
     Set here the time (in seconds) to wait before an inactive transfer
     times out.
 
-  set share-unlink 1
+  set sharefail-unlink 1
     By default, linked bots will unlink when the userfile sharing fails.
     Set this to 0 to keep the bots linked and retry every minute.
 

--- a/doc/sphinx_source/coreDocs/transfer.rst
+++ b/doc/sphinx_source/coreDocs/transfer.rst
@@ -39,8 +39,9 @@ There are also some variables you can set in your config file:
     times out.
 
   set sharefail-unlink 1
-    By default, linked bots will unlink when the userfile sharing fails.
-    Set this to 0 to keep the bots linked and retry every minute (Both 
-    bots must be v1.9.0 or higher).
+    By default, Eggdrop will abort the linking process if userfile sharing is
+    enabled but the userfile transfer fails. Set this to 0 to keep the bots
+    linked if the userfile transfer fails and retry every minute (both bots must
+    be v1.9.0 or higher).
 
 Copyright (C) 2000 - 2019 Eggheads Development Team

--- a/doc/sphinx_source/coreDocs/transfer.rst
+++ b/doc/sphinx_source/coreDocs/transfer.rst
@@ -40,6 +40,7 @@ There are also some variables you can set in your config file:
 
   set sharefail-unlink 1
     By default, linked bots will unlink when the userfile sharing fails.
-    Set this to 0 to keep the bots linked and retry every minute.
+    Set this to 0 to keep the bots linked and retry every minute (Both 
+    bots must be v1.9.0 or higher).
 
 Copyright (C) 2000 - 2019 Eggheads Development Team

--- a/doc/sphinx_source/coreDocs/transfer.rst
+++ b/doc/sphinx_source/coreDocs/transfer.rst
@@ -38,4 +38,8 @@ There are also some variables you can set in your config file:
     Set here the time (in seconds) to wait before an inactive transfer
     times out.
 
+  set share-unlink 1
+    By default, linked bots will unlink when the userfile sharing fails.
+    Set this to 0 to keep the bots linked and retry every minute.
+
 Copyright (C) 2000 - 2019 Eggheads Development Team

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1386,9 +1386,10 @@ set copy-to-tmp 1
 # Set here the time (in seconds) to wait before an inactive transfer times out.
 set xfer-timeout 30
 
-# By default, linked bots will unlink when the userfile sharing fails.
-# Set this to 0 to keep the bots linked and retry every minute (Both 
-# bots must be v1.9.0 or higher).
+# By default, Eggdrop will abort the linking process if userfile sharing is
+# enabled but the userfile transfer fails. Set this to 0 to keep the bots
+# linked if the userfile transfer fails and retry every minute (both bots must
+# be v1.9.0 or higher).
 #set sharefail-unlink 1
 
 #### SHARE MODULE ####

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1387,8 +1387,9 @@ set copy-to-tmp 1
 set xfer-timeout 30
 
 # By default, linked bots will unlink when the userfile sharing fails.
-# Set this to 0 to keep the bots linked and retry every minute.
-#set sharefail-unlink 0
+# Set this to 0 to keep the bots linked and retry every minute (Both 
+# bots must be v1.9.0 or higher).
+#set sharefail-unlink 1
 
 #### SHARE MODULE ####
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1386,6 +1386,9 @@ set copy-to-tmp 1
 # Set here the time (in seconds) to wait before an inactive transfer times out.
 set xfer-timeout 30
 
+# By default, linked bots will unlink when the userfile sharing fails.
+# Set this to 0 to keep the bots linked and retry every minute.
+#set share-unlink 0
 
 #### SHARE MODULE ####
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1388,7 +1388,7 @@ set xfer-timeout 30
 
 # By default, linked bots will unlink when the userfile sharing fails.
 # Set this to 0 to keep the bots linked and retry every minute.
-#set share-unlink 0
+#set sharefail-unlink 0
 
 #### SHARE MODULE ####
 

--- a/src/mod/transfer.mod/help/set/transfer.help
+++ b/src/mod/transfer.mod/help/set/transfer.help
@@ -28,3 +28,7 @@
    This is the number of seconds to wait before a dcc send or get is
    considered to have timed out. If no traffic occurs on the transfer
    in the given time, it closes.
+%{help=set share-unlink}%{+n}
+###  %bset share-unlink%b <0/1>
+   By default, linked bots will unlink when the userfile sharing fails.
+   Set this to 0 to keep the bots linked and retry every minute.

--- a/src/mod/transfer.mod/help/set/transfer.help
+++ b/src/mod/transfer.mod/help/set/transfer.help
@@ -28,7 +28,7 @@
    This is the number of seconds to wait before a dcc send or get is
    considered to have timed out. If no traffic occurs on the transfer
    in the given time, it closes.
-%{help=set share-unlink}%{+n}
-###  %bset share-unlink%b <0/1>
+%{help=set sharefail-unlink}%{+n}
+###  %bset sharefail-unlink%b <0/1>
    By default, linked bots will unlink when the userfile sharing fails.
    Set this to 0 to keep the bots linked and retry every minute.

--- a/src/mod/transfer.mod/help/set/transfer.help
+++ b/src/mod/transfer.mod/help/set/transfer.help
@@ -30,5 +30,7 @@
    in the given time, it closes.
 %{help=set sharefail-unlink}%{+n}
 ###  %bset sharefail-unlink%b <0/1>
-   By default, linked bots will unlink when the userfile sharing fails.
-   Set this to 0 to keep the bots linked and retry every minute.
+    By default, Eggdrop will abort the linking process if userfile sharing is
+    enabled but the userfile transfer fails. Set this to 0 to keep the bots
+    linked if the userfile transfer fails and retry every minute (both bots must
+    be v1.9.0 or higher).

--- a/src/mod/transfer.mod/help/transfer.help
+++ b/src/mod/transfer.mod/help/transfer.help
@@ -5,5 +5,5 @@
 
    Config file variables for configuring the transfer module:
       %bxfer-timeout    copy-to-tmp         dcc-block%b
-      %bmax-dloads%b    share-unlink
+      %bmax-dloads      sharefail-unlink%b
    (Use %b'.help set <variable>'%b for more info)

--- a/src/mod/transfer.mod/help/transfer.help
+++ b/src/mod/transfer.mod/help/transfer.help
@@ -5,5 +5,5 @@
 
    Config file variables for configuring the transfer module:
       %bxfer-timeout    copy-to-tmp         dcc-block%b
-      %bmax-dloads%b
+      %bmax-dloads%b    share-unlink
    (Use %b'.help set <variable>'%b for more info)

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -1105,7 +1105,7 @@ static tcl_ints myints[] = {
   {"max-dloads",       &dcc_limit},
   {"dcc-block",        &dcc_block},
   {"xfer-timeout", &wait_dcc_xfer},
-  {"share-unlink",      &shunlink},
+  {"sharefail-unlink",  &shunlink},
   {NULL,                     NULL}
 };
 

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -46,6 +46,7 @@ static p_tcl_bind_list H_rcvd, H_sent, H_lost, H_tout;
 static int wait_dcc_xfer = 300; /* Timeout time on DCC xfers */
 static int dcc_limit = 3;       /* Max simultaneous downloads allowed */
 static int dcc_block = 0;       /* Size of one dcc block */
+static int shunlink = 1;        /* Unlink bots when userfile sharing fails */
 static fileq_t *fileq = NULL;
 
 static struct dcc_table DCC_SEND, DCC_GET, DCC_GET_PENDING;
@@ -352,29 +353,32 @@ static void eof_dcc_send(int idx)
       if ((!strcasecmp(dcc[x].nick, dcc[idx].host)) &&
           (dcc[x].type->flags & DCT_BOT))
         y = x;
+    unlink(dcc[idx].u.xfer->filename);
     if (y) {
-      putlog(LOG_BOTS, "*", TRANSFER_USERFILE_LOST, dcc[y].nick);
-      unlink(dcc[idx].u.xfer->filename);
-      /* Drop that bot */
-      dprintf(y, "bye\n");
-      egg_snprintf(s, sizeof s, TRANSFER_USERFILE_DISCON, dcc[y].nick);
-      botnet_send_unlinked(y, dcc[y].nick, s);
-      putlog(LOG_BOTS, "*", "%s.", s);
-      if (y != idx) {
-        killsock(dcc[y].sock);
-        lostdcc(y);
+      if (shunlink) {
+        /* Drop that bot */
+        dprintf(y, "bye\n");
+        egg_snprintf(s, sizeof s, TRANSFER_USERFILE_DISCON, dcc[y].nick);
+        botnet_send_unlinked(y, dcc[y].nick, s);
+        putlog(LOG_BOTS, "*", "%s.", s);
+        if (y != idx) {
+          killsock(dcc[y].sock);
+          lostdcc(y);
+        }
+      } else {
+        putlog(LOG_BOTS, "*", TRANSFER_USERFILE_LOST, dcc[y].nick);
+        dcc[y].status &= ~(STAT_GETTING | STAT_SHARE);
       }
-      killsock(dcc[idx].sock);
-      lostdcc(idx);
-    }
+    } else
+      putlog(LOG_BOTS, "*", TRANSFER_ABORT_USERFILE);
   } else {
     putlog(LOG_FILES, "*", TRANSFER_LOST_DCCSEND, dcc[idx].u.xfer->origname,
            dcc[idx].nick, dcc[idx].host, dcc[idx].status,
            dcc[idx].u.xfer->length);
-    killsock(dcc[idx].sock);
-    lostdcc(idx);
   }
 
+  killsock(dcc[idx].sock);
+  lostdcc(idx);
 }
 
 /* Determine byte order. Used for resend DCC startup packets.
@@ -571,21 +575,25 @@ static void eof_dcc_get(int idx)
       if (!strcasecmp(dcc[x].nick, dcc[idx].host) &&
           (dcc[x].type->flags & DCT_BOT))
         y = x;
-    putlog(LOG_BOTS, "*", TRANSFER_ABORT_USERFILE);
     /* Note: no need to unlink the xfer file, as it's already unlinked. */
     xnick[0] = 0;
-    /* Drop that bot */
-    dprintf(-dcc[y].sock, "bye\n");
-    egg_snprintf(s, sizeof s, TRANSFER_USERFILE_DISCON, dcc[y].nick);
-    botnet_send_unlinked(y, dcc[y].nick, s);
-    putlog(LOG_BOTS, "*", "%s.", s);
-    if (y != idx) {
-      killsock(dcc[y].sock);
-      lostdcc(y);
-    }
-    killsock(dcc[idx].sock);
-    lostdcc(idx);
-    return;
+    if (y) {
+      if (shunlink) {
+        /* Drop that bot */
+        dprintf(-dcc[y].sock, "bye\n");
+        egg_snprintf(s, sizeof s, TRANSFER_USERFILE_DISCON, dcc[y].nick);
+        botnet_send_unlinked(y, dcc[y].nick, s);
+        putlog(LOG_BOTS, "*", "%s.", s);
+        if (y != idx) {
+          killsock(dcc[y].sock);
+          lostdcc(y);
+        }
+      } else {
+        putlog(LOG_BOTS, "*", TRANSFER_USERFILE_LOST, dcc[y].nick);
+        dcc[y].status &= ~(STAT_SENDING | STAT_SHARE);
+      }
+    } else
+      putlog(LOG_BOTS, "*", TRANSFER_ABORT_USERFILE);
   } else {
     struct userrec *u;
 
@@ -603,7 +611,7 @@ static void eof_dcc_get(int idx)
   killsock(dcc[idx].sock);
   lostdcc(idx);
   /* Send next queued file if there is one */
-  if (!at_limit(xnick))
+  if (xnick[0] && !at_limit(xnick))
     send_next_file(xnick);
 }
 
@@ -638,25 +646,24 @@ static void transfer_get_timeout(int i)
       if ((!strcasecmp(dcc[x].nick, dcc[i].host)) &&
           (dcc[x].type->flags & DCT_BOT))
         y = x;
-    if (y != 0) {
-      dcc[y].status &= ~STAT_SENDING;
-      dcc[y].status &= ~STAT_SHARE;
-    }
     unlink(dcc[i].u.xfer->filename);
-    putlog(LOG_BOTS, "*", TRANSFER_USERFILE_TIMEOUT);
-    dprintf(y, "bye\n");
-    egg_snprintf(xx, sizeof xx, TRANSFER_DICONNECT_TIMEOUT, dcc[y].nick);
-    botnet_send_unlinked(y, dcc[y].nick, xx);
-    putlog(LOG_BOTS, "*", "%s.", xx);
-    if (y < i) {
-      int t = y;
-
-      y = i;
-      i = t;
-    }
-    killsock(dcc[y].sock);
-    lostdcc(y);
     xx[0] = 0;
+    if (y) {
+      if (shunlink) {
+        dprintf(y, "bye\n");
+        egg_snprintf(xx, sizeof xx, TRANSFER_DICONNECT_TIMEOUT, dcc[y].nick);
+        botnet_send_unlinked(y, dcc[y].nick, xx);
+        putlog(LOG_BOTS, "*", "%s.", xx);
+        if (y != i) {
+          killsock(dcc[y].sock);
+          lostdcc(y);
+        }
+      } else {
+        putlog(LOG_BOTS, "*", TRANSFER_USERFILE_TIMEOUT);
+        dcc[y].status &= ~(STAT_SENDING | STAT_SHARE);
+      }
+    } else
+      putlog(LOG_BOTS, "*", TRANSFER_USERFILE_TIMEOUT);
   } else {
     char *p;
     struct userrec *u;
@@ -679,7 +686,7 @@ static void transfer_get_timeout(int i)
   }
   killsock(dcc[i].sock);
   lostdcc(i);
-  if (!at_limit(xx))
+  if (xx[0] && !at_limit(xx))
     send_next_file(xx);
 }
 
@@ -1098,6 +1105,7 @@ static tcl_ints myints[] = {
   {"max-dloads",       &dcc_limit},
   {"dcc-block",        &dcc_block},
   {"xfer-timeout", &wait_dcc_xfer},
+  {"share-unlink",      &shunlink},
   {NULL,                     NULL}
 };
 


### PR DESCRIPTION
Found by: simple & Cizzle
Patch by: Cizzle
Fixes: 

One-line summary: Introduce the `share-unlink` setting to allow bots to remain linked when userfile sharing fails.

Test cases demonstrating functionality (if applicable): to deliberatly have a userfile share fail, you could switch arguments 2 and 3 at transfer.c line 228: `r = fread(bf, 1, actual_size, file);`.
