### PR TITLE
Fix segfault for small max-socks

### DIFF
--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -82,13 +82,11 @@ int increase_socks_max()
     max_dcc_new = td->MAXSOCKS - 10;
     if (max_dcc_new > max_dcc)
       max_dcc = max_dcc_new;
-    else {
-      if (max_dcc == 0)
+    else if (max_dcc == 0)
         max_dcc = 1;
-      else {
+    else {
         putlog(LOG_MISC, "*", "Maximum dcc limit reached. Consider raising max-socks.");
         return -1;
-      }
     }
     if (dcc)
       dcc = nrealloc(dcc, sizeof(struct dcc_t) * max_dcc);


### PR DESCRIPTION
Found by:
Patch by:
Fixes: #791 

One-line summary:
Fix segfault for small max-socks

Additional description (if needed):
Eggdrop increases dcc table in amounts of 10 entries per increase with upper limit max-socks. It distinguishes between socket and dcc and tries to keep max_dcc = MAXSOCKS - 10.
See https://github.com/eggheads/eggdrop/blob/develop/src/dccutil.c#L82
The whole dcc table increase handling looks ugly. Why is is increasing in amounts of 10 entries per increase? Why is it keeping max_dcc below MAXSOCKS, i mean why exactly 10 below , and why is new_dcc() counting up every time it is called? If eggdrop tries to connect to irc server and every time it does, it increases the dcc value, it will hit that max-socks soon. If you don't change max-socks, after about 100 connects it will fail to try again with:
```
[04:06:47] NO MORE DCC CONNECTIONS -- Can't create server connection.
[04:06:48] Maximum socket limit reached. Consider raising max-socks.
```
This would make sense in that you don't want to go higher than max-socks. But: Eggdrop doesn't really use dcc/socks here, it just wastes them. and the dcc table grows with empty entries. Every failed connection will count against sock-max. Something should be done about that. I don't think this is intended.
There is also repeated code in eggdrop like:
```
if (dcc_total == max_dcc && increase_socks_max())
[...]
i = new_dcc()
```
This code wantes some improvement. I mean: new_dcc() is already doing this check and increase.

**Anywayz, this patch fixes the segfault by properly handling max_dcc. Lets merge it as is.**

Test cases demonstrating functionality (if applicable):
```
$ grep max-socks BotA.conf
set max-socks 11
```

Before:
```
$ ./eggdrop -nt BotA.conf 

Eggdrop v1.8.3+sendfprint (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
--- Loading eggdrop v1.8.3+sendfprint (Thu Dec  6 2018)
Listening for telnet connections on 0.0.0.0:3333 (all).
Module loaded: blowfish        
* Last context: tclhash.c/250 []
* Please REPORT this BUG!
* Check doc/BUG-REPORT on how to do so.
Segmentation fault (core dumped)
```

After:
```
$ ./eggdrop -nt BotA.conf 

Eggdrop v1.8.3+sendfprint (C) 1997 Robey Pointer (C) 2010-2018 Eggheads
--- Loading eggdrop v1.8.3+sendfprint (Thu Dec  6 2018)
Listening for telnet connections on 0.0.0.0:3333 (all).
Module loaded: blowfish        
Maximum dcc limit reached. Consider raising max-socks.
Can't load modules dns: NO MORE DCC CONNECTIONS -- Can't create DNS socket.
Module loaded: channels        
Module loaded: server          
Module loaded: ctcp            
Module loaded: irc             
Module loaded: notes            (with lang support)
Module loaded: console          (with lang support)
Module loaded: uptime          
Loading dccwhois.tcl...
Loaded dccwhois.tcl
Userinfo TCL v1.07 loaded (URL BF GF IRL EMAIL DOB PHONE ICQ).
use '.help userinfo' for commands.
Writing channel file...
Userfile loaded, unpacking...
=== BotA: 0 channels, 5 users.
[04:14:52] * ERROR: Failed to initialize foreground chat.
```