### PR TITLE
Enhance memory management

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -37,7 +37,7 @@ extern Tcl_Interp *interp;
 
 tand_t *tandbot;                   /* Keep track of tandem bots on the botnet */
 party_t *party;                    /* Keep track of people on the botnet */
-static int party_size = 1;
+static int party_size = 0;
 int tands = 0;                     /* Number of bots on the botnet */
 int parties = 0;                   /* Number of people on the botnet */
 char botnetnick[HANDLEN + 1] = ""; /* Botnet nickname */
@@ -66,7 +66,6 @@ int expmem_botnet()
 void init_bots()
 {
   tandbot = NULL;
-  party = nmalloc(party_size * sizeof(party_t));
 }
 
 tand_t *findbot(char *who)
@@ -167,7 +166,11 @@ int addparty(char *bot, char *nick, int chan, char flag, int sock,
     }
   }
   /* New member */
-  if (parties == party_size) {
+  if (!party_size) {
+      party_size = 1;
+      party = nmalloc(party_size * sizeof(party_t));
+  }
+  else if (parties == party_size) {
     party_size <<= 1;
     party = nrealloc(party, party_size * sizeof(party_t));
     debug1("botnet: party size doubled to %i.", party_size);

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -49,11 +49,9 @@ int tls_vfybots = 0;               /* Verify SSL certificates from bots? */
 int expmem_botnet()
 {
   int size = 0, i;
-  tand_t *bot;
 
-  for (bot = tandbot; bot; bot = bot->next)
-    size += sizeof(tand_t);
-  size += (party_size * sizeof(party_t));
+  size = tands * sizeof(tand_t);
+  size += party_size * sizeof(party_t);
   for (i = 0; i < parties; i++) {
     if (party[i].away)
       size += strlen(party[i].away) + 1;

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -37,7 +37,7 @@ extern Tcl_Interp *interp;
 
 tand_t *tandbot;                   /* Keep track of tandem bots on the botnet */
 party_t *party;                    /* Keep track of people on the botnet */
-static int maxparty = 50;          /* Maximum space for party line members */
+static int party_size = 1;
 int tands = 0;                     /* Number of bots on the botnet */
 int parties = 0;                   /* Number of people on the botnet */
 char botnetnick[HANDLEN + 1] = ""; /* Botnet nickname */
@@ -53,7 +53,7 @@ int expmem_botnet()
 
   for (bot = tandbot; bot; bot = bot->next)
     size += sizeof(tand_t);
-  size += (maxparty * sizeof(party_t));
+  size += (party_size * sizeof(party_t));
   for (i = 0; i < parties; i++) {
     if (party[i].away)
       size += strlen(party[i].away) + 1;
@@ -66,9 +66,7 @@ int expmem_botnet()
 void init_bots()
 {
   tandbot = NULL;
-  /* Grab space for 50 bots for now -- expand later as needed */
-  maxparty = 50;
-  party = nmalloc(maxparty * sizeof(*party));
+  party = nmalloc(party_size * sizeof(party_t));
 }
 
 tand_t *findbot(char *who)
@@ -169,9 +167,10 @@ int addparty(char *bot, char *nick, int chan, char flag, int sock,
     }
   }
   /* New member */
-  if (parties == maxparty) {
-    maxparty += 50;
-    party = (party_t *) nrealloc((void *) party, maxparty * sizeof(party_t));
+  if (parties == party_size) {
+    party_size <<= 1;
+    party = nrealloc(party, party_size * sizeof(party_t));
+    debug1("botnet: party size doubled to %i.", party_size);
   }
   strncpy(party[parties].nick, nick, HANDLEN);
   party[parties].nick[HANDLEN] = 0;

--- a/src/mem.c
+++ b/src/mem.c
@@ -79,7 +79,7 @@ void init_mem()
   size_t size;
   int i;
 
-  size = sizeof(*memtbl) * memtbl_size;
+  size =  memtbl_size * sizeof(*memtbl);
   if (!(memtbl = malloc(size))) {
     putlog(LOG_MISC, "*", "*** FAILED MALLOC mem.c (memtbl) (%i): %s", size,
            strerror(errno));
@@ -353,7 +353,7 @@ void *n_malloc(int size, const char *file, int line)
       putlog(LOG_MISC, "*", "*** MEMORY TABLE FULL: %s (%d)", file, line);
       fatal("Memory table full", 0);
     }
-    size2 = sizeof(*memtbl) * memtbl_size;
+    size2 = memtbl_size * sizeof(*memtbl);
     if (!(memtbl = realloc(memtbl, size2))) {
       putlog(LOG_MISC, "*", "*** FAILED REALLOC mem.c (memtbl) (%i): %s", size2,
              strerror(errno));


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance memory management of botnet party array

Additional description (if needed):
botnet parties are stored in an array of party_t. eggdrop started with array size 50 (even for single/unlinked bots, this wastes 4K of memory) and if it gets full adds 50 more. With this patch, eggdrop will start with size 1 and if it gets full doubles size. This is a good algorithm we already use for memtbl. Additionally this patch also makes use of the known lengths of the tand bot list, so we dont need to iterate there.

Test cases demonstrating functionality (if applicable):
```
make debug
.console +d
```
Before:
```
.debug
[...]
File 'botnet.c  ' accounted for 5600/5600 (ok)
```
After:
```
.debug
[...]
File 'botnet.c  ' accounted for 0/0 (ok)
[...]
.link BotA
[...]
[00:00:09] Linked to BotA.
[...]
.debug
[...]
File 'botnet.c  ' accounted for 198/198 (ok)
[...]
[00:05:13] botnet: party size doubled to 2.
*** (BotB) michael has joined the party line.
[...]
.debug
[...]
File 'botnet.c  ' accounted for 327/327 (ok)
```