### PR TITLE
Do not set TCL_TRACE_READS for Tcl_TraceVar(net-type)

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2071,7 +2071,7 @@ static char *server_close()
                  TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                  traced_serveraddress, NULL);
   Tcl_UntraceVar(interp, "net-type",
-                 TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
+                 TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                  traced_nettype, NULL);
   Tcl_UntraceVar(interp, "nick-len",
                  TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
@@ -2244,7 +2244,7 @@ char *server_start(Function *global_funcs)
                TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                traced_serveraddress, NULL);
   Tcl_TraceVar(interp, "net-type",
-               TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
+               TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                traced_nettype, NULL);
   Tcl_TraceVar(interp, "nick-len",
                TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
traced_nettype() is unnecessarily called for TCL_TRACE_READS

Additional description (if needed):
This looks like one example of unnecessary calles to (or processings within) trace-Functions. The other cases will be tracked and fixed with #854.

Test cases demonstrating functionality (if applicable):
Before (Function is called many times):
```
$ ./eggdrop -nt BotA.conf
[...]
Module loaded: server          
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
Module loaded: ctcp
[...]
use '.help userinfo' for commands.
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
Module loaded: ident
```
After (Function is called one time only):
```
Module loaded: server          
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
Module loaded: ctcp
```