### PR TITLE
Fix strcpy param overlap in splitc()

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -208,11 +208,7 @@ void splitc(char *first, char *rest, char divider)
   if (first != NULL)
     strcpy(first, rest);
   if (first != rest)
-    /*    In most circumstances, strcpy with src and dst being the same buffer
-     *  can produce undefined results. We're safe here, as the src is
-     *  guaranteed to be at least 2 bytes higher in memory than dest. <Cybah>
-     */
-    strcpy(rest, p + 1);
+    memmove(rest, p + 1, strlen(p + 1) + 1);
 }
 
 /*    As above, but lets you specify the 'max' number of bytes (EXCLUDING the


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix strcpy param overlap in splitc()

Additional description (if needed):
Found with CFLAGS -O1 -fsanitize=address

Test cases demonstrating functionality (if applicable):
Before:
```
$ ./eggdrop -nt BotA.conf
[...]
.link BotB
[...]
[01:18:02] Linked to BotB.
.botinfo
[01:18:04] tcl: builtin dcc call: *dcc:botinfo -HQ 1 
[01:18:04] #-HQ# botinfo
*** [BotA] eggdrop v1.8.3+sendfprint <I.didn't.edit.my.config.file.net> (no channels) [UP 00:00]
=================================================================
==6998==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x5585077f1980,0x5585077f1984) and [0x5585077f1982, 0x5585077f1986) overlap
    #0 0x7f59ffd54567 in __interceptor_strcpy /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:389
    #1 0x55850773ec4f in splitc /home/michael/projects/eggdrop/src/misc.c:215
    #2 0x5585076f2452 in add_note /home/michael/projects/eggdrop/src/botmsg.c:820
    #3 0x5585076e7a81 in bot_priv /home/michael/projects/eggdrop/src/botcmd.c:249
    #4 0x55850771ba0d in dcc_bot /home/michael/projects/eggdrop/src/dcc.c:548
    #5 0x55850773a1cf in mainloop main.c:881
    #6 0x55850773c3a0 in main main.c:1286
    #7 0x7f59ff28b222 in __libc_start_main (/usr/lib/libc.so.6+0x24222)
    #8 0x5585076e416d in _start (/home/michael/eggdrop/eggdrop-1.8.3+0x4216d)

0x5585077f1980 is located 0 bytes inside of global variable 'TBUF' defined in 'botcmd.c:46:13' (0x5585077f1980) of size 1024
0x5585077f1982 is located 2 bytes inside of global variable 'TBUF' defined in 'botcmd.c:46:13' (0x5585077f1980) of size 1024
SUMMARY: AddressSanitizer: strcpy-param-overlap /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:389 in __interceptor_strcpy
==6998==ABORTING
```
After:
```
$ ./eggdrop -nt BotA.conf
[...]
.link BotB
[...]
[01:21:11] Linked to BotB.
.botinfo
[01:21:15] tcl: builtin dcc call: *dcc:botinfo -HQ 1 
[01:21:15] #-HQ# botinfo
*** [BotA] eggdrop v1.8.3+sendfprint <I.didn't.edit.my.config.file.net> (no channels) [UP 00:00]
*** [BotB] eggdrop v1.8.3+sendfprint <I.didn't.edit.my.config.file.net> (no channels) [UP 00:23]
```