### PR TITLE
Fix --disable-ipv6

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1536,7 +1536,10 @@ static void server_resolve_failure(int);
  */
 static void connect_server(void)
 {
-  char pass[121], botserver[UHOSTLEN], buf[16], s[1024];
+  char pass[121], botserver[UHOSTLEN], s[1024];
+#ifdef IPV6
+  char buf[sizeof(struct in6_addr)];
+#endif
   int servidx, len = 0;
   unsigned int botserverport = 0;
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix --disable-ipv6

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
./configure --disable-ipv6
[...]
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
In file included from .././server.mod/server.c:137:
.././server.mod/servmsg.c: In function ‘connect_server’:
.././server.mod/servmsg.c:1539:40: warning: unused variable ‘buf’ [-Wunused-variable]
 1539 |   char pass[121], botserver[UHOSTLEN], buf[16], s[1024];
      |                                        ^~~
```