### PR TITLE
Add base64 fallback functions for SASL

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -288,6 +288,8 @@ dnl EGG_FUNC_B64_NTOP()
 dnl
 AC_DEFUN([EGG_FUNC_B64_NTOP],
 [
+  # https://raw.githubusercontent.com/tmux/tmux/2dd9a4fb9cd73987bdca5b8b2f85ca8b1a6e4e73/configure.ac
+
   # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
   AC_MSG_CHECKING(for b64_ntop)
   AC_TRY_LINK(

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -322,7 +322,7 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
     fi
   fi
   if test "x$found_b64_ntop" = xyes; then
-    AC_DEFINE([HAVE_B64_NTOP], [1], [Define if b64_ntop exists.])
+    AC_DEFINE([HAVE_BASE64], [1], [Define if b64_ntop exists.])
     AC_MSG_RESULT(yes)
   else
     AC_LIBOBJ(base64)

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -284,6 +284,52 @@ dnl Checks for types and functions.
 dnl
 
 
+dnl EGG_FUNC_B64_NTOP()
+dnl
+AC_DEFUN([EGG_FUNC_B64_NTOP],
+[
+  # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
+  AC_MSG_CHECKING(for b64_ntop)
+  AC_TRY_LINK(
+    [
+      #include <sys/types.h>
+      #include <netinet/in.h>
+      #include <resolv.h>
+    ],
+    [b64_ntop(NULL, 0, NULL, 0);],
+    found_b64_ntop=yes,
+    found_b64_ntop=no
+  )
+  if test "x$found_b64_ntop" = xno; then
+    AC_MSG_RESULT(no)
+
+    AC_MSG_CHECKING(for b64_ntop with -lresolv)
+    OLD_LIBS="$LIBS"
+    LIBS="$LIBS -lresolv"
+    AC_TRY_LINK(
+      [
+        #include <sys/types.h>
+        #include <netinet/in.h>
+        #include <resolv.h>
+      ],
+      [b64_ntop(NULL, 0, NULL, 0);],
+      found_b64_ntop=yes,
+      found_b64_ntop=no
+    )
+    if test "x$found_b64_ntop" = xno; then
+      LIBS="$OLD_LIBS"
+      AC_MSG_RESULT(no)
+    fi
+  fi
+  if test "x$found_b64_ntop" = xyes; then
+    AC_DEFINE([HAVE_B64_NTOP], [1], [Define if b64_ntop exists.])
+    AC_MSG_RESULT(yes)
+  else
+    AC_LIBOBJ(base64)
+  fi
+])
+
+
 dnl EGG_FUNC_VPRINTF()
 dnl
 AC_DEFUN([EGG_FUNC_VPRINTF],

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AX_CREATE_STDINT_H([eggint.h])
 # Checks for functions and their arguments.
 AC_CHECK_FUNCS([clock dprintf getrandom getrusage inet_aton inet_ntop isascii random rand lrand48 setpgid snprintf strlcpy vsnprintf])
 AC_FUNC_SELECT_ARGTYPES
+EGG_FUNC_B64_NTOP
 EGG_FUNC_VPRINTF
 AC_FUNC_MMAP
 

--- a/src/compat/Makefile.in
+++ b/src/compat/Makefile.in
@@ -17,8 +17,8 @@ STRIP = @STRIP@
 CFLAGS = @CFLAGS@ -I../.. -I$(top_srcdir) -I$(top_srcdir)/src @SSL_INCLUDES@ @DEFS@ $(CFLGS)
 CPPFLAGS = @CPPFLAGS@
 
-OBJS = gethostbyname2.o in6.o inet_aton.o inet_ntop.o inet_pton.o snprintf.o \
-	strlcpy.o
+OBJS = base64.o gethostbyname2.o in6.o inet_aton.o inet_ntop.o inet_pton.o \
+	snprintf.o strlcpy.o
 
 doofus:
 	@echo ""
@@ -41,48 +41,51 @@ compat: $(OBJS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
 #safety hash
+base64.o: base64.c
 gethostbyname2.o: gethostbyname2.c gethostbyname2.h ../../src/main.h \
  ../../config.h ../../eggint.h ../../lush.h ../../src/lang.h \
  ../../src/eggdrop.h ../../src/compat/in6.h ../../src/flags.h \
  ../../src/proto.h ../../src/misc_file.h ../../src/cmdt.h \
  ../../src/tclegg.h ../../src/tclhash.h ../../src/chan.h \
- ../../src/users.h ../../src/compat/compat.h ../../src/compat/inet_aton.h \
- ../../src/compat/snprintf.h ../../src/compat/inet_ntop.h \
- ../../src/compat/inet_pton.h ../../src/compat/gethostbyname2.h \
- ../../src/compat/strlcpy.h
+ ../../src/users.h ../../src/compat/compat.h ../../src/compat/base64.h \
+ ../../src/compat/inet_aton.h ../../src/compat/snprintf.h \
+ ../../src/compat/inet_ntop.h ../../src/compat/inet_pton.h \
+ ../../src/compat/gethostbyname2.h ../../src/compat/strlcpy.h
 in6.o: in6.c in6.h
 inet_aton.o: inet_aton.c ../../src/main.h ../../config.h ../../eggint.h \
  ../../lush.h ../../src/lang.h ../../src/eggdrop.h ../../src/compat/in6.h \
  ../../src/flags.h ../../src/proto.h ../../src/misc_file.h \
  ../../src/cmdt.h ../../src/tclegg.h ../../src/tclhash.h ../../src/chan.h \
- ../../src/users.h ../../src/compat/compat.h ../../src/compat/inet_aton.h \
- ../../src/main.h ../../src/compat/snprintf.h \
- ../../src/compat/inet_ntop.h ../../src/compat/inet_pton.h \
- ../../src/compat/gethostbyname2.h ../../src/compat/strlcpy.h inet_aton.h
+ ../../src/users.h ../../src/compat/compat.h ../../src/compat/base64.h \
+ ../../src/compat/inet_aton.h ../../src/main.h \
+ ../../src/compat/snprintf.h ../../src/compat/inet_ntop.h \
+ ../../src/compat/inet_pton.h ../../src/compat/gethostbyname2.h \
+ ../../src/compat/strlcpy.h inet_aton.h
 inet_ntop.o: inet_ntop.c inet_ntop.h ../../src/main.h ../../config.h \
  ../../eggint.h ../../lush.h ../../src/lang.h ../../src/eggdrop.h \
  ../../src/compat/in6.h ../../src/flags.h ../../src/proto.h \
  ../../src/misc_file.h ../../src/cmdt.h ../../src/tclegg.h \
  ../../src/tclhash.h ../../src/chan.h ../../src/users.h \
- ../../src/compat/compat.h ../../src/compat/inet_aton.h \
- ../../src/compat/snprintf.h ../../src/compat/inet_ntop.h \
- ../../src/compat/inet_pton.h ../../src/compat/gethostbyname2.h \
- ../../src/compat/strlcpy.h
+ ../../src/compat/compat.h ../../src/compat/base64.h \
+ ../../src/compat/inet_aton.h ../../src/compat/snprintf.h \
+ ../../src/compat/inet_ntop.h ../../src/compat/inet_pton.h \
+ ../../src/compat/gethostbyname2.h ../../src/compat/strlcpy.h
 inet_pton.o: inet_pton.c inet_pton.h ../../src/main.h ../../config.h \
  ../../eggint.h ../../lush.h ../../src/lang.h ../../src/eggdrop.h \
  ../../src/compat/in6.h ../../src/flags.h ../../src/proto.h \
  ../../src/misc_file.h ../../src/cmdt.h ../../src/tclegg.h \
  ../../src/tclhash.h ../../src/chan.h ../../src/users.h \
- ../../src/compat/compat.h ../../src/compat/inet_aton.h \
- ../../src/compat/snprintf.h ../../src/compat/inet_ntop.h \
- ../../src/compat/inet_pton.h ../../src/compat/gethostbyname2.h \
- ../../src/compat/strlcpy.h
+ ../../src/compat/compat.h ../../src/compat/base64.h \
+ ../../src/compat/inet_aton.h ../../src/compat/snprintf.h \
+ ../../src/compat/inet_ntop.h ../../src/compat/inet_pton.h \
+ ../../src/compat/gethostbyname2.h ../../src/compat/strlcpy.h
 snprintf.o: snprintf.c ../../src/main.h ../../config.h ../../eggint.h \
  ../../lush.h ../../src/lang.h ../../src/eggdrop.h ../../src/compat/in6.h \
  ../../src/flags.h ../../src/proto.h ../../src/misc_file.h \
  ../../src/cmdt.h ../../src/tclegg.h ../../src/tclhash.h ../../src/chan.h \
- ../../src/users.h ../../src/compat/compat.h ../../src/compat/inet_aton.h \
- ../../src/main.h ../../src/compat/snprintf.h \
- ../../src/compat/inet_ntop.h ../../src/compat/inet_pton.h \
- ../../src/compat/gethostbyname2.h ../../src/compat/strlcpy.h snprintf.h
+ ../../src/users.h ../../src/compat/compat.h ../../src/compat/base64.h \
+ ../../src/compat/inet_aton.h ../../src/main.h \
+ ../../src/compat/snprintf.h ../../src/compat/inet_ntop.h \
+ ../../src/compat/inet_pton.h ../../src/compat/gethostbyname2.h \
+ ../../src/compat/strlcpy.h snprintf.h
 strlcpy.o: strlcpy.c ../../config.h

--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 1996, 1998 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+/*
+ * Portions Copyright (c) 1995 by International Business Machines, Inc.
+ *
+ * International Business Machines, Inc. (hereinafter called IBM) grants
+ * permission under its copyrights to use, copy, modify, and distribute this
+ * Software with or without fee, provided that the above copyright notice and
+ * all paragraphs of this notice appear in all copies, and that the name of IBM
+ * not be used in connection with the marketing of any product incorporating
+ * the Software or modifications thereof, without specific, written prior
+ * permission.
+ *
+ * To the extent it has a right to do so, IBM grants an immunity from suit
+ * under its patents, if any, for the use, sale or manufacture of products to
+ * the extent that such products are used for performing Domain Name System
+ * dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+ * granted for any product per se or for any other function of any product.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+ * DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+ * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+#include <sys/param.h>
+#include <sys/socket.h>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+
+#include <ctype.h>
+#include <resolv.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define Assert(Cond) if (!(Cond)) abort()
+
+static const char Base64[] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char Pad64 = '=';
+
+/* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
+   The following encoding technique is taken from RFC 1521 by Borenstein
+   and Freed.  It is reproduced here in a slightly edited form for
+   convenience.
+
+   A 65-character subset of US-ASCII is used, enabling 6 bits to be
+   represented per printable character. (The extra 65th character, "=",
+   is used to signify a special processing function.)
+
+   The encoding process represents 24-bit groups of input bits as output
+   strings of 4 encoded characters. Proceeding from left to right, a
+   24-bit input group is formed by concatenating 3 8-bit input groups.
+   These 24 bits are then treated as 4 concatenated 6-bit groups, each
+   of which is translated into a single digit in the base64 alphabet.
+
+   Each 6-bit group is used as an index into an array of 64 printable
+   characters. The character referenced by the index is placed in the
+   output string.
+
+                         Table 1: The Base64 Alphabet
+
+      Value Encoding  Value Encoding  Value Encoding  Value Encoding
+          0 A            17 R            34 i            51 z
+          1 B            18 S            35 j            52 0
+          2 C            19 T            36 k            53 1
+          3 D            20 U            37 l            54 2
+          4 E            21 V            38 m            55 3
+          5 F            22 W            39 n            56 4
+          6 G            23 X            40 o            57 5
+          7 H            24 Y            41 p            58 6
+          8 I            25 Z            42 q            59 7
+          9 J            26 a            43 r            60 8
+         10 K            27 b            44 s            61 9
+         11 L            28 c            45 t            62 +
+         12 M            29 d            46 u            63 /
+         13 N            30 e            47 v
+         14 O            31 f            48 w         (pad) =
+         15 P            32 g            49 x
+         16 Q            33 h            50 y
+
+   Special processing is performed if fewer than 24 bits are available
+   at the end of the data being encoded.  A full encoding quantum is
+   always completed at the end of a quantity.  When fewer than 24 input
+   bits are available in an input group, zero bits are added (on the
+   right) to form an integral number of 6-bit groups.  Padding at the
+   end of the data is performed using the '=' character.
+
+   Since all base64 input is an integral number of octets, only the
+         -------------------------------------------------                       
+   following cases can arise:
+   
+       (1) the final quantum of encoding input is an integral
+           multiple of 24 bits; here, the final unit of encoded
+	   output will be an integral multiple of 4 characters
+	   with no "=" padding,
+       (2) the final quantum of encoding input is exactly 8 bits;
+           here, the final unit of encoded output will be two
+	   characters followed by two "=" padding characters, or
+       (3) the final quantum of encoding input is exactly 16 bits;
+           here, the final unit of encoded output will be three
+	   characters followed by one "=" padding character.
+   */
+
+int
+b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize) {
+	size_t datalength = 0;
+	u_char input[3];
+	u_char output[4];
+	size_t i;
+
+	while (2 < srclength) {
+		input[0] = *src++;
+		input[1] = *src++;
+		input[2] = *src++;
+		srclength -= 3;
+
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[3] = input[2] & 0x3f;
+		Assert(output[0] < 64);
+		Assert(output[1] < 64);
+		Assert(output[2] < 64);
+		Assert(output[3] < 64);
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		target[datalength++] = Base64[output[2]];
+		target[datalength++] = Base64[output[3]];
+	}
+    
+	/* Now we worry about padding. */
+	if (0 != srclength) {
+		/* Get what's left. */
+		input[0] = input[1] = input[2] = '\0';
+		for (i = 0; i < srclength; i++)
+			input[i] = *src++;
+	
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		Assert(output[0] < 64);
+		Assert(output[1] < 64);
+		Assert(output[2] < 64);
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		if (srclength == 1)
+			target[datalength++] = Pad64;
+		else
+			target[datalength++] = Base64[output[2]];
+		target[datalength++] = Pad64;
+	}
+	if (datalength >= targsize)
+		return (-1);
+	target[datalength] = '\0';	/* Returned value doesn't count \0. */
+	return (datalength);
+}
+
+/* skips all whitespace anywhere.
+   converts characters, four at a time, starting at (or after)
+   src from base - 64 numbers into three 8 bit bytes in the target area.
+   it returns the number of data bytes stored at the target, or -1 on error.
+ */
+
+int
+b64_pton(const char *src, u_char *target, size_t targsize)
+{
+	int tarindex, state, ch;
+	u_char nextbyte;
+	char *pos;
+
+	state = 0;
+	tarindex = 0;
+
+	while ((ch = *src++) != '\0') {
+		if (isspace((unsigned char)ch))        /* Skip whitespace anywhere. */
+			continue;
+
+		if (ch == Pad64)
+			break;
+
+		pos = strchr(Base64, ch);
+		if (pos == NULL)		/* A non-base64 character. */
+			return (-1);
+
+		switch (state) {
+		case 0:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex] = (pos - Base64) << 2;
+			}
+			state = 1;
+			break;
+		case 1:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex]   |=  (pos - Base64) >> 4;
+				nextbyte = ((pos - Base64) & 0x0f) << 4;
+				if ((size_t)tarindex + 1 < targsize)
+					target[tarindex + 1] = nextbyte;
+				else if (nextbyte)
+					return (-1);
+			}
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex]   |=  (pos - Base64) >> 2;
+				nextbyte = ((pos - Base64) & 0x03) << 6;
+				if ((size_t)tarindex + 1 < targsize)
+					target[tarindex + 1] = nextbyte;
+				else if (nextbyte)
+					return (-1);
+			}
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex] |= (pos - Base64);
+			}
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			abort();
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (!isspace((unsigned char)ch))
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (!isspace((unsigned char)ch))
+					return (-1);
+
+			/*
+			 * Now make sure for cases 2 and 3 that the "extra"
+			 * bits that slopped past the last full byte were
+			 * zeros.  If we don't check them, they become a
+			 * subliminal channel.
+			 */
+			if (target && (size_t)tarindex < targsize &&
+			    target[tarindex] != 0)
+				return (-1);
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}

