### PR TITLE
Fix memory table status report

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -79,7 +79,7 @@ void init_mem()
   size_t size;
   int i;
 
-  size =  memtbl_size * sizeof(*memtbl);
+  size =  memtbl_size * sizeof *memtbl;
   if (!(memtbl = malloc(size))) {
     putlog(LOG_MISC, "*", "*** FAILED MALLOC mem.c (memtbl) (%i): %s", size,
            strerror(errno));
@@ -120,7 +120,7 @@ void tell_mem_status_dcc(int idx)
     dprintf(idx, "Memory fault: only accounting for %d/%ld (%.1f%%)\n",
             exp, memused, per);
   dprintf(idx, "Memory table itself occupies an additional %dk static\n",
-          (int) (sizeof(memtbl) / 1024));
+          (int) memtbl_size * sizeof *memtbl / 1024);
 #endif
 }
 
@@ -353,7 +353,7 @@ void *n_malloc(int size, const char *file, int line)
       putlog(LOG_MISC, "*", "*** MEMORY TABLE FULL: %s (%d)", file, line);
       fatal("Memory table full", 0);
     }
-    size2 = memtbl_size * sizeof(*memtbl);
+    size2 = memtbl_size * sizeof *memtbl;
     if (!(memtbl = realloc(memtbl, size2))) {
       putlog(LOG_MISC, "*", "*** FAILED REALLOC mem.c (memtbl) (%i): %s", size2,
              strerror(errno));


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix memory table status report

Additional description (if needed):
Bug was my fault, introduced with #786, truly sorry.

Test cases demonstrating functionality (if applicable):
Before:
```
.status
Memory table: 3256/4096 (79.5% full)
Memory table itself occupies an additional 0k static
```
After:
```
.status
Memory table: 3256/4096 (79.5% full)
Memory table itself occupies an additional 160k static
```