### PR TITLE
Handle IRCv3 invite-notify, add invite bind

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -3290,11 +3290,11 @@ The following is a list of bind types and how they work. Below each bind type is
 
 (51) INVT (stackable)
 
-  bind invt <flags> <mask> <prov>
+  bind invt <flags> <mask> <proc>
 
-  procname <nick> <user@host> <invitee> <channel>
+  procname <nick> <user@host> <channel> <invitee>
 
-  Description: triggered when eggdrop received an INVITE message. nick is the nickname of the person sending the invite request, user@host is the user@host of the person sending the invite, invitee is the target of the invite, channel is the channel the invitee is being invited to. The invitee argument was added to support the IRCv3 invite-notify capability, where the eggdrop may be able to see invite messages for other people that are not the eggdrop.
+  Description: triggered when eggdrop received an INVITE message. The mask for the bind is in the format "#channel nickname", where nickname (not a hostmask) is that of the invitee. For the proc, nick is the nickname of the person sending the invite request, user@host is the user@host of the person sending the invite, channel is the channel the invitee is being invited to, and invitee is the target (nickname only) of the invite. The invitee argument was added to support the IRCv3 invite-notify capability, where the eggdrop may be able to see invite messages for other people that are not the eggdrop.
 
 ^^^^^^^^^^^^^
 Return Values

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -3288,6 +3288,14 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Module: core
 
+(51) INVT (stackable)
+
+  bind invt <flags> <mask> <prov>
+
+  procname <nick> <user@host> <invitee> <channel>
+
+  Description: triggered when eggdrop received an INVITE message. nick is the nickname of the person sending the invite request, user@host is the user@host of the person sending the invite, invitee is the target of the invite, channel is the channel the invitee is being invited to. The invitee argument was added to support the IRCv3 invite-notify capability, where the eggdrop may be able to see invite messages for other people that are not the eggdrop.
+
 ^^^^^^^^^^^^^
 Return Values
 ^^^^^^^^^^^^^

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -30,7 +30,6 @@ static int count_ctcp = 0;
 static time_t last_invtime = (time_t) 0L;
 static char last_invchan[CHANNELLEN + 1] = "";
 
-
 /* ID length for !channels.
  */
 #define CHANNEL_ID_LEN 5
@@ -1520,12 +1519,12 @@ static int gotinvite(char *from, char *msg)
   invitee = newsplit(&msg);
   fixcolon(msg);
   nick = splitnick(&from);
-  check_tcl_invite(nick, from, invitee, msg);
+  check_tcl_invite(nick, from, msg, invitee);
 /* Because who needs RFCs? Freakin IRCv3... */
   if (!match_my_nick(invitee)) {
     putlog(LOG_DEBUG, "*", "Received invite notifiation for %s to %s by %s.",
             invitee, msg, nick);
-  return 1;
+    return 1;
   }
   if (!rfc_casecmp(last_invchan, msg))
     if (now - last_invtime < 30)

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -30,6 +30,7 @@ static int count_ctcp = 0;
 static time_t last_invtime = (time_t) 0L;
 static char last_invchan[CHANNELLEN + 1] = "";
 
+
 /* ID length for !channels.
  */
 #define CHANNEL_ID_LEN 5
@@ -1507,16 +1508,25 @@ static int got475(char *from, char *msg)
   return 0;
 }
 