--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -64,6 +64,7 @@
  * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
  */
 
+#include <sys/types.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 

--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -21,7 +21,7 @@
 
 #include <config.h>
 
-#ifndef HAVE_STRLCPY
+#ifndef HAVE_BASE64
 /*
  * Copyright (c) 1996, 1998 by Internet Software Consortium.
  *
@@ -338,4 +338,4 @@ b64_pton(const char *src, u_char *target, size_t targsize)
 
 	return (tarindex);
 }
-#endif /* HAVE_STRLCPY */
+#endif /* HAVE_BASE64 */

--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -22,6 +22,8 @@
 #include <config.h>
 
 #ifndef HAVE_BASE64
+/* https://raw.githubusercontent.com/freebsd/freebsd/f0171d33b464dee5ac308f1d13ede2ddd9d030a7/lib/libc/net/base64.c */
+
 /*
  * Copyright (c) 1996, 1998 by Internet Software Consortium.
  *

--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -1,4 +1,28 @@
 /*
+ * base64.c -- provides b64_ntop() and b64_pton() if necessary
+ */
+/*
+ * Copyright (C) 2010 - 2019 Eggheads Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <config.h>
+
+#ifndef HAVE_STRLCPY
+/*
  * Copyright (c) 1996, 1998 by Internet Software Consortium.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -314,3 +338,4 @@ b64_pton(const char *src, u_char *target, size_t targsize)
 
 	return (tarindex);
 }
+#endif /* HAVE_STRLCPY */

