### PR TITLE
Fix -Wformat-overflow=2

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2080,9 +2080,9 @@ struct dcc_table DCC_TELNET_PW = {
 
 static int call_tcl_func(char *name, int idx, char *args)
 {
-  char s[11];
+  char s[12];
 
-  sprintf(s, "%d", idx);
+  snprintf(s, sizeof s, "%d", idx);
   Tcl_SetVar(interp, "_n", s, 0);
   Tcl_SetVar(interp, "_a", args, 0);
   if (Tcl_VarEval(interp, name, " $_n $_a", NULL) == TCL_ERROR) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix -Wformat-overflow=2

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
CFLAGS -Wformat-overflow=2
Before:
```
$ make
[...]
dcc.c: In function ‘call_tcl_func’:
dcc.c:2085:17: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
   sprintf(s, "%d", idx);
                 ^
dcc.c:2085:3: note: ‘sprintf’ output between 2 and 12 bytes into a destination of size 11
   sprintf(s, "%d", idx);
   ^~~~~~~~~~~~~~~~~~~~~
```
After:
clean make of dcc.c