### PR TITLE
Allow space in passwds

### DIFF
--- a/src/userent.c
+++ b/src/userent.c
@@ -252,7 +252,7 @@ int pass_set(struct userrec *u, struct user_entry *e, void *buf)
     if (strlen(pass) > 30)
       pass[30] = 0;
     while (*p) {
-      if ((*p <= 32) || (*p == 127))
+      if ((*p < 32) || (*p == 127))
         *p = '?';
       p++;
     }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Allow space in passwds

Additional description (if needed):
One more char means higher entropy means eggdrop passwds become slightly more secure by this tiny patch.

Test cases demonstrating functionality (if applicable):