-/* got invitation
+/* got invitation. Updated 2019 to handle IRCv3 invite-notify capability
+ * where invites seen may not be for you, so we have to check the target and
+ * and ignore if it is not for us.
  */
 static int gotinvite(char *from, char *msg)
 {
-  char *nick, *key;
+  char *nick, *key, *invitee;
   struct chanset_t *chan;
 
-  newsplit(&msg);
+  invitee = newsplit(&msg);
   fixcolon(msg);
   nick = splitnick(&from);
+  check_tcl_invite(nick, from, invitee, msg);
+/* Because who needs RFCs? Freakin IRCv3... */
+  if (!match_my_nick(invitee)) {
+    putlog(LOG_DEBUG, "*", "Received invite notifiation for %s to %s by %s.",
+            invitee, msg, nick);
+  return 1;
+  }
   if (!rfc_casecmp(last_invchan, msg))
     if (now - last_invtime < 30)
       return 0; /* Two invites to the same channel in 30 seconds? */

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -750,7 +750,7 @@ static int invite_4char STDVAR
 {
   Function F = (Function) cd;
 
-  BADARGS(5, 5, " nick uhost invitee channel");
+  BADARGS(5, 5, " nick uhost channel invitee");
 
   CHECKVALIDITY(invite_4char);
   F(argv[1], argv[2], argv[3], argv[4]);
@@ -852,13 +852,16 @@ static void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
                  MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
 }
 
-static void check_tcl_invite(char *nick, char *from, char *invitee, char *chan)
+static void check_tcl_invite(char *nick, char *from, char *chan, char *invitee)
 {
+  char args[512];
+
   Tcl_SetVar(interp, "_invite1", nick, 0);
   Tcl_SetVar(interp, "_invite2", from, 0);
-  Tcl_SetVar(interp, "_invite3", invitee, 0);
-  Tcl_SetVar(interp, "_invite4", chan, 0);
-  check_tcl_bind(H_invt, from, 0, " $_invite1 $_invite2 $_invite3 $_invite4",
+  Tcl_SetVar(interp, "_invite3", chan, 0);
+  Tcl_SetVar(interp, "_invite4", invitee, 0);
+  simple_sprintf(args, "%s %s", chan, invitee);
+  check_tcl_bind(H_invt, args, 0, " $_invite1 $_invite2 $_invite3 $_invite4",
                     MATCH_MASK | BIND_STACKABLE);
 }
 

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -32,7 +32,7 @@
 #include <sys/utsname.h>
 
 static p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
-static p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need;
+static p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt;
 
 static Function *global = NULL, *channels_funcs = NULL, *server_funcs = NULL;
 
@@ -746,6 +746,18 @@ static int channels_2char STDVAR
   return TCL_OK;
 }
 
+static int invite_4char STDVAR
+{
+  Function F = (Function) cd;
+
+  BADARGS(5, 5, " nick uhost invitee channel");
+
+  CHECKVALIDITY(invite_4char);
+  F(argv[1], argv[2], argv[3], argv[4]);
+  return TCL_OK;
+}
+
+
 static void check_tcl_joinspltrejn(char *nick, char *uhost, struct userrec *u,
                                    char *chname, p_tcl_bind_list table)
 {
@@ -838,6 +850,16 @@ static void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
   check_tcl_bind(H_kick, args, &fr,
                  " $_kick1 $_kick2 $_kick3 $_kick4 $_kick5 $_kick6",
                  MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
+}
+
+static void check_tcl_invite(char *nick, char *from, char *invitee, char *chan)
+{
+  Tcl_SetVar(interp, "_invite1", nick, 0);
+  Tcl_SetVar(interp, "_invite2", from, 0);
+  Tcl_SetVar(interp, "_invite3", invitee, 0);
+  Tcl_SetVar(interp, "_invite4", chan, 0);
+  check_tcl_bind(H_invt, from, 0, " $_invite1 $_invite2 $_invite3 $_invite4",
+                    MATCH_MASK | BIND_STACKABLE);
 }
 
 static int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
@@ -1133,6 +1155,7 @@ static char *irc_close()
   del_bind_table(H_nick);
   del_bind_table(H_mode);
   del_bind_table(H_kick);
+  del_bind_table(H_invt);
   del_bind_table(H_join);
   del_bind_table(H_pubm);
   del_bind_table(H_pub);
@@ -1193,7 +1216,8 @@ static Function irc_table[] = {
   (Function) me_voice,
   /* 24 - 27 */
   (Function) getchanmode,
-  (Function) reset_chan_info
+  (Function) reset_chan_info,
+  (Function) & H_invt           /* p_tcl_bind_list              */
 };
 
 char *irc_start(Function *global_funcs)
@@ -1253,6 +1277,7 @@ char *irc_start(Function *global_funcs)
   H_nick = add_bind_table("nick", HT_STACKABLE, channels_5char);
   H_mode = add_bind_table("mode", HT_STACKABLE, channels_6char);
   H_kick = add_bind_table("kick", HT_STACKABLE, channels_6char);
+  H_invt = add_bind_table("invt", HT_STACKABLE, invite_4char);
   H_join = add_bind_table("join", HT_STACKABLE, channels_4char);
   H_pubm = add_bind_table("pubm", HT_STACKABLE, channels_5char);
   H_pub = add_bind_table("pub", 0, channels_5char);

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -36,6 +36,7 @@
 #ifdef MAKING_IRC
 static void check_tcl_need(char *, char *);
 static void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);
+static void check_tcl_invite(char *, char *, char *, char *);
 static void check_tcl_mode(char *, char *, struct userrec *, char *, char *, char *);
 static void check_tcl_joinspltrejn(char *, char *, struct userrec *, char *,
                                    p_tcl_bind_list);


### PR DESCRIPTION
Patch by: Geo

One-line summary:
Add an invite bind

Additional description (if needed):
Fix invite handling to handle IRCv3 invite-notify, where an INVITE you see may not actually be for you. Proc takes 4 args- nick, uhost, invitee, channel.


Test cases demonstrating functionality (if applicable):

Setup:
```
.tcl proc inv {nick user invitee chan} {putlog "nick $nick user $user invitee $invitee chan $chan"}
.tcl bind invt * * inv
.binds
Command bindings:
  TYPE FLAGS    COMMAND              HITS BINDING (TCL)
  invt -|-      *                       0 inv
```
Invite bot directly:
```
[03:37:58] [@] foobert!case@irc-e9idnb.a4df.hp2m.eaceia.IP INVITE TestEgg :#foober
[03:37:58] nick foobert user case@irc-e9idnb.a4df.hp2m.eaceia.IP invitee TestEgg chan #foober
[03:37:58] foobert!case@irc-e9idnb.a4df.hp2m.eaceia.IP invited me to #foober
```
With invite-notify negotiated, invite a different user to a channel bot is on:
```
[03:38:19] [@] foobert!case@irc-e9idnb.a4df.hp2m.eaceia.IP INVITE ChanServ :#foober
[03:38:19] nick foobert user case@irc-e9idnb.a4df.hp2m.eaceia.IP invitee ChanServ chan #foober
[03:38:19] Received invite notifiation for ChanServ to #foober by foobert.
```