### PR TITLE
Fix tiny filesys bug

### DIFF
--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -531,17 +531,14 @@ static void cmd_get(int idx, char *par)
 
 static void cmd_file_help(int idx, char *par)
 {
-  char *s;
+  char s[256];
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
   get_user_flagrec(dcc[idx].user, &fr, dcc[idx].u.file->chat->con_chan);
   if (par[0]) {
     putlog(LOG_FILES, "*", "files: #%s# help %s", dcc[idx].nick, par);
-    s = nmalloc(strlen(par) + 9);
-    sprintf(s, "filesys/%s", par);
-    s[256] = 0;
+    snprintf(s, sizeof s, "filesys/%s", par);
     tellhelp(idx, s, &fr, 0);
-    my_free(s);
   } else {
     putlog(LOG_FILES, "*", "files: #%s# help", dcc[idx].nick);
     tellhelp(idx, "filesys/help", &fr, 0);

--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -531,14 +531,18 @@ static void cmd_get(int idx, char *par)
 
 static void cmd_file_help(int idx, char *par)
 {
-  char s[256];
+  int l;
+  char *s;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
   get_user_flagrec(dcc[idx].user, &fr, dcc[idx].u.file->chat->con_chan);
   if (par[0]) {
     putlog(LOG_FILES, "*", "files: #%s# help %s", dcc[idx].nick, par);
-    snprintf(s, sizeof s, "filesys/%s", par);
+    l = snprintf(NULL, 0, "filesys/%s", par);
+    s = nmalloc(l + 1);
+    sprintf(s, "filesys/%s", par);
     tellhelp(idx, s, &fr, 0);
+    my_free(s);
   } else {
     putlog(LOG_FILES, "*", "files: #%s# help", dcc[idx].nick);
     tellhelp(idx, "filesys/help", &fr, 0);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix tiny filesys bug

Additional description (if needed):
See also: https://github.com/eggheads/eggdrop/commit/ed3a0485e641c57f6f4ec8365235b6fbad4fb103#diff-f6d970b843b7d594745fbbeabf54dc71L448 where a buffer was changed from static len 1024 to nmalloc()ed len but `s[256] = 0` left in place. After reading https://github.com/eggheads/eggdrop/commit/ed3a0485e641c57f6f4ec8365235b6fbad4fb103#diff-f36d07cbe5f8b52e90f8c04ba0ec7af6 IRC discussion resulted in `s[256]=0` was probably left in place by mistake.

Test cases demonstrating functionality (if applicable):
**No real world test was done yet, pls someone step in here**