### PR TITLE
Update -nc console flag output. Fixes #787

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -342,8 +342,8 @@ void tell_verbose_status(int idx)
     cputime -= hr * 60;
     sprintf(s2, "CPU: %02d:%05.2f", (int) hr, cputime); /* Actually min/sec */
   }
-  if ((cache_hit + cache_miss)) {      /* 2019, still can't divide by zero */
-    cache_total = 100.0 * (cache_hit) / ((cache_hit + cache_miss));
+  if (cache_hit + cache_miss) {      /* 2019, still can't divide by zero */
+    cache_total = 100.0 * (cache_hit) / (cache_hit + cache_miss);
   } else cache_total = 0;
     dprintf(idx, "%s %s (%s) - %s - %s: %4.1f%%\n", MISC_ONLINEFOR,
             s, s1, s2, MISC_CACHEHIT, cache_total);

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -290,7 +290,7 @@ void tell_verbose_status(int idx)
   char *vers_t, *uni_t;
   int i;
   time_t now2 = now - online_since, hr, min;
-  float cputime, cache_total;
+  double cputime, cache_total;
 #ifdef HAVE_UNAME
   struct utsname un;
 
@@ -342,8 +342,8 @@ void tell_verbose_status(int idx)
     cputime -= hr * 60;
     sprintf(s2, "CPU: %02d:%05.2f", (int) hr, cputime); /* Actually min/sec */
   }
-  if ((float) (cache_hit + cache_miss)) {      /* 2019, still can't divide by zero */
-    cache_total = 100.0 * ((float) cache_hit) / ((float) (cache_hit + cache_miss));
+  if ((cache_hit + cache_miss)) {      /* 2019, still can't divide by zero */
+    cache_total = 100.0 * (cache_hit) / ((cache_hit + cache_miss));
   } else cache_total = 0;
     dprintf(idx, "%s %s (%s) - %s - %s: %4.1f%%\n", MISC_ONLINEFOR,
             s, s1, s2, MISC_CACHEHIT, cache_total);

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -290,7 +290,7 @@ void tell_verbose_status(int idx)
   char *vers_t, *uni_t;
   int i;
   time_t now2 = now - online_since, hr, min;
-  float cputime;
+  float cputime, cache_total;
 #ifdef HAVE_UNAME
   struct utsname un;
 
@@ -342,9 +342,11 @@ void tell_verbose_status(int idx)
     cputime -= hr * 60;
     sprintf(s2, "CPU: %02d:%05.2f", (int) hr, cputime); /* Actually min/sec */
   }
-  dprintf(idx, "%s %s (%s) - %s - %s: %4.1f%%\n", MISC_ONLINEFOR,
-          s, s1, s2, MISC_CACHEHIT,
-          100.0 * ((float) cache_hit) / ((float) (cache_hit + cache_miss)));
+  if ((float) (cache_hit + cache_miss)) {      /* 2019, still can't divide by zero */
+    cache_total = 100.0 * ((float) cache_hit) / ((float) (cache_hit + cache_miss));
+  } else cache_total = 0;
+    dprintf(idx, "%s %s (%s) - %s - %s: %4.1f%%\n", MISC_ONLINEFOR,
+            s, s1, s2, MISC_CACHEHIT, cache_total);
 
   dprintf(idx, "Configured with: " EGG_AC_ARGS "\n");
   if (admin[0])

--- a/src/main.c
+++ b/src/main.c
@@ -634,7 +634,7 @@ static struct tm nowtm;
  */
 static void core_secondly()
 {
-  static int cnt = 0;
+  static int cnt = 10; /* Don't wait the first 10 seconds to display */
   int miltime;
   time_t nowmins;
   int i;


### PR DESCRIPTION
Found by: mortmann
Patch by: Geo
Fixes: #787 

One-line summary:
Update -nc console flag output

Additional description (if needed):
- Don't wait 10 seconds to display channel stat output
- Don't divide by zero. (if the total cache float rounded to 0, a not-a-number error was generated when dividing by the total cache)

I'm not 100% sold on not waiting 10 seconds, maybe there's a good reason to do so? I can't think of one though, so I put it in, I don't think it's a bad idea. 

Test cases demonstrating functionality (if applicable):
