### PR TITLE
Fix memleak

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -651,8 +651,10 @@ void ssl_info(SSL *ssl, int where, int ret)
     putlog(data->loglevel, "*", "TLS: handshake successful. Secure connection "
            "established.");
 
-    if ((cert = SSL_get_peer_certificate(ssl)))
+    if ((cert = SSL_get_peer_certificate(ssl))) {
       ssl_showcert(cert, data->loglevel);
+      X509_free(cert);
+    }
     else
       putlog(data->loglevel, "*", "TLS: peer did not present a certificate");
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Memleak

One-line summary:
Fixes memleak in tls.c

Additional description (if needed):
Fixes the following Memleak found with clang
```
==14319==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 352 byte(s) in 1 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880fa5d9 in CRYPTO_zalloc (/usr/lib/libcrypto.so.1.1+0x17e5d9)

Indirect leak of 3336 byte(s) in 41 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880fa5d9 in CRYPTO_zalloc (/usr/lib/libcrypto.so.1.1+0x17e5d9)

Indirect leak of 855 byte(s) in 1 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe38801ce5c  (/usr/lib/libcrypto.so.1.1+0xa0e5c)

Indirect leak of 526 byte(s) in 1 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880070b8  (/usr/lib/libcrypto.so.1.1+0x8b0b8)

Indirect leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880070b8  (/usr/lib/libcrypto.so.1.1+0x8b0b8)
    #2 0x62a000000574  (<unknown module>)

Indirect leak of 225 byte(s) in 15 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880109ba in ASN1_STRING_set (/usr/lib/libcrypto.so.1.1+0x949ba)

Indirect leak of 192 byte(s) in 2 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe388049adc in BUF_MEM_grow (/usr/lib/libcrypto.so.1.1+0xcdadc)

Indirect leak of 144 byte(s) in 4 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe3880fa5d9 in CRYPTO_zalloc (/usr/lib/libcrypto.so.1.1+0x17e5d9)
    #2 0xfe625990dea9aeff  (<unknown module>)

Indirect leak of 138 byte(s) in 2 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe38817ba7c  (/usr/lib/libcrypto.so.1.1+0x1ffa7c)

Indirect leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe388039ec7 in BN_MONT_CTX_new (/usr/lib/libcrypto.so.1.1+0xbdec7)

Indirect leak of 48 byte(s) in 3 object(s) allocated from:
    #0 0x55bed63ecffa in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x227ffa)
    #1 0x7fe38801b433  (/usr/lib/libcrypto.so.1.1+0x9f433)

SUMMARY: AddressSanitizer: 6432 byte(s) leaked in 72 allocation(s).
```

Test cases demonstrating functionality (if applicable):