--- a/src/compat/base64.h
+++ b/src/compat/base64.h
@@ -1,9 +1,9 @@
 /*
- * compat.h
- *   wrap-around header for all compatibility functions.
+ * base64.h
+ *   prototypes for base64.c
  */
 /*
- * Copyright (C) 2000 - 2019 Eggheads Development Team
+ * Copyright (C) 2010 - 2019 Eggheads Development Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,15 +20,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#ifndef _EGG_COMPAT_COMPAT_H
-#define _EGG_COMPAT_COMPAT_H
+#ifndef _EGG_COMPAT_BASE64_H_
+#define _EGG_COMPAT_BASE64_H_
 
-#include "base64.h"
-#include "inet_aton.h"
-#include "snprintf.h"
-#include "inet_ntop.h"
-#include "inet_pton.h"
-#include "gethostbyname2.h"
-#include "strlcpy.h"
+#ifndef HAVE_BASE64
+int b64_ntop(u_char const *, size_t, char *, size_t);
+int b64_pton(const char *, u_char *, size_t);
+#endif /* HAVE_BASE64 */
 
-#endif /* !__EGG_COMPAT_COMPAT_H */
+#endif /* _EGG_COMPAT_BASE64_H_ */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
**Please run misc/runautotools and misc/makedepend after merge.**
The code in aclocal.m4 is from https://github.com/tmux/tmux/blob/master/configure.ac under ISC license.
The code in base64.c is from https://github.com/freebsd/freebsd/blob/master/lib/libc/net/base64.c which is from BIND 8.

Test cases demonstrating functionality (if applicable):
Tested with musl / openwrt which lacks base64 functions in libc/resolv.