### PR TITLE
(WIP) Add egg_strdup() for core and modules and converted 1 example for each

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1064,6 +1064,18 @@ void help_subst(char *s, char *nick, struct flag_record *flags,
   }
 }
 
+/* As strdup() but with nmalloc() */
+char *egg_strdup(const char *str)
+{
+  size_t len;
+  char *copy;
+
+  len = strlen(str) + 1;
+  copy = nmalloc(len);
+  memcpy(copy, str, len);
+  return copy;
+}
+
 static void scan_help_file(struct help_ref *current, char *filename, int type)
 {
   FILE *f;
@@ -1080,8 +1092,7 @@ static void scan_help_file(struct help_ref *current, char *filename, int type)
           *p = 0;
           list = nmalloc(sizeof *list);
 
-          list->name = nmalloc(p - q + 1);
-          strcpy(list->name, q);
+          list->name = egg_strdup(q);
           list->next = current->first;
           list->type = type;
           current->first = list;
@@ -1108,8 +1119,7 @@ void add_help_reference(char *file)
       return;                   /* Already exists, can't re-add :P */
   current = nmalloc(sizeof *current);
 
-  current->name = nmalloc(strlen(file) + 1);
-  strcpy(current->name, file);
+  current->name = egg_strdup(file);
   current->next = help_list;
   current->first = NULL;
   help_list = current;

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1038,8 +1038,7 @@ void parserespacket(uint8_t *response, int len)
           return;
         }
         if (!rp->hostn) {
-          rp->hostn = nmalloc(strlen(namestring) + 1);
-          strcpy(rp->hostn, namestring);
+          rp->hostn = egg_strdup(namestring);
           linkresolvehost(rp);
           passrp(rp, rr->ttl, T_PTR);
           return;
@@ -1224,8 +1223,7 @@ static void dns_forward(char *hostn)
   rp = allocresolve();
   rp->state = STATE_AREQ;
   rp->sends = 1;
-  rp->hostn = nmalloc(strlen(hostn) + 1);
-  strcpy(rp->hostn, hostn);
+  rp->hostn = egg_strdup(hostn);
   rp->type = T_A;
   linkresolvehost(rp);
   sendrequest(rp, T_A);

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -507,6 +507,7 @@
 #endif
 /* 304 - 307 */
 #define strncpyz ((size_t (*) (char *, const char *, size_t))global[304])
+#define egg_strdup ((char *(*) (const char *))global[305])
 
 
 /* hostmasking */

--- a/src/modules.c
+++ b/src/modules.c
@@ -606,7 +606,8 @@ Function global_table[] = {
   (Function) 0,
 #endif
   /* 304 - 307 */
-  (Function) strncpyz
+  (Function) strncpyz,
+  (Function) egg_strdup
 };
 
 void init_modules(void)

--- a/src/proto.h
+++ b/src/proto.h
@@ -259,6 +259,7 @@ char *strchr_unescape(char *, const char, const char);
 void str_unescape(char *, const char);
 int str_isdigit(const char *);
 void kill_bot(char *, char *);
+char *egg_strdup(const char *);
 
 void maskaddr(const char *, char *, int);
 #define maskhost(a,b) maskaddr((a),(b),3)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add egg_strdup() for core and modules and converted 1 example for each

Additional description (if needed):
After this patch, about 100 more code blocks like the few ones done here, can be converted.
Less magick numbers, like in:
```
module_list->name = nmalloc(8);
strcpy(module_list->name, "eggdrop");
```
Maybe also Code like "malloc_strcpy()" in filesys module. 

**Now i wonder, if the nmalloc() memory accounting also / still works, when the nmalloc() is wrapped in a misc.c func.** Maybe the egg_strdup() won't work and this PR is garbage. And i dont want to re-introduce keyword `inline` here. I have the strange feeling, i've dont this before, read about this idea and problem before. **Deja vu.**
Test cases demonstrating functionality (if applicable):
