### PR TITLE
Fix ident module include

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include "src/mod/module.h"
 #include "server.mod/server.h"
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Portability of ident module

One-line summary:
Ident module needs to include sys/stat.h

Additional description (if needed):
Found under FreeBSD

Test cases demonstrating functionality (if applicable):

Before:
```
cc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././ident.mod/ident.c && mv -f ident.o ../
.././ident.mod/ident.c:113:54: error: use of undeclared identifier 'S_IRUSR'
  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IROTH)) < 0) {
                                                     ^
.././ident.mod/ident.c:113:64: error: use of undeclared identifier 'S_IWUSR'
  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IROTH)) < 0) {
                                                               ^
.././ident.mod/ident.c:113:74: error: use of undeclared identifier 'S_IROTH'
  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IROTH)) < 0) {
                                                                         ^
3 errors generated.
*** Error code 1

Stop.
make[2]: stopped in /usr/home/michael/usr/src/eggdrop/src/mod/ident.mod
*** Error code 1

Stop.
make[1]: stopped in /usr/home/michael/usr/src/eggdrop/src/mod
*** Error code 1

Stop.
make: stopped in /usr/home/michael/usr/src/eggdrop
```
After:
```
cc -shared -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../../../ident.so ../ident.o -L/usr/local/lib -ltcl86 -lz -lpthread -lm -lssl -lcrypto  && touch ../../../ident.so
cc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././irc.mod/irc.c && mv -f irc.o ../

```