### PR TITLE
Fix oversize

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -59,8 +59,8 @@ unsigned long timer_id = 1;        /* Next timer of any sort will
                                     * have this number             */
 struct chanset_t *chanset = NULL;  /* Channel list                 */
 char admin[121] = "";              /* Admin info                   */
-char origbotname[NICKLEN + 1];
-char botname[NICKLEN + 1];         /* Primary botname              */
+char origbotname[NICKLEN];
+char botname[NICKLEN];             /* Primary botname              */
 char owner[121] = "";              /* Permanent botowner(s)        */
 
 

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -53,7 +53,7 @@ static cmd_t ident_raw[] = {
 static void ident_activity(int idx, char *buf, int len)
 {
   int s;
-  char buf2[IDENT_SIZE + sizeof " : USERID : UNIX : \r\n" + NICKLEN + 1], *pos;
+  char buf2[IDENT_SIZE + sizeof " : USERID : UNIX : \r\n" + NICKLEN], *pos;
   ssize_t i;
 
   s = answer(dcc[idx].sock, &dcc[idx].sockname, 0, 0);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix oversize

Additional description (if needed):
NICKLEN is already NICKMAX + 1, see: https://github.com/eggheads/eggdrop/blob/develop/src/eggdrop.h#L78. So NICKLEN + 1 is oversized.

Test cases demonstrating functionality (if applicable):
