### PR TITLE
Performance/Cleanup/Enhancement

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -520,7 +520,13 @@ void putlog EGG_VARARGS_DEF(int, arg1)
   char *format, *chname, s[LOGLINELEN], s1[256], *out, ct[81], *s2, stamp[34];
   va_list va;
   time_t now2 = time(NULL);
-  struct tm *t = localtime(&now2);
+  static time_t now2_last = 0; /* cache expensive localtime() */
+  static struct tm *t;
+ 
+  if (now2 != now2_last) {
+    now2_last = now2;
+    t = localtime(&now2);
+  }
 
   type = EGG_VARARGS_START(int, arg1, va);
   chname = va_arg(va, char *);

--- a/src/tclhash.h
+++ b/src/tclhash.h
@@ -28,12 +28,10 @@
 
 typedef struct tcl_cmd_b {
   struct tcl_cmd_b *next;
-
   struct flag_record flags;
   char *func_name;              /* Proc name. */
-  /* FIXME: 'hits' could overflow if a bind is triggered enough. */
-  int hits;                     /* Number of times this proc was triggered. */
-  uint8_t attributes;          /* Flags for this entry. TC_* */
+  uint8_t attributes;           /* Flags for this entry. TC_* */
+  unsigned int hits;            /* Number of times this proc was triggered. */
 } tcl_cmd_t;
 
 struct threaddata {
@@ -49,10 +47,9 @@ struct threaddata {
 
 typedef struct tcl_bind_mask_b {
   struct tcl_bind_mask_b *next;
-
-  tcl_cmd_t *first;             /* List of commands registered for this bind. */
   char *mask;
-  uint8_t flags;               /* Flags for this entry. TBM_* */
+  uint8_t flags;                /* Flags for this entry. TBM_* */
+  tcl_cmd_t *first;             /* List of commands registered for this bind. */
 } tcl_bind_mask_t;
 
 
@@ -62,12 +59,11 @@ typedef struct tcl_bind_mask_b {
 
 typedef struct tcl_bind_list_b {
   struct tcl_bind_list_b *next;
-
-  tcl_bind_mask_t *first;       /* Pointer to registered binds for this list. */
   char name[5];                 /* Name of the bind. */
-  uint8_t flags;               /* Flags for this element. HT_* */
+  uint8_t flags;                /* Flags for this element. HT_* */
   IntFunc func;                 /* Function used as the Tcl calling interface
                                  * for procs actually representing C functions. */
+  tcl_bind_mask_t *first;       /* Pointer to registered binds for this list. */
 } tcl_bind_list_t, *p_tcl_bind_list;
 
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Performance enhancement: Cache expensive localtime() in putlog(), make tcl_cmd_b->hits unsigned int and cleanup tclhash structs.

Additional description (if needed):
Found with Valgrind

Test cases demonstrating functionality (if applicable):
```
$ CFLAGS="-g3" ./configure
[...]
$ valgrind --tool=callgrind ./eggdrop -nt BotA.conf
[...]
.jump 127.0.0.1 +6697
[...]
.die
[...]
$ kcachegrind callgrind.out.<pid>
```
Inclusive Cost (eggdrop) = 107.47
**Vorher:**
Inclusive Cost (localtime())= 0.32
Called (localtime()) = 196
**Nachher:**
Inclusive Cost (localtime()) = 0.02
Called (localtime()) = 13