### PR TITLE
Fix buffer sizes in seen.mod

### DIFF
--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -486,7 +486,7 @@ targetcont:
             (tv == 1) ? "" : "s");
   }
   if (!word2[0] && (work < 60)) {
-    strncpy(word2, "just moments ago!!", sizeof word2);
+    strlcpy(word2, "just moments ago!!", sizeof word2);
   } else {
     strcpy(word2 + strlen(word2) - 2, " ago.");
   }

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -138,7 +138,7 @@ static int msg_seen(char *nick, char *host, struct userrec *u, char *text)
     return 0;
   }
   putlog(LOG_CMDS, "*", "(%s!%s) !%s! SEEN %s", nick, host, u->handle, text);
-  sprintf(prefix, "PRIVMSG %s :", nick);
+  snprintf(prefix, sizeof prefix, "PRIVMSG %s :", nick);
   do_seen(DP_SERVER, prefix, nick, u->handle, "", text);
   return 0;
 }
@@ -153,7 +153,7 @@ static int dcc_seen(struct userrec *u, int idx, char *par)
 static void do_seen(int idx, char *prefix, char *nick, char *hand,
                     char *channel, char *text)
 {
-  char stuff[512], word1[512], word2[512], whotarget[512], object[512],
+  char stuff[512], word1[512], word2[512], whotarget[128], object[128],
        whoredirect[512], *oix, *lastonplace = 0;
   struct userrec *urec;
   struct chanset_t *chan;
@@ -199,7 +199,7 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
         m = ismember(chan, object);
         if (m) {
           onchan = 1;
-          sprintf(stuff, "%s!%s", object, m->userhost);
+          snprintf(stuff, sizeof stuff, "%s!%s", object, m->userhost);
           urec = get_user_by_host(stuff);
           if (!urec || !egg_strcasecmp(object, urec->handle))
             break;
@@ -207,7 +207,7 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
           strcat(whoredirect, " is ");
           strcat(whoredirect, urec->handle);
           strcat(whoredirect, ", and ");
-          strcpy(object, urec->handle);
+          strlcpy(object, urec->handle, sizeof object);
           break;
         }
         chan = chan->next;
@@ -219,9 +219,9 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
       }
     }
     if (!egg_strcasecmp(word1, "bf") || !egg_strcasecmp(word1, "boyfriend")) {
-      strcpy(whotarget, getxtra(object, "BF"));
+      strlcpy(whotarget, getxtra(object, "BF"), sizeof whotarget);
       if (whotarget[0]) {
-        sprintf(whoredirect, "%s boyfriend is %s, and ",
+        snprintf(whoredirect, sizeof whoredirect, "%s boyfriend is %s, and ",
                 fixnick(object), whotarget);
         goto targetcont;
       }
@@ -231,9 +231,9 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
       return;
     }
     if (!egg_strcasecmp(word1, "gf") || !egg_strcasecmp(word1, "girlfriend")) {
-      strcpy(whotarget, getxtra(object, "GF"));
+      strlcpy(whotarget, getxtra(object, "GF"), sizeof whotarget);
       if (whotarget[0]) {
-        sprintf(whoredirect, "%s girlfriend is %s, and ",
+        snprintf(whoredirect, sizeof whoredirect, "%s girlfriend is %s, and ",
                 fixnick(object), whotarget);
         goto targetcont;
       }
@@ -263,9 +263,9 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
     }
     /* "my boyfriend" */
     if (!egg_strcasecmp(word1, "boyfriend") || !egg_strcasecmp(word1, "bf")) {
-      strcpy(whotarget, getxtra(hand, "BF"));
+      strlcpy(whotarget, getxtra(hand, "BF"), sizeof whotarget);
       if (whotarget[0]) {
-        sprintf(whoredirect, "%s, your boyfriend is %s, and ", nick, whotarget);
+        snprintf(whoredirect, sizeof whoredirect, "%s, your boyfriend is %s, and ", nick, whotarget);
       } else {
         dprintf(idx, "%sI didn't know you had a boyfriend, %s\n", prefix, nick);
         return;
@@ -274,9 +274,9 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
     /* "my girlfriend" */
     else if (!egg_strcasecmp(word1, "girlfriend") ||
              !egg_strcasecmp(word1, "gf")) {
-      strcpy(whotarget, getxtra(hand, "GF"));
+      strlcpy(whotarget, getxtra(hand, "GF"), sizeof whotarget);
       if (whotarget[0]) {
-        sprintf(whoredirect, "%s, your girlfriend is %s, and ",
+        snprintf(whoredirect, sizeof whoredirect, "%s, your girlfriend is %s, and ",
                 nick, whotarget);
       } else {
         dprintf(idx, "%sI didn't know you had a girlfriend, %s\n", prefix,
@@ -325,13 +325,13 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
   }
   /* Check for keyword match in the internal table */
   else if (match_trigger(word1)) {
-    sprintf(word2, "%s%s\n", prefix, match_trigger(word1));
+    snprintf(word2, sizeof word2, "%s%s\n", prefix, match_trigger(word1));
     dprintf(idx, word2, nick);
     return;
   }
   /* Otherwise, make the target to the first word and continue */
   else
-    strcpy(whotarget, word1);
+    strlcpy(whotarget, word1, sizeof whotarget);
 
 targetcont:
   /* Looking for ones own nick? */
@@ -346,7 +346,7 @@ targetcont:
     m = ismember(chan, whotarget);
     if (m) {
       onchan = 1;
-      sprintf(word1, "%s!%s", whotarget, m->userhost);
+      snprintf(word1, sizeof word1, "%s!%s", whotarget, m->userhost);
       urec = get_user_by_host(word1);
       if (!urec || !egg_strcasecmp(whotarget, urec->handle))
         break;
@@ -364,7 +364,7 @@ targetcont:
     while (chan) {
       m = chan->channel.member;
       while (m && m->nick[0]) {
-        sprintf(word2, "%s!%s", m->nick, m->userhost);
+        snprintf(word2, sizeof word2, "%s!%s", m->nick, m->userhost);
         urec = get_user_by_host(word2);
         if (urec && !egg_strcasecmp(urec->handle, whotarget)) {
           onchan = 1;
@@ -372,7 +372,7 @@ targetcont:
           strcat(whoredirect, " is ");
           strcat(whoredirect, m->nick);
           strcat(whoredirect, ", and ");
-          strcpy(whotarget, m->nick);
+          strlcpy(whotarget, m->nick, sizeof whotarget);
           break;
         }
         m = m->next;
@@ -472,7 +472,7 @@ targetcont:
   work = now - laston;
   if (work >= 86400) {
     tv = work / 86400;
-    sprintf(word2, "%lu day%s, ", tv, (tv == 1) ? "" : "s");
+    snprintf(word2, sizeof word2, "%lu day%s, ", tv, (tv == 1) ? "" : "s");
     work = work % 86400;
   }
   if (work >= 3600) {
@@ -486,18 +486,18 @@ targetcont:
             (tv == 1) ? "" : "s");
   }
   if (!word2[0] && (work < 60)) {
-    strcpy(word2, "just moments ago!!");
+    strncpy(word2, "just moments ago!!", sizeof word2);
   } else {
     strcpy(word2 + strlen(word2) - 2, " ago.");
   }
   if (lastonplace[0] && (strchr(CHANMETA, lastonplace[0]) != NULL))
-    sprintf(word1, "on IRC channel %s", lastonplace);
+    snprintf(word1, sizeof word1, "on IRC channel %s", lastonplace);
   else if (lastonplace[0] == '@')
-    sprintf(word1, "on %s", lastonplace + 1);
+    snprintf(word1, sizeof word1, "on %s", lastonplace + 1);
   else if (lastonplace[0] != 0)
-    sprintf(word1, "on my %s", lastonplace);
+    snprintf(word1, sizeof word1, "on my %s", lastonplace);
   else
-    strcpy(word1, "seen");
+    strlcpy(word1, "seen", sizeof word1);
   dprintf(idx, "%s%s%s was last %s %s\n",
           prefix, whoredirect, whotarget, word1, word2);
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix buffer sizes in seen.mod

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Before:
```
.seen michael's gf
[09:16:38] tcl: builtin dcc call: *dcc:seen -HQ 1 michael's gf
[09:16:38] #-HQ# seen michael's gf
michael's girlfriend is 12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
Aborted (core dumped)
```
After:
```
.seen michael's gf
[15:33:45] tcl: builtin dcc call: *dcc:seen -HQ 1 michael's gf
[15:33:45] #-HQ# seen michael's gf
michael's girlfriend is 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567, and I don't know who 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567 is.
```