### PR TITLE
Fix strcpy param overlap in wordshift()

### DIFF
--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -571,7 +571,7 @@ static void wordshift(char *first, char *rest)
   do {
     p = newsplit(&q);
     strcpy(first, p);
-    strcpy(rest, q);
+    memmove(rest, q, strlen(q) + 1);
   } while (!egg_strcasecmp(first, "and") || !egg_strcasecmp(first, "or"));
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix strcpy param overlap in wordshift()

Additional description (if needed):
Found with CFLAGS -fsanitize=address

Test cases demonstrating functionality (if applicable):
Before:
```
$ ./eggdrop -nt
[...]
.seen foo
[00:38:15] tcl: builtin dcc call: *dcc:seen -HQ 1 foo
[00:38:15] #-HQ# seen foo
=================================================================
==31306==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x62900007b0f0,0x62900007b0f1) and [0x62900007b0f0, 0x62900007b0f1) overlap
    #0 0x7f59aef78567 in __interceptor_strcpy /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:389
    #1 0x7f59a902fffe in wordshift .././seen.mod/seen.c:574
    #2 0x7f59a9033a32 in do_seen .././seen.mod/seen.c:447
    #3 0x7f59a9036dd1 in dcc_seen .././seen.mod/seen.c:149
    #4 0x5576d3e5ddf3 in builtin_dcc /home/michael/projects/eggdrop/src/tclhash.c:681
    #5 0x7f59aeda992b in TclInvokeStringCommand (/usr/lib/libtcl8.6.so+0x3992b)
    #6 0x7f59aedaea36 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x3ea36)
    #7 0x7f59aedb0a67 in TclEvalEx (/usr/lib/libtcl8.6.so+0x40a67)
    #8 0x7f59aedb1152 in Tcl_EvalEx (/usr/lib/libtcl8.6.so+0x41152)
    #9 0x7f59aedb1175 in Tcl_Eval (/usr/lib/libtcl8.6.so+0x41175)
    #10 0x7f59aedb1729 in Tcl_VarEvalVA (/usr/lib/libtcl8.6.so+0x41729)
    #11 0x7f59aedb17f9 in Tcl_VarEval (/usr/lib/libtcl8.6.so+0x417f9)
    #12 0x5576d3e590e5 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:748
    #13 0x5576d3e5fb8d in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:953
    #14 0x5576d3e6054b in check_tcl_dcc /home/michael/projects/eggdrop/src/tclhash.c:985
    #15 0x5576d3dd5c4a in dcc_chat /home/michael/projects/eggdrop/src/dcc.c:1090
    #16 0x5576d3e0c7e5 in mainloop main.c:881
    #17 0x5576d3d32f59 in main main.c:1286
    #18 0x7f59ad98b222 in __libc_start_main (/usr/lib/libc.so.6+0x24222)
    #19 0x5576d3d3476d in _start (/home/michael/eggdrop/eggdrop-1.8.3+0x21276d)

0x62900007b0f0 is located 12016 bytes inside of 16384-byte region [0x629000078200,0x62900007c200)
allocated by thread T0 here:
    #0 0x7f59af021019 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:86
    #1 0x7f59aee96caa in TclpAlloc (/usr/lib/libtcl8.6.so+0x126caa)

0x62900007b0f0 is located 12016 bytes inside of 16384-byte region [0x629000078200,0x62900007c200)
allocated by thread T0 here:
    #0 0x7f59af021019 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:86
    #1 0x7f59aee96caa in TclpAlloc (/usr/lib/libtcl8.6.so+0x126caa)

SUMMARY: AddressSanitizer: strcpy-param-overlap /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:389 in __interceptor_strcpy
==31306==ABORTING
```
After:
```
$ ./eggdrop -nt
[...]
.seen foo
[04:41:12] tcl: builtin dcc call: *dcc:seen -HQ 1 foo
[04:41:12] #-HQ# seen foo
I've never seen foo around.
```