### PR TITLE
Fix --disable-ipv6, fix Dead increment and cleanup

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1536,15 +1536,18 @@ static void server_resolve_failure(int);
  */
 static void connect_server(void)
 {
-  char pass[121], botserver[UHOSTLEN], buf[16], s[1024];
+  char pass[121], botserver[UHOSTLEN], s[1024];
+#ifdef IPV6
+  char buf[sizeof(struct in6_addr)];
+#endif
   int servidx, len = 0;
   unsigned int botserverport = 0;
 
   lastpingcheck = 0;
   trying_server = now;
   empty_msgq();
-  if (newserverport) {          /* Jump to specified server */
-    curserv = -1;             /* Reset server list */
+  if (newserverport) { /* Jump to specified server */
+    curserv = -1;      /* Reset server list */
     strcpy(botserver, newserver);
     botserverport = newserverport;
     strcpy(pass, newserverpass);
@@ -1580,19 +1583,19 @@ static void connect_server(void)
 
 #ifdef IPV6
     if (inet_pton(AF_INET6, botserver, buf)) {
-      len += egg_snprintf(s, sizeof s, "%s [%s]", IRC_SERVERTRY, botserver);
+      egg_snprintf(s, sizeof s, "%s [%s]", IRC_SERVERTRY, botserver);
     } else {
 #endif
-     len += egg_snprintf(s, sizeof s, "%s %s", IRC_SERVERTRY, botserver);
+      egg_snprintf(s, sizeof s, "%s %s", IRC_SERVERTRY, botserver);
 #ifdef IPV6
     }
 #endif
 
 #ifdef TLS
-    len += egg_snprintf(s + len, sizeof s - len, ":%s%d",
-            use_ssl ? "+" : "", botserverport);
+    egg_snprintf(s + len, sizeof s - len, ":%s%d",
+                 use_ssl ? "+" : "", botserverport);
 #else
-    len += egg_snprintf(s + len, sizeof s - len, ":%d", botserverport);
+    egg_snprintf(s + len, sizeof s - len, ":%d", botserverport);
 #endif
     putlog(LOG_SERV, "*", "%s", s);
     dcc[servidx].port = botserverport;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
```
$ ./configure --disable-ipv6
[...]
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
In file included from .././server.mod/server.c:137:
.././server.mod/servmsg.c: In function ‘connect_server’:
.././server.mod/servmsg.c:1539:40: warning: unused variable ‘buf’ [-Wunused-variable]
 1539 |   char pass[121], botserver[UHOSTLEN], buf[16], s[1024];
      |                                        ^~~
In file included from .././server.mod/server.c:146:
.././server.mod/cmdsserv.c: In function ‘cmd_servers’:
.././server.mod/cmdsserv.c:32:8: warning: unused variable ‘buf’ [-Wunused-variable]
   32 |   char buf[16];
      |        ^~~
```

Test cases demonstrating functionality (if applicable):
