### PR TITLE
Request CAP features during registration

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -503,47 +503,6 @@ set ssl-capath "/etc/ssl/"
 #set ssl-verify-clients 0
 
 
-##### SASL #####
-
-# SASL is a method that allows Eggdrop to authenticate with a NickServ service
-# as part of the connection process to a server, eliminating the need to later
-# authenticate via a /msg command. Not all servers support SASL, please consult
-# with your server admins to confirm this capability exists on your server.
-
-# To request SASL authentication, set this to 1
-#set sasl 0
-
-# Set SASL mechanism to authenticate with.
-# For the ECDSA-NIST256P method, set the certificate location in the ecdsa-key
-# setting below. For the EXTERNAL method, the ssl certificates to use are set
-# via the ssl-certificate and ssl-privatekey settings in the SSL section above.
-# Options are:
-#   0 = PLAIN 
-#   1 = ECDSA-NIST256P-CHALLENGE
-#   2 = EXTERNAL 
-#set sasl-mechanism 0
-
-# Set username to authenticate to IRC NickServ with
-#set sasl-username "llamabot"
-
-# Set password to authenticate to IRC NickServ with
-#set sasl-password "password"
-
-# Specify the location of certificate to use for the SASL
-# ecdsa-nist256p-challenge. An ECDSA certificate can be generated with the
-# command:
-#   openssl ecparam -genkey -name prime256v1 -out eggdrop-ecdsa.pem
-#set sasl-ecdsa-key "/home/user/eggdrop/eggdrop-ecdsa.pem"
-
-# Set SASL failure action
-# If SASL authentication fails, do you want to connect to the server anyway?
-# Set to this to 0 to disconnect and retry until success, or 1 to continue
-# connecting to the server without SASL authentication.
-#set sasl-continue 1
-#
-# Timeout (in seconds) before giving up SASL authentication
-#set sasl-timeout 15
-
 ##### MORE ADVANCED SETTINGS #####
 
 # Set this to your socks host if your Eggdrop sits behind a firewall. If
@@ -1103,6 +1062,70 @@ addserver you.need.to.change.this 6667
 addserver another.example.com 6669 password
 addserver 2001:db8:618:5c0:263:: 6669 password
 addserver ssl.example.net +7000
+
+#### CAP Features ####
+# This section controls IRCv3 capabilities supported natively by Eggdrop. You
+# can enable individual settings here to be requested as part of the
+# registration process with the IRC server. Not all servers support all CAP
+# features. https://ircv3.net/support/networks.html maintains a list of some
+# popular servers, and you can also use '.tcl cap available' from the partyline
+# to list capabilities available on that server.
+
+# SASL is a method that allows Eggdrop to authenticate with a NickServ service
+# as part of the connection process to a server, eliminating the need to later
+# authenticate via a /msg command.
+#
+# To request SASL authentication via CAP, set this to 1
+#set sasl 0
+
+# Set SASL mechanism to authenticate with.
+# For the ECDSA-NIST256P method, set the certificate location in the ecdsa-key
+# setting below. For the EXTERNAL method, the ssl certificates to use are set
+# via the ssl-certificate and ssl-privatekey settings in the SSL section above.
+# Options are:
+#   0 = PLAIN
+#   1 = ECDSA-NIST256P-CHALLENGE
+#   2 = EXTERNAL
+#set sasl-mechanism 0
+
+# Set username to authenticate to IRC NickServ with
+#set sasl-username "llamabot"
+
+# Set password to authenticate to IRC NickServ with
+#set sasl-password "password"
+
+# Specify the location of certificate to use for the SASL
+# ecdsa-nist256p-challenge. An ECDSA certificate can be generated with the
+# command:
+#   openssl ecparam -genkey -name prime256v1 -out eggdrop-ecdsa.pem
+#set sasl-ecdsa-key "/home/user/eggdrop/eggdrop-ecdsa.pem"
+
+# Set SASL failure action
+# If SASL authentication fails, do you want to connect to the server anyway?
+# Set to this to 0 to disconnect and retry until success, or 1 to continue
+# connecting to the server without SASL authentication.
+#set sasl-continue 1
+#
+# Timeout (in seconds) before giving up SASL authentication
+#set sasl-timeout 15
+
+# To request the account-notify feature via CAP, set this to 1
+#set account-notify 0
+
+# To request the invite-notify feature via CAP, set this to 1
+#set invite-notify 0
+
+# To request the message-tags feature via CAP, set this to 1. NOTE: Enabling
+# this feature may interfere with RAW binds in scripts.
+#set message-tags 0
+
+# If you have any additional CAP features you would like to request at
+# registration but are not listed above, set them here as space separated
+# strings. Setting features here does not guarantee Eggdrop's ability to support
+# these them.
+#set cap-request "feature1 feature2 feature3"
+
+#### End of CAP features ####
 
 # Number of seconds to wait between transmitting queued lines to the server.
 # Lower this value at your own risk.  ircd is known to start flood control

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -126,7 +126,11 @@ static int del_server(const char *, const char *);
 static void free_server(struct server_list *);
 
 static int sasl = 0;
