### PR TITLE
Expose language as a global Tcl variable

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -2699,6 +2699,13 @@ configureargs
 
   Module: core
 
+^^^^^^^^
+language
+^^^^^^^^
+  Value: a string containing the language with the highest priority for use by Eggdrop. This commonly reflects what is added with addlang in the config file
+
+  Module: core
+
 Binds
 -----
 

--- a/src/language.c
+++ b/src/language.c
@@ -65,7 +65,6 @@
 
 extern struct dcc_t *dcc;
 
-
 typedef struct lang_st {
   struct lang_st *next;
   char *lang;
@@ -98,6 +97,7 @@ static char *get_specific_langfile(char *, lang_sec *);
 static char *get_langfile(lang_sec *);
 static int split_lang(char *, char **, char **);
 int cmd_loadlanguage(struct userrec *, int, char *);
+char language[64];
 
 
 /* Add a new preferred language to the list of languages. Newly added
@@ -665,6 +665,7 @@ static int tcl_plslang STDVAR
 {
   BADARGS(2, 2, " language");
 
+  strlcpy(language, argv[1], sizeof language);
   add_lang(argv[1]);
   recheck_lang_sections();
 

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -47,7 +47,7 @@ extern char origbotname[], botuser[], motdfile[], admin[], userfile[],
             firewall[], helpdir[], notify_new[], vhost[], moddir[], owner[],
             network[], botnetnick[], bannerfile[], egg_version[], natip[],
             configfile[], logfile_suffix[], log_ts[], textdir[], pid_file[],
-            listen_ip[], stealth_prompt[];
+            listen_ip[], stealth_prompt[], language[];
 
 
 extern int flood_telnet_thr, flood_telnet_time, shtime, share_greet,
@@ -399,6 +399,7 @@ static tcl_strings def_tcl_strings[] = {
   {"pidfile",         pid_file,       120,           STR_PROTECT},
   {"configureargs",   EGG_AC_ARGS,    0,             STR_PROTECT},
   {"stealth-prompt",  stealth_prompt, 80,                      0},
+  {"language",        language,       64,            STR_PROTECT},
   {NULL,              NULL,           0,                       0}
 };
 


### PR DESCRIPTION
Found by: CrazyCat
Patch by: Geo 
Fixes: 

One-line summary:
```
.tcl putlog $language
[19:03:58] english
```

Exposes the highest-priority language added to Eggdrop