### PR TITLE
Separate EOF and TIMEOUT on telnet ident connect

### DIFF
--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -423,8 +423,9 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0xe2c,Tcl fejl [%s]: %s
 0xe2d,*** ATTENTION: DEAD SOCKET (%d) OF TYPE %s UNTRAPPED
 0xe2e,Mistede forbindelsen under identing [%s/%d]
-0xe2f,Timeout/EOF ident forbindelse
+0xe2f,EOF ident forbindelse
 0xe30,Mistede ident wait telnet socket!!
 0xe31,Afviste telnet: %s, Ingen Adgang
 0xe32,Afviste telnet forbindelse fra %s (forsøg på at bruge mit botnetnick)
 0xe33,Mistede telnet forbindelse fra %s mens der blev tjekket for dubletter
+0xe34,TIMEOUT ident forbindelse

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -423,8 +423,9 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0xe2c,Tcl error [%s]: %s
 0xe2d,*** ATTENTION: DEAD SOCKET (%d) OF TYPE %s UNTRAPPED
 0xe2e,Lost connection while identing [%s/%d]
-0xe2f,Timeout/EOF ident connection
+0xe2f,EOF ident connection
 0xe30,Lost ident wait telnet socket!!
 0xe31,Denied telnet: %s, No Access
 0xe32,Refused telnet connection from %s (tried using my botnetnick)
 0xe33,Lost telnet connection from %s while checking for duplicate
+0xe34,TIMEOUT ident connection

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -423,8 +423,9 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0xe2c,Tcl virhe [%s]: %s
 0xe2d,*** HUOMIO: KUOLLUT SOCKET (%d) TYYPISSÄ %s EI VANGITTU
 0xe2e,Kadotetaan yhteys silläaikaa kun identitettiin [%s/%d]
-0xe2f,Kadotettu/EOF ident yhteys
+0xe2f,EOF ident yhteys
 0xe30,Kadotettu ident odotus telnet socketti!!
 0xe31,Evätty telnet: %s, Ei pääsyä
 0xe32,Evätään telnet yhteys %s (yritä käyttää minun botnetnickkiäni)
 0xe33,Telnet yhteys hukattu %s silläaikaa kun tarkistettiin tuplausta
+0xe34,Kadotettu ident yhteys

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -424,8 +424,9 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe2c,Erreur tcl [%s]: %s
 0xe2d,*** ATTENTION: DEAD SOCKET (%d) OF TYPE %s UNTRAPPED
 0xe2e,Connexion perdue pendant l'ident [%s/%d]
-0xe2f,Timeout/EOF ident connection
+0xe2f,EOF ident connection
 0xe30,Lost ident wait telnet socket!!
 0xe31,Telnet refusé: %s, aucun accès
 0xe32,Refus de la connexion telnet de %s (essai avec mon surnom botnet)
 0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
+0xe34,Timeout ident connection

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -432,8 +432,9 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe2c,Tcl-Fehler [%s]: %s
 0xe2d,*** VORSICHT: TOD EINES SOCKETS (%d), TYP %s WURDE NICHT ABGEFANGEN
 0xe2e,Telnet-Verbindung waehrend des Ident-Vorgangs verloren [%s/%d]
-0xe2f,Zeitueberschreitung/EOF bei der Ident-Verbindung
+0xe2f,EOF bei der Ident-Verbindung
 0xe30,Ident-Socket beim Wartern auf die Antwort verloren!!
 0xe31,Telnet verweigert: %s, Kein Zugriff
 0xe32,Telnet-Verbindung von %s zurueckgewiesen (versuchte, meinen botnetnick zu benutzen)
 0xe33,Telnet-Verbindung von %s waerend Kontrolle auf Duplikat verloren
+0xe34,Zeitueberschreitung bei der Ident-Verbindung

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -423,8 +423,9 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe2c,Erro de Tcl [%s]: %s
 0xe2d,*** ATENÇÃO: SOCKET INOPERANTE (%d) DO TIPO %s NÃO DESENVOLVIDA
 0xe2e,Perdida ligação aquando identificação [%s/%d]
-0xe2f,Timeout/EOF em ligação de identificação
+0xe2f,EOF em ligação de identificação
 0xe30,Perdida identificação aguardando por socket telnet!!
 0xe31,Telnet negada: %s, Sem acesso
 0xe32,Recusada ligação telnet de %s (tentou usar o meu nick de botnet)
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
+0xe34,Timeout em ligação de identificação

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2328,7 +2328,7 @@ void dcc_ident(int idx, char *buf, int len)
   lostdcc(idx);
 }
 
-void eof_dcc_ident(int idx)
+void eof_timeout_dcc_ident(int idx, const char *s)
 {
   char buf[UHOSTLEN];
   int i;
@@ -2336,13 +2336,23 @@ void eof_dcc_ident(int idx)
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_IDENTWAIT) &&
         (dcc[i].sock == dcc[idx].u.ident_sock)) {
-      putlog(LOG_MISC, "*", DCC_EOFIDENT);
+      putlog(LOG_MISC, "*", s);
       simple_sprintf(buf, "telnet@%s", dcc[idx].host);
       dcc_telnet_got_ident(i, buf);
     }
   killsock(dcc[idx].sock);
   dcc[idx].u.other = 0;
   lostdcc(idx);
+}
+
+void eof_dcc_ident(int idx)
+{
+  eof_timeout_dcc_ident(idx, DCC_EOFIDENT);
+}
+
+void timeout_dcc_ident(int idx)
+{
+  eof_timeout_dcc_ident(idx, DCC_TIMEOUTIDENT);
 }
 
 static void display_dcc_ident(int idx, char *buf)
@@ -2356,7 +2366,7 @@ struct dcc_table DCC_IDENT = {
   eof_dcc_ident,
   dcc_ident,
   &identtimeout,
-  eof_dcc_ident,
+  timeout_dcc_ident,
   display_dcc_ident,
   NULL,
   NULL,

--- a/src/lang.h
+++ b/src/lang.h
@@ -488,5 +488,6 @@
 #define DCC_NOACCESS            get_language(0xe31)
 #define DCC_MYBOTNETNICK        get_language(0xe32)
 #define DCC_LOSTDUP             get_language(0xe33)
+#define DCC_TIMEOUTIDENT        get_language(0xe34)
 
 #endif /* _EGG_LANG_H */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Separate EOF and TIMEOUT on telnet ident connect

Additional description (if needed):
May help with debugging things like #880

Test cases demonstrating functionality (if applicable):
**Case EOF:**
[01:47:21] EOF ident connection
**Case TIMEOUT:**
_not tested yet, can someone else test this for me?_