### PR TITLE
Cleanup btos()

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -3004,7 +3004,7 @@ static void cmd_traffic(struct userrec *u, int idx, char *par)
 static char traffictxt[20];
 static char *btos(unsigned long bytes)
 {
-  char *unit;
+  const char *unit;
   float xbytes;
 
   xbytes = bytes;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -3004,25 +3004,24 @@ static void cmd_traffic(struct userrec *u, int idx, char *par)
 static char traffictxt[20];
 static char *btos(unsigned long bytes)
 {
-  char unit[10];
+  char *unit;
   float xbytes;
 
-  sprintf(unit, "Bytes");
   xbytes = bytes;
   if (xbytes > 1024.0) {
-    sprintf(unit, "KBytes");
+    unit = "KBytes";
     xbytes = xbytes / 1024.0;
   }
   if (xbytes > 1024.0) {
-    sprintf(unit, "MBytes");
+    unit = "MBytes";
     xbytes = xbytes / 1024.0;
   }
   if (xbytes > 1024.0) {
-    sprintf(unit, "GBytes");
+    unit = "GBytes";
     xbytes = xbytes / 1024.0;
   }
   if (xbytes > 1024.0) {
-    sprintf(unit, "TBytes");
+    unit = "TBytes";
     xbytes = xbytes / 1024.0;
   }
   if (bytes > 1024)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance / harden string handling by ripping out some sprintf() with array.

Additional description (if needed):
The function could be cleaned up much further, but my intention was not to waste too much time on it, but to enhance / harden string handling in general.

Test cases demonstrating functionality (if applicable):
Generate some traffic, then:
```
.traffic
[21:47:50] tcl: builtin dcc call: *dcc:traffic -HQ 1 
Traffic since last restart
==========================
IRC:
  out: 143 Bytes (143 Bytes today)
   in: 1.92 KBytes (1.92 KBytes today)
Partyline:
  out: 0 Bytes (0 Bytes today)
   in: 31 Bytes (31 Bytes today)
---
Total:
  out: 143 Bytes (143 Bytes today)
   in: 1.95 KBytes (1.95 KBytes today)
```