### PR TITLE
CAP: Fix unused variable

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1354,7 +1354,6 @@ void update_cap_negotiated() {
  * before adding to the desired list.
  */
 void add_cape(char *cape) {
-  int len = 0, i = 0;
   if (!strstr(cap.negotiated, cape)) {
     putlog(LOG_DEBUG, "*", "CAP: Adding cape %s to negotiated list", cape);
     Tcl_ListObjAppendElement(interp, ncapeslist, Tcl_NewStringObj(cape, -1));


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix unused variable

Additional description (if needed):
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././transfer.mod/transfer.c && mv -f transfer.o ../
In file included from .././server.mod/server.c:132:
.././server.mod/servmsg.c: In function ‘add_cape’:
.././server.mod/servmsg.c:1357:16: warning: unused variable ‘i’ [-Wunused-variable]
 1357 |   int len = 0, i = 0;
      |                ^
.././server.mod/servmsg.c:1357:7: warning: unused variable ‘len’ [-Wunused-variable]
 1357 |   int len = 0, i = 0;
      |       ^~~
```

Test cases demonstrating functionality (if applicable):
