### PR TITLE
Create sslsilent Makefile option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -298,7 +298,7 @@ install-end =	echo "" && echo "Installation completed." && echo "" && \
 		echo "Remember to change directory to $(DEST) before you proceed." && \
 		echo ""
 
-sslcert:
+sslstart:
 	@if test ! -d $(DEST); then \
 		echo "You haven't installed eggdrop yet, or you installed using the DEST= flag.";\
 		echo "Please run \"make install\" first.";\
@@ -310,8 +310,14 @@ sslcert:
 	fi && \
 	if test -f $(DEST)/eggdrop.crt; then \
 		cp $(DEST)/eggdrop.crt $(DEST)/eggdrop.crt~old; \
-	fi && \
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf; \
+	fi
+
+sslcert: sslstart
+	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
+
+sslsilent: sslstart
+	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
+	    -subj "/O=Eggheads/OU=Eggdrop/CN=Self-generated Eggdrop Certificate"
 
 install: ainstall
 

--- a/doc/sphinx_source/installAndSetup/install.rst
+++ b/doc/sphinx_source/installAndSetup/install.rst
@@ -88,6 +88,11 @@ Eggdrop uses the GNU autoconfigure scripts to make things easier.
 
        make sslcert DEST=<directory>
 
+    For those using scripts to install Eggdrop, you can non-interactively
+    generate a key and certificate by running:
+
+       make sslsilent
+
      Read docs/TLS for more info on this process.
 
 6. Edit your config file completely.

--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -115,7 +115,9 @@ The easy way to create a key and a certificate is to type 'make sslcert'
 after compiling your bot (If you installed eggdrop to a non-standard
 location, use make sslcert DEST=/path/to/eggdrop). This will generate a
 4096-bit private key (eggdrop.key) and a certificate (eggdrop.crt) after
-you fill in therequired fields.
+you fill in therequired fields. Alternatively, you can use 'make sslsilent'
+to generate a key and certificate non-interactively, using pre-set values.
+This is useful when installing Eggdrop via a scripted process.
 
 To authenticate with a certificate instead of using password, you should
 make a ssl certificate for yourself and enable ssl-cert-auth in the config

--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -115,7 +115,7 @@ The easy way to create a key and a certificate is to type 'make sslcert'
 after compiling your bot (If you installed eggdrop to a non-standard
 location, use make sslcert DEST=/path/to/eggdrop). This will generate a
 4096-bit private key (eggdrop.key) and a certificate (eggdrop.crt) after
-you fill in therequired fields. Alternatively, you can use 'make sslsilent'
+you fill in the required fields. Alternatively, you can use 'make sslsilent'
 to generate a key and certificate non-interactively, using pre-set values.
 This is useful when installing Eggdrop via a scripted process.
 


### PR DESCRIPTION
This allows Eggdrop to generate SSL certificates without human intervention,
good for scripts and testing. Uses preset values for O, OU, and CN

Test cases demonstrating functionality (if applicable):

```
$ make sslsilent
openssl req -new -x509 -nodes -days 365 -keyout /home/foo/eggdrop/eggdrop.key -out /home/foo/eggdrop/eggdrop.crt -config ssl.conf \
    -subj "/O=Eggheads/OU=Eggdrop/CN=Self-generated Eggdrop Certificate"
Generating a RSA private key
................................................................................................................................................................++++
..........................................................................................................++++
writing new private key to '/home/foo/eggdrop/eggdrop.key'
-----
$
```
old still works, too:
```
$ make sslcert
openssl req -new -x509 -nodes -days 365 -keyout /home/foo/eggdrop/eggdrop.key -out /home/foo/eggdrop/eggdrop.crt -config ssl.conf
Generating a RSA private key
.................................++++
.....++++
writing new private key to '/home/foo/eggdrop/eggdrop.key'
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [EU]:

$