### PR TITLE
Fix tls.c memory leak

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -238,6 +238,7 @@ int ssl_init()
           putlog(LOG_MISC, "*", "ERROR: TLS: unable to set tmp dh %s: %s",
                  tls_dhparam, ERR_error_string(ERR_get_error(), NULL));
         }
+        DH_free(dh);
       }
       else {
         putlog(LOG_MISC, "*", "ERROR: TLS: unable to read DHparams %s: %s",


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix tls.c memory leak found with CC="clang -fsanitize=address".

Additional description (if needed):
```
==11562==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 144 byte(s) in 1 object(s) allocated from:
    #0 0x55599454103a in __interceptor_malloc (/home/michael/eggdrop/eggdrop-1.9.0+0x16103a)
    #1 0x7f4f27c2018f in CRYPTO_malloc /home/michael/usr/src/openssl-1.1.1c/crypto/mem.c:222:11
    #2 0x7f4f27c201c2 in CRYPTO_zalloc /home/michael/usr/src/openssl-1.1.1c/crypto/mem.c:230:17
    #3 0x7f4f27b7feea in DH_new_method /home/michael/usr/src/openssl-1.1.1c/crypto/dh/dh_lib.c:44:15
    #4 0x7f4f27b7feb7 in DH_new /home/michael/usr/src/openssl-1.1.1c/crypto/dh/dh_lib.c:39:12
    #5 0x7f4f27b7dff1 in dh_cb /home/michael/usr/src/openssl-1.1.1c/crypto/dh/dh_asn1.c:22:31
    #6 0x7f4f27b07ce6 in asn1_item_embed_new /home/michael/usr/src/openssl-1.1.1c/crypto/asn1/tasn_new.c:109:17
    #7 0x7f4f27b07a94 in ASN1_item_ex_new /home/michael/usr/src/openssl-1.1.1c/crypto/asn1/tasn_new.c:39:12
    #8 0x7f4f27b041c8 in asn1_item_embed_d2i /home/michael/usr/src/openssl-1.1.1c/crypto/asn1/tasn_dec.c:306:24
    #9 0x7f4f27b0393a in ASN1_item_ex_d2i /home/michael/usr/src/openssl-1.1.1c/crypto/asn1/tasn_dec.c:124:10
    #10 0x7f4f27b038ba in ASN1_item_d2i /home/michael/usr/src/openssl-1.1.1c/crypto/asn1/tasn_dec.c:114:9
    #11 0x7f4f27b7e06f in d2i_DHparams /home/michael/usr/src/openssl-1.1.1c/crypto/dh/dh_asn1.c:40:1
    #12 0x7f4f27c3c100 in PEM_read_bio_DHparams /home/michael/usr/src/openssl-1.1.1c/crypto/pem/pem_pkey.c:219:15
    #13 0x7f4f27c3c203 in PEM_read_DHparams /home/michael/usr/src/openssl-1.1.1c/crypto/pem/pem_pkey.c:239:11
    #14 0x555994675869 in ssl_init /home/michael/projects/eggdrop/src/tls.c:234:12
    #15 0x55599461521e in main /home/michael/projects/eggdrop/src/./main.c:1177:3
    #16 0x7f4f27898ee2 in __libc_start_main (/usr/lib/libc.so.6+0x26ee2)
```

Test cases demonstrating functionality (if applicable):