### PR TITLE
Fix base64 fallback

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -501,6 +501,10 @@
 #endif
 /* 304 - 307 */
 #define strncpyz ((size_t (*) (char *, const char *, size_t))global[304])
+#ifndef HAVE_BASE64
+# define b64_ntop ((int (*) (u_char const *, size_t, char *, size_t))global[305])
+# define b64_pton ((int (*) (const char *, u_char *, size_t))global[306])
+#endif
 
 
 /* hostmasking */

--- a/src/modules.c
+++ b/src/modules.c
@@ -597,7 +597,14 @@ Function global_table[] = {
   (Function) 0,
 #endif
   /* 304 - 307 */
-  (Function) strncpyz
+  (Function) strncpyz,
+#ifndef HAVE_BASE64
+  (Function) b64_ntop,
+  (Function) b64_pton
+#else
+  (Function) 0,
+  (Function) 0
+#endif
 };
 
 void init_modules(void)


### PR DESCRIPTION
Found by: monkers
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Tested on Alpine Linux 3.10.2 / musl 1.1.22
Before:
`Can't load modules server: Error relocating /home/michael/eggdrop/modules/server.so: b64_ntop: symbol not found`
After:
`Module loaded: server`