+static int away_notify = 0;
+static int invite_notify = 0;
+static int message_tags = 0;
 
+static char cap_request[CAPMAX - 9];
 static int sasl_mechanism = 0;
 static char sasl_username[NICKMAX + 1];
 static char sasl_password[81];
@@ -1567,6 +1571,7 @@ static tcl_strings my_tcl_strings[] = {
   {"connect-server",      connectserver,  120,               0},
   {"stackable-commands",  stackablecmds,  510,               0},
   {"stackable2-commands", stackable2cmds, 510,               0},
+  {"cap-request",         cap_request,    CAPMAX - 9,        0},
   {"sasl-username",       sasl_username,  NICKMAX,           0},
   {"sasl-password",       sasl_password,  80,                0},
   {"sasl-ecdsa-key",      sasl_ecdsa_key, 120,               0},
@@ -1613,6 +1618,9 @@ static tcl_ints my_tcl_ints[] = {
   {"sasl-mechanism",    &sasl_mechanism,            0},
   {"sasl-continue",     &sasl_continue,             0},
   {"sasl-timeout",      &sasl_timeout,              0},
+  {"away-notify",       &away_notify,               0},
+  {"invite-notify",     &invite_notify,             0},
+  {"message-tags",      &message_tags,              0},
   {NULL,                NULL,                       0}
 };
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1402,6 +1402,7 @@ void add_req(char *cape) {
 
 static int gotcap(char *from, char *msg) {
   char *cmd, *splitstr;
+  char *cape, *p;
   int listlen = 0;
 
   newsplit(&msg);
@@ -1411,15 +1412,28 @@ static int gotcap(char *from, char *msg) {
   if (!strcmp(cmd, "LS")) {
     putlog(LOG_DEBUG, "*", "CAP: %s supports CAP sub-commands: %s", from, msg);
     strlcpy(cap.supported, msg, sizeof cap.supported);
+/* CAP is supported, yay! Lets load what we want to request */
     if (sasl) {
-      /* TODO: is this the right place to check for error in eggdrop conf setting ?
-       * (with error i mean, bot would crash, if the config setting is not validated) */
       if (sasl_mechanism < 0)
         putlog(LOG_SERV, "*", "SASL error: sasl-mechanism must be equal to or greater than 0");
       else if (sasl_mechanism >= SASL_MECHANISM_NUM)
         putlog(LOG_SERV, "*", "SASL error: sasl-mechanism must be less than %i", SASL_MECHANISM_NUM);
       else
         add_req("sasl");
+    }
+    if (away_notify)
+      add_req("away-notify");
+    if (invite_notify)
+      add_req("invite-notify");
+    if (message_tags)
+      add_req("message-tags");
+/* Add any custom capes the user listed */
+    cape = cap_request;
+    if ( (p = strtok(cape, " ")) ) {
+      while (p != NULL) {
+        add_req(p);
+        p = strtok(NULL, " ");
+      }
     }
     if (strlen(cap.desired) > 0) {
       putlog(LOG_DEBUG, "*", "CAP: Requesting %s capabilities from server", cap.desired);


### PR DESCRIPTION
Patch by: Geo

One-line summary:
Request CAP features during registration

Reconfigure eggdrop.conf to state/handle each available CAP command, and request those commands during server registration.