### PR TITLE
Add Server Name Indication (SNI) support

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -867,6 +867,15 @@ int ssl_handshake(int sock, int flags, int verify, int loglevel, char *host,
     SSL_set_verify(td->socklist[i].ssl, SSL_VERIFY_PEER, ssl_verify);
     /* Introduce 1ms lag so an unpatched hub has time to setup the ssl handshake */
     nanosleep(&req, NULL);
+#ifdef SSL_set_tlsext_host_name
+    if (!SSL_set_tlsext_host_name(td->socklist[i].ssl, data->host))
+       debug1("TLS: setting the server name indication (SNI) to %s failed", data->host);
+    else
+       debug1("TLS: setting the server name indication (SNI) to %s successful", data->host);
+#else
+    debug1("TLS: setting the server name indication (SNI) not supported by ssl "
+           "lib, probably < openssl 0.9.8f", data->host);
+#endif
     ret = SSL_connect(td->socklist[i].ssl);
     if (!ret)
       debug0("TLS: connect handshake failed.");


### PR DESCRIPTION
Found by: vanosg
Patch by: michaelortmann
Fixes: #140 

One-line summary:
Add Server Name Indication (SNI) support

Additional description (if needed):
https://ircv3.net/specs/core/sni-3.3.html

Test cases demonstrating functionality (if applicable):
```
$ openssl s_client -connect irc.darenet.org:6697 -tls1_3 -servername irc.darenet.org </dev/null 2>/dev/null | openssl x509 -fingerprint -sha256 -noout -in /dev/stdin
SHA256 Fingerprint=53:1C:BA:DD:51:77:36:B2:E0:35:BE:AC:2E:E5:27:1F:9A:98:3E:D4:1A:1B:92:40:31:FE:B1:9E:17:00:2B:AC
```
Before:
```
.jump irc.darenet.org +6697
[...]
[03:46:03] TLS: certificate subject: CN=explorer.darenet.org
[...]
[03:46:03] TLS: certificate SHA-256 Fingerprint: ED:F2:85:54:29:09:AD:DA:EF:CD:EF:16:DB:A1:40:9E:8E:6F:C2:10:8E:CA:03:3C:99:07:68:64:6A:37:D2:0A
```
After:
```
.jump irc.darenet.org +6697
[...]
[03:47:30] TLS: setting the server name indication (SNI) to irc.darenet.org successful
[...]
[03:47:30] TLS: certificate subject: CN=irc.darenet.org
[...]
[03:47:30] TLS: certificate SHA-256 Fingerprint: 53:1C:BA:DD:51:77:36:B2:E0:35:BE:AC:2E:E5:27:1F:9A:98:3E:D4:1A:1B:92:40:31:FE:B1:9E:17:00:2B:AC
```