### PR TITLE
Modify module version check to not prevent newer versions from running

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -892,11 +892,12 @@ module_entry *module_find(char *name, int major, int minor)
   module_entry *p;
 
   for (p = module_list; p && p->name; p = p->next) {
-    if ((major == p->major || !major) && minor <= p->minor &&
-        !egg_strcasecmp(name, p->name))
+    if ( (((major < p->major) || !major) || ((major == p->major) &&
+        (minor <= p->minor))) && !egg_strcasecmp(name, p->name) )
       return p;
   }
   return NULL;
+
 }
 
 static int module_rename(char *name, char *newname)

--- a/src/version.h
+++ b/src/version.h
@@ -26,6 +26,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#define EGG_STRINGVER "1.8.4"
-#define EGG_NUMVER 1080405
+#define EGG_STRINGVER "1.9.0"
+#define EGG_NUMVER 1090000
 #define EGG_PATCH "base"


### PR DESCRIPTION
Found by: tuvok
Patch by: Geo
Fixes: #804 

One-line summary:


Additional description (if needed):
Modules check version newness using '==' not '<=' for the major version. Thus, modules that require 1.8.0 or later incorrectly do not run on 1.9.0 bots, since 1.9 != 1.8. 

Test cases demonstrating functionality (if applicable):
```
--- Loading eggdrop v1.9.0+base (Tue Jun 18 2019)
<snip>
Module loaded: dns             
Module loaded: channels        
Module loaded: server          
<snip>
```
etc. 