### PR TITLE
Typo fixes for CAP, SASL and more

### DIFF
--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -103,7 +103,7 @@ struct server_list {
 };
 
 typedef struct cap_list {
-  char supported[CAPMAX];   /* Capes supportd by IRCD                   */
+  char supported[CAPMAX];   /* Capes supported by IRCD                  */
   char negotiated[CAPMAX];  /* Common capes between IRCD and client     */
   char desired[CAPMAX];     /* Capes Eggdrop wants to request from IRCD */
 } cap_list;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1200,7 +1200,7 @@ static int tryauthenticate(char *from, char *msg)
     dprintf(DP_MODE, "AUTHENTICATE %s\n", dst);
 #ifdef HAVE_OPENSSL_SSL_H
   } else {
-    putlog(LOG_SERV, "*", "SASL: got AUTHENTICATE Challange");
+    putlog(LOG_SERV, "*", "SASL: got AUTHENTICATE Challenge");
     olen = b64_pton(msg, dst, sizeof dst);
     if (olen == -1) {
       putlog(LOG_SERV, "*", "SASL: AUTHENTICATE error: could not base64 encode");

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -814,7 +814,7 @@ void addhost_by_handle(char *handle, char *host)
   struct userrec *u = get_user_by_handle(userlist, handle);
 
   set_user(&USERENTRY_HOSTS, u, host);
-  /* u will be cached, so really no overhead, even tho this looks dumb: */
+  /* u will be cached, so really no overhead, even though this looks dumb: */
   if ((!noshare) && !(u->flags & USER_UNSHARED)) {
     if (u->flags & USER_BOT)
       shareout(NULL, "+bh %s %s\n", handle, host);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Typo fixes for CAP, SASL and more

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
