### PR TITLE
Small french typos

### DIFF
--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -4,109 +4,109 @@
 
 # General stuff
 0x001,Utilisation
-0x002,A Ã©chouÃ©.\n
+0x002,A échoué.\n
 
 # MODES_
-0x130,CrÃ©Ã©
-0x131,utilisÃ© derniÃ¨rement
+0x130,Créé
+0x131,utilisé dernièrement
 0x132,inactif
-0x133,placÃ© par
+0x133,placé par
 0x135,non actif sur
 0x137,non actif
-0x138,non placÃ© par le bot
+0x138,non placé par le bot
 
 # BANS_
 0x104,Bans globaux
-0x106,Bans spÃ©cifiques au canal
-0x109,Utilisez '.bans all' pour voir la liste complÃ¨te
+0x106,Bans spécifiques au canal
+0x109,Utilisez '.bans all' pour voir la liste complète
 0x10a,Annulation du ban
 
 # EXEMPTS_
 0x114,Exceptions globales
-0x116,Exceptions spÃ©cifiques au canal
-0x119,Utilisez '.exempts all' pour voir la liste complÃ¨te
+0x116,Exceptions spécifiques au canal
+0x119,Utilisez '.exempts all' pour voir la liste complète
 0x11a,Annulation de l'exception
 
 # INVITES_
 0x124,Invitations globales
-0x126,Invitations spÃ©cifiques au canal
-0x129,Utilisez '.invites all' pour voir la liste complÃ¨te
+0x126,Invitations spécifiques au canal
+0x129,Utilisez '.invites all' pour voir la liste complète
 0x12a,Annulation de l'invitation
 
 # MOD_
-0x200,DÃ©jÃ  chargÃ©.
-0x201,Ne peut pas dÃ©terminer le rÃ©pertoire courant.
-0x202,Aucune fonction de dÃ©marrage dÃ©finie.
+0x200,Déjà chargé.
+0x201,Ne peut pas déterminer le répertoire courant.
+0x202,Aucune fonction de démarrage définie.
 0x204,Requis par un autre module
 0x205,Aucune fonction de fermeture
-0x206,Module dÃ©chargÃ©:
+0x206,Module déchargé:
 0x207,Aucun module de ce nom
 0x209,Erreur pendant le chargement du module:
-0x20a,Erreur pendant le dÃ©chargement du module:
+0x20a,Erreur pendant le déchargement du module:
 0x20b,Ne peut pas charger les modules
-0x20c,Modules stagnant; il va y avoir perte de mÃ©moire!
-0x20d,Vous avez installÃ© des modules, mais n'avez pas choisi de module de cryptage,\n\
+0x20c,Modules stagnant; il va y avoir perte de mémoire!
+0x20d,Vous avez installé des modules, mais n'avez pas choisi de module de cryptage,\n\
 consultez le ficher de configuration initiale pour plus de renseignements.\n
-0x20e,Module Filesys non chargÃ©.
-0x20f,Module chargÃ©: %s \t\t(avec support internationnal)
-0x210,Module chargÃ©: %s
+0x20e,Module Filesys non chargé.
+0x20f,Module chargé: %s \t\t(avec support internationnal)
+0x210,Module chargé: %s
 
 # USERF_
-0x400,Transfert de la liste utilisateurs terminÃ©; liste prise en compte
+0x400,Transfert de la liste utilisateurs terminé; liste prise en compte
 0x402,NE PEUT PAS LIRE LA NOUVELLE LISTE UTILISATEURS
 0x403,Ne peut vous envoyer la liste utilisateurs (erreur interne)
-0x404,Personne ne correspond Ã  ces critÃ¨res
+0x404,Personne ne correspond à ces critères
 0x405,Ancienne liste utilisateurs, utilisez 'tclsh scripts/weed <fichier-usagers> c' pour la convertir
 0x406,Format de liste utilisateurs invalide.
 0x407,Enregistrement utilisateur corrompu
 0x408,Enregistrement utilisateur en double
 0x409,Mot de passe corrompu pour:
-0x40a,Ban(s) ignorÃ©(s) pour le(s) canal(aux):
+0x40a,Ban(s) ignoré(s) pour le(s) canal(aux):
 0x40b,Ecriture de la liste utilisateurs...
-0x40c,ERREUR pendant l'Ã©criture de la liste utilisateurs.
-0x40d,ERREUR pendant l'Ã©criture de la liste utilisateurs Ã  transfÃ©rer.
-0x40e,CrÃ©ation de la liste utilisateurs inutile--ignorÃ©e
+0x40c,ERREUR pendant l'écriture de la liste utilisateurs.
+0x40d,ERREUR pendant l'écriture de la liste utilisateurs à transférer.
+0x40e,Création de la liste utilisateurs inutile--ignorée
 0x40f,Relecture de la configuration...
 0x410,Je ne connais personne de ce nom.\n
 0x411,Aucun enregistrement pour cet utilisateur.
 0x412,Sauvegarde de la liste utilisateurs...
 0x413,Echec de la connexion; interruption du transfert de la liste utilisateurs.
 0x414,Demande de partage (ancienne version) par
-0x415,Demande de partage dÃ©suÃ¨te
-0x416,Liste utilisateurs rejetÃ©e par
+0x415,Demande de partage désuète
+0x416,Liste utilisateurs rejetée par
 
 # MISC_
-0x500,a expirÃ©
+0x500,a expiré
 0x501,au total
-0x502,SupprimÃ©
+0x502,Supprimé
 0x504,sur
 0x505,Recherche
 0x506,je laisse tomber d'abord
-0x507,(plus de %d rÃ©sultats; liste tronquÃ©e)\n
-0x508,--- TrouvÃ© %d rÃ©sultat%s.\n
-0x509,Commande ambiguÃ«.\n
+0x507,(plus de %d résultats; liste tronquée)\n
+0x508,--- Trouvé %d résultat%s.\n
+0x509,Commande ambiguë.\n
 0x50a,Quoi? Essayez '.help'\n
 0x50b,Liaisons de commande:\n
-0x50c,RedÃ©marrage...
+0x50c,Redémarrage...
 0x50d,s
 0x50e,Rotation des fichiers de log...
 0x512,inactif
 0x513,ABSENT
-0x516,DÃ©connectÃ©
+0x516,Déconnecté
 0x517,bot non valide
-0x518,Boucle dÃ©tectÃ©e: dÃ©connection
+0x518,Boucle détectée: déconnection
 0x51a,de
-0x51b,pÃ©rimÃ©
-0x51c,rejetÃ©
+0x51b,périmé
+0x51c,rejeté
 0x51d,imposteur
 0x51e,j'essaie
 0x51f,Fichier MOTD:
 0x520,Aucun fichier MOTD.
 0x521,Utilisez:
-0x522,<addresse> <numÃ©ro de port>[/<numÃ©ro de port-relais>]
+0x522,<addresse> <numéro de port>[/<numéro de port-relais>]
 0x526,en suspens
 0x527,je ne suis pas op
-0x529,arriÃ¨re plan
+0x529,arrière plan
 0x52a,mode terminal
 0x52b,mode statut
 0x52c,mode log
@@ -117,100 +117,100 @@ consultez le ficher de configuration initiale pour plus de renseignements.\n
 0x531,annonce
 0x532,Proprietaire(s) permanent(s)
 0x534,FICHIER DE CONFIGURATION NON CHARGE (INTROUVABLE OU ERREUR)
-0x535,LISTE UTILISATEURS NON TROUVEE!  (essayez './eggdrop -m %s' pour en crÃ©er une)\n
+0x535,LISTE UTILISATEURS NON TROUVEE!  (essayez './eggdrop -m %s' pour en créer une)\n
 0x536,DEMARRAGE DU BOT EN MODE CREATION DE LISTE UTILISATEURS.\n\
 Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x537,OU allez sur IRC et:  /msg %s hello\n
-0x538,Le bot vous reconnaitra alors comme maÃ®tre.
+0x538,Le bot vous reconnaitra alors comme maître.
 0x539,LA LISTE UTILISATEURS EXISTE DEJA (enlevez le '-m')
-# 0x53a - unused / inutilisÃ©
+# 0x53a - unused / inutilisé
 0x53b,Ne peut pas recharger la liste utilisateurs!
 0x53c,La liste utilisateurs est inexistante!
 0x53e,%B  (%E)\n\nEntrez votre surnom.\n
-0x53f,Rotation du fichier log %s, taille maximale depassÃ©e (%d)
-# 0x540 - unused / inutilisÃ©
-0x541,Dernier message repÃ©tÃ© %d fois.\n
-0x542,bloquÃ©
+0x53f,Rotation du fichier log %s, taille maximale depassée (%d)
+# 0x540 - unused / inutilisé
+0x541,Dernier message repété %d fois.\n
+0x542,bloqué
 0x543,Pas de socket libre disponible.
 0x544,Tcl version:
 0x545,header version
 
 # IRC_
 0x600,Banni
-0x601,Vous Ãªtes banni
-0x602,Tentative de Ban sur moi-mÃªme--Ã©vitÃ©e.
-0x603,c'Ã©tait drÃ´le, refaites-le encore une fois!
+0x601,Vous êtes banni
+0x602,Tentative de Ban sur moi-même--évitée.
+0x603,c'était drôle, refaites-le encore une fois!
 0x604,Salut
 0x605,Au revoir
-0x606,Vous Ãªtes banni, goober.
-0x607,NOTICE %s :Ton nick Ã©tait trop long, j'ai du le changer Ã  '%s'.\n
-0x608,PrÃ©sentÃ© Ã 
+0x606,Vous êtes banni, goober.
+0x607,NOTICE %s :Ton nick était trop long, j'ai du le changer à '%s'.\n
+0x608,Présenté à
 0x609,site public
 0x60a,NOTICE %s :Salut %s!  Je suis %s, un bot eggdrop.\n
-0x60b,NOTICE %s :Je vais vous reconnaÃ®tre par votre hostmask '%s' Ã  partir de maintenant.\n
-0x60c,Etant donnÃ© que vous venez d'un site IRC public, vous devriez
+0x60b,NOTICE %s :Je vais vous reconnaître par votre hostmask '%s' à partir de maintenant.\n
+0x60c,Etant donné que vous venez d'un site IRC public, vous devriez
 0x60d,toujours utiliser ce surnom quand vous me parlez.
 0x60e,VOUS ETES MAINTENANT LE PROPRIETAIRE DE CE BOT
-0x60f,Installation du bot terminÃ©e, le premier maÃ®tre est %s
+0x60f,Installation du bot terminée, le premier maître est %s
 0x610,Bienvenue sur Eggdrop! =]
-0x611,prÃ©sentÃ© Ã  %s de %s
-0x612,Vous avez un mot de passe de dÃ©fini.
-0x613,Vous n'avez pas de mot de passe de dÃ©fini.
-0x615,Vous avez dÃ©jÃ  un mot de passe de dÃ©fini.
-0x616,Employez au moins 6 caractÃ¨res.
-0x617,Mot de passe dÃ©fini:
+0x611,présenté à %s de %s
+0x612,Vous avez un mot de passe de défini.
+0x613,Vous n'avez pas de mot de passe de défini.
+0x615,Vous avez déjà un mot de passe de défini.
+0x616,Employez au moins 6 caractères.
+0x617,Mot de passe défini:
 0x618,Mot de passe incorrect.
 0x619,Nouveau mot de passe:
-0x61a,Vous Ãªtes sur un site public; vous n'avez pas accÃ¨s Ã  IDENT.
-0x61b,NOTICE %s :Vous n'Ãªtes pas %s, vous Ãªtes %s.\n
-0x61c,AccÃ¨s refusÃ©.
-0x61d,Je vous reconnais lÃ .
-0x61e,Hostmask ajoutÃ©
+0x61a,Vous êtes sur un site public; vous n'avez pas accès à IDENT.
+0x61b,NOTICE %s :Vous n'êtes pas %s, vous êtes %s.\n
+0x61c,Accès refusé.
+0x61d,Je vous reconnais là.
+0x61e,Hostmask ajouté
 0x620,Actuellement:
 0x621,Maintenant:
 0x622,Pour l'enlever:
-0x624,Votre ligne de renseignements est verrouillÃ©e
+0x624,Votre ligne de renseignements est verrouillée
 0x625,Retrait de votre ligne de renseignements sur
 0x626,Retrait de votre ligne de renseignements.
 0x627,Vous n'avez aucun renseignements sur
 0x628,Vous n'avez aucun renseignements.
-0x629,Je ne contrÃ´le pas ce canal.
-0x62a,RÃ©initialisation des renseignements du canal.
+0x629,Je ne contrôle pas ce canal.
+0x62a,Réinitialisation des renseignements du canal.
 0x62b,Changement de serveur...
-0x62c,Le canal est actuellement cachÃ©.
+0x62c,Le canal est actuellement caché.
 0x62d,Maintenant sur le canal
 0x62e,N'est jamais venu sur l'un de mes canaux.
-0x62f,Vu la derniÃ¨re fois Ã 
-0x630,Vous n'Ãªtes pas enregistrÃ© ; prÃ©sentez vous d'abord.
+0x62f,Vu la dernière fois à
+0x630,Vous n'êtes pas enregistré ; présentez vous d'abord.
 0x631,Aucune aide.
-0x632,Aucune aide disponible lÃ -dessus.
+0x632,Aucune aide disponible là-dessus.
 # 0x633 - unused
 0x634,Pas sur ce canal en ce moment.
-0x635,Je rÃ©cupÃ¨re mon surnom (%s)
+0x635,Je récupère mon surnom (%s)
 0x636,Le serveur me dit que mon surnom est invalide.
 0x637,SURNOM EN UTILISATION: Essai de '%s'
 0x638,Ne peut pas changer de surnom sur %s.  Mon surnom est-il interdit?
-0x639,Surnom bloquÃ©
-0x63a,Le canal %s est bloquÃ©. :(
-0x63b,%s dit que je ne suis pas enregistrÃ©, essai du suivant.
+0x639,Surnom bloqué
+0x63a,Le canal %s est bloqué. :(
+0x63b,%s dit que je ne suis pas enregistré, essai du suivant.
 0x63c,Vous avez un serveur incorrect.
 0x63d,Flood de @%s!  Placement en ignorance!
 0x63f,Flood de JOIN de @%s!  Interdiction.
 0x640,Flood de canal de %s -- je le kick
 0x641,Essai du serveur
-0x642,La requÃªte DNS a Ã©chouÃ©
-0x643,Echec de la connexion Ã 
-0x644,Le serveur ne rÃ©pond plus; changement...
-0x645,DÃ©connectÃ© de
+0x642,La requête DNS a échoué
+0x643,Echec de la connexion à
+0x644,Le serveur ne répond plus; changement...
+0x645,Déconnecté de
 0x646,Aucun serveur actuellement.
-0x647,La file d'attente des modes est Ã 
-0x648,La file d'attente des serveurs est Ã 
-0x649,La file d'attente d'aide est Ã 
-0x64a,Le vhost qui est configurÃ© dans le fichier de configuration n'est pas capable de connecter Ã  l'addresse du serveur
-0x64b,Le vhost qui est configurÃ© dans le fichier de configuration n'est pas disponsible sur cette machine
+0x647,La file d'attente des modes est à
+0x648,La file d'attente des serveurs est à
+0x649,La file d'attente d'aide est à
+0x64a,Le vhost qui est configuré dans le fichier de configuration n'est pas capable de connecter à l'addresse du serveur
+0x64b,Le vhost qui est configuré dans le fichier de configuration n'est pas disponsible sur cette machine
 0x64c,Traitement du canal
 0x64d,Canal
-0x64e,Je dÃ©sire le canal
+0x64e,Je désire le canal
 0x64f,Sujet du canal
 0x650,+o en suspens -- Je lag
 0x651,-o en suspens -- Je lag
@@ -218,167 +218,167 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x653,FAUX OPERATEUR DONNE PAR LE SERVEUR
 0x654,Fin de renseigements du canal.
 0x655,Kick massif, va t'asseoir dans un coin
-0x656,Ban annulÃ©
+0x656,Ban annulé
 0x657,Hmm, info sur les modes d'un canal sur lequel je ne suis pas
-0x658,...et merci d'avoir jouÃ©.
+0x658,...et merci d'avoir joué.
 0x659,Changement de serveur (j'ai besoin de %d serveurs, je n'en ai que %d)
 0x65a,changement de serveur
 0x65b,Je suis sur trop de canaux--ne peut rejoindre: %s
 0x65c,Le canal est plein--ne peut rejoindre: %s
-0x65d,Le canal est rÃ©servÃ© aux invitÃ©s--ne peut rejoindre: %s
+0x65d,Le canal est réservé aux invités--ne peut rejoindre: %s
 0x65e,Banni sur le canal--ne peut rejoindre: %s
 0x65f,Le serveur dit que je ne suis pas sur le canal: %s
-0x660,Mauvaise clÃ©--ne peut rejoindre: %s
-0x661,NOTICE %s :Toutes les commandes sont accessibles par /MSG. Pour la liste complÃ¨te, /MSG %s help   Cya!\n
-0x662,NOTICE %s :Je ne vous reconnais pas de cet hÃ´te.\n
+0x660,Mauvaise clé--ne peut rejoindre: %s
+0x661,NOTICE %s :Toutes les commandes sont accessibles par /MSG. Pour la liste complète, /MSG %s help   Cya!\n
+0x662,NOTICE %s :Je ne vous reconnais pas de cet hôte.\n
 0x663,NOTICE %s :Soit vous utilisez le nick de quelqu'un d'autre, soit vous devez taper: /MSG %s IDENT (mot de passe)\n
-0x664,NOTICE %s :En tant que maÃ®tre, vous devez vraiment dÃ©finir un mot de passe: avec /MSG %s pass <le-mot-de-passe-que-vous-avez-choisi>.\n
-0x665,NOTICE %s :La majoritÃ© des commandes est accessible en DCC chat. DorÃ©navant, vous n'avez plus besoin de l'option -m quand vous dÃ©marrez le bot. Amusez-vous bien !!\n
-0x666,Ceci est l'interface telnet de %s, un bot eggdrop.\nN'en abusez pas, et elle sera ouverte Ã©galement Ã  tous vos amis.\n
-0x667,Maintenant vous devez trouver un nick Ã  utiliser sur le bot,\net un mot de passe, ainsi personne ne peut prÃ©tendre Ãªtre vous.\nRetenez les!
-0x668,DorÃ©navant, vous n'avez plus besoin d'utiliser l'option -m pour dÃ©marrer le bot.\nAmusez-vous bien !!
+0x664,NOTICE %s :En tant que maître, vous devez vraiment définir un mot de passe: avec /MSG %s pass <le-mot-de-passe-que-vous-avez-choisi>.\n
+0x665,NOTICE %s :La majorité des commandes est accessible en DCC chat. Dorénavant, vous n'avez plus besoin de l'option -m quand vous démarrez le bot. Amusez-vous bien !!\n
+0x666,Ceci est l'interface telnet de %s, un bot eggdrop.\nN'en abusez pas, et elle sera ouverte également à tous vos amis.\n
+0x667,Maintenant vous devez trouver un nick à utiliser sur le bot,\net un mot de passe, ainsi personne ne peut prétendre être vous.\nRetenez les!
+0x668,Dorénavant, vous n'avez plus besoin d'utiliser l'option -m pour démarrer le bot.\nAmusez-vous bien !!
 0x669,Flood de connexions telnet de %s!  On ignore!
 0x66a,Banni:
 0x66b,avalanche de surnom
-0x66c,touches pas Ã  mon pote
+0x66c,touches pas à mon pote
 0x66d,...pas la peine de revenir.
 0x66e,Retour au surnom alternatif %s
 0x66f,ne deope pas mes amis !
-0x670,Exception enlevÃ©e
-0x671,Invitation enlevÃ©e
+0x670,Exception enlevée
+0x671,Invitation enlevée
 0x672,Flood de SURNOM de @%s! Banni.
 0x673,flood de surnoms
 
 # EGG_
-#0x700 - unused / inutilisÃ©
-0x701,Je dÃ©tecte que %s est s'exÃ©cute dÃ©jÃ  depuis ce rÃ©pertoire.\n
+#0x700 - unused / inutilisé
+0x701,Je détecte que %s est s'exécute déjà depuis ce répertoire.\n
 0x702,Si ce n'est pas le cas, supprimez '%s'\n
-0x703,* Attention! Impossible d'Ã©crire le fichier %s!\n
+0x703,* Attention! Impossible d'écrire le fichier %s!\n
 
 # USER_
 0x800,  (est un op global)
 0x801,  (est un bot)
-0x802,  (est un maÃ®tre)
+0x802,  (est un maître)
 
 # CHAN_
-0x900,Aucun canal de ce nom dÃ©fini
+0x900,Aucun canal de ce nom défini
 0x902,* Changement de mode sur %s pour le non-existant %s!
 0x903,Deop en masse sur %s par %s
 0x904,Deop en masse.  Va t'asseoir dans un coin.
 0x907,Oops. Quelqu'un m'a fait rejoindre %s... j'en pars...
 0x908,Changement de mode par un faux op sur %s!  Annulation...
-0x909,Abus d'un op mal gagnÃ© par serveur
+0x909,Abus d'un op mal gagné par serveur
 0x90a,Changement de mode par un non-op sur %s!  Annulation...
-0x90b,Abus d'une dÃ©synchronisation
+0x90b,Abus d'une désynchronisation
 0x90c,flood
 
-0xa00,Aucun ignorÃ©
+0xa00,Aucun ignoré
 0xa01,Actuellement, j'ignore
 0xa02,Je n'ignore plus
 
-0xb00,Ce bot n'est pas lÃ .\n
-0xb01,C'est un bot.  Vous ne pouvez laisser de notes Ã  un bot.\n
+0xb00,Ce bot n'est pas là.\n
+0xb01,C'est un bot.  Vous ne pouvez laisser de notes à un bot.\n
 0xb02,est absent
-0xb07,Une note est arrivÃ©e pour vous
-0xb08,Message stockÃ©
-0xb18,L'arrÃªt du bot commence....
+0xb07,Une note est arrivée pour vous
+0xb08,Message stocké
+0xb18,L'arrêt du bot commence....
 0xb19,Aucun utilisateur de ce nom
 0xb1a,Aucuns canaux
 0xb1b,Membres de la party line:
-0xb1c,Bots connectÃ©s
+0xb1c,Bots connectés
 0xb1d,Autres personnes sur le bot
-0xb1f,Tentative de liaison Ã 
-0xb20,Non en ligne; note enregistrÃ©e.
-0xb21,La boite Ã  messages est pleine, dÃ©solÃ©.
-0xb22,est absent; note stockÃ©e.
-0xb23,Note envoyÃ©e Ã 
-0xb24,DÃ©connectÃ© de:
+0xb1f,Tentative de liaison à
+0xb20,Non en ligne; note enregistrée.
+0xb21,La boite à messages est pleine, désolé.
+0xb22,est absent; note stockée.
+0xb23,Note envoyée à
+0xb24,Déconnecté de:
 0xb25,Personnes sur le canal
-0xb26,Ne peut me relier lÃ 
-0xb27,Ne peux me dÃ©lier
-0xb28,Boucle dÃ©tectÃ©e
+0xb26,Ne peut me relier là
+0xb27,Ne peux me délier
+0xb28,Boucle détectée
 0xb29,Annonce de lien incorrect de
-0xb2b,Reste deconnectÃ©
-0xb2c,LiÃ© Ã 
-0xb2d,Lien illÃ©gal par un leaf
-0xb2e,Vous Ãªtes supposÃ©s Ãªtre un leaf!
-0xb2f,Bot rejetÃ©
-0xb30,Vieux bot dÃ©tectÃ© (non-supportÃ©)
-0xb31,RÃ©sultat de trace
+0xb2b,Reste deconnecté
+0xb2c,Lié à
+0xb2d,Lien illégal par un leaf
+0xb2e,Vous êtes supposés être un leaf!
+0xb2f,Bot rejeté
+0xb30,Vieux bot détecté (non-supporté)
+0xb31,Résultat de trace
 0xb32,n'existe pas
-0xb33,Les boots distants ne sont pas autorisÃ©s.
-0xb34,Je ne peux virer le propriÃ©taire du bot.
+0xb33,Les boots distants ne sont pas autorisés.
+0xb34,Je ne peux virer le propriétaire du bot.
 0xb35,TRANSFERT DE FICHIER REJETE
-0xb37,Utilisateurs Ã  travers le botnet
+0xb37,Utilisateurs à travers le botnet
 0xb38,Party line
 0xb39,Canal local
 0xb3a,Utilisateurs du canal
-0xb3b,Aucun bot reliÃ©.
+0xb3b,Aucun bot relié.
 0xb3c,Aucunes informations de trace:
 0xb3d,L'arborescence est trop complexe!
-0xb3e,DÃ©connexion de tous les bots...
-0xb3f,Tentative de terminer le lien Ã 
+0xb3e,Déconnexion de tous les bots...
+0xb3f,Tentative de terminer le lien à
 0xb40,Plus aucun essai de lien avec:
-0xb41,DÃ©nouage du lien avec
-0xb42,DÃ©liÃ© de:
-0xb43,Non connectÃ© Ã  ce bot.
+0xb41,Dénouage du lien avec
+0xb42,Délié de:
+0xb43,Non connecté à ce bot.
 0xb44,Vidange de la table des bots et des assocs...
 0xb45,n'est pas un bot connu.
-0xb46,Me relier Ã  moi mÃªme?  Heh mon garcon, un grand jour pour Freud.
-0xb47,Ce bot est dÃ©ja connectÃ©.
-0xb48,Adresse de port telnet invalide:port enregistrÃ© pour
+0xb46,Me relier à moi même?  Heh mon garcon, un grand jour pour Freud.
+0xb47,Ce bot est déja connecté.
+0xb48,Adresse de port telnet invalide:port enregistré pour
 0xb49,Liaison avec
-0xb4a,Ne peut trouver d'utilisateur Ã  relayer!
+0xb4a,Ne peut trouver d'utilisateur à relayer!
 0xb4b,Liaison impossible avec
-0xb4c,Faire un relais sur moi-mÃªme?  Quel est l'intÃ©rÃªt?!
-0xb4d,Connexion Ã 
+0xb4c,Faire un relais sur moi-même?  Quel est l'intérêt?!
+0xb4d,Connexion à
 0xb4e,(Tapez *BYE* seul sur une ligne pour abandonner.)
-0xb4f,Abandon de la tentative de relais Ã 
-0xb50,Vous Ãªtes maintenant de retour sur
-0xb51,Relais abandonnÃ©:
+0xb4f,Abandon de la tentative de relais à
+0xb50,Vous êtes maintenant de retour sur
+0xb51,Relais abandonné:
 0xb53,Perte de la connexion DCC avec
-0xb54,Abandon de la tentative de relais Ã 
-0xb55,SuccÃ¨s!\n\nMAINTENANT CONNECTE AU BOT RELAIS
-0xb56,(Vous pouvez taper *BYE* pour fermer la connexion prÃ©maturÃ©ment.)
+0xb54,Abandon de la tentative de relais à
+0xb55,Succès!\n\nMAINTENANT CONNECTE AU BOT RELAIS
+0xb56,(Vous pouvez taper *BYE* pour fermer la connexion prématurément.)
 0xb57,Liaison relais:
-0xb58,a quittÃ© la party line.
-0xb59,Liaison relais terminÃ©e
-0xb5a,ABANDON DE LA CONNEXION RELAIS.\nVous Ãªtes de retour sur
+0xb58,a quitté la party line.
+0xb59,Liaison relais terminée
+0xb5a,ABANDON DE LA CONNEXION RELAIS.\nVous êtes de retour sur
 0xb5b,a rejoint la party line.
-0xb5c,Abandon de la liaison de relais Ã 
-0xb5d,ArrÃªt de la connexion Ã 
-0xb5e,Relais cassÃ©
+0xb5c,Abandon de la liaison de relais à
+0xb5d,Arrêt de la connexion à
+0xb5e,Relais cassé
 0xb5f,Ping timeout
-0xb60,celÃ  ne ressemble pas Ã  un comportement de leaf
+0xb60,celà ne ressemble pas à un comportement de leaf
 0xb61,Abandon du bot
-0xb62,Connection en cours Ã  ce bot.
+0xb62,Connection en cours à ce bot.
 
-0xc00,Je n'accepte pas les DCC chats des Ã©trangers.
-0xc01,DCC chat refusÃ© (aucun accÃ¨s)
-0xc02,Aucun accÃ¨s
-0xc03,Vous devez avoir dÃ©fini un mot de passe.
-0xc04,DCC chat refusÃ© (pas de mot de passe)
-0xc05,DCC chat refusÃ© (+x mais pas de systÃ¨me de fichiers)
-0xc07,Trop de personnes sont dans le systÃ¨me de fichier pour l'instant.
-0xc0c,DÃ©solÃ©, trop de connexions DCC.
+0xc00,Je n'accepte pas les DCC chats des étrangers.
+0xc01,DCC chat refusé (aucun accès)
+0xc02,Aucun accès
+0xc03,Vous devez avoir défini un mot de passe.
+0xc04,DCC chat refusé (pas de mot de passe)
+0xc05,DCC chat refusé (+x mais pas de système de fichiers)
+0xc07,Trop de personnes sont dans le système de fichier pour l'instant.
+0xc0c,Désolé, trop de connexions DCC.
 0xc0d,Connexions DCC pleines: %s %s (%s!%s)
 0xc19,Echec de la connexion
 0xc1a,Echec de la connexion DCC
 0xc1c,Entrez votre mot de passe.
-0xc1d,%s a Ã©tÃ© enlevÃ© de force pour flood.\n
+0xc1d,%s a été enlevé de force pour flood.\n
 0xc1e,-=- poof -=-\n
-0xc1f,Vous avez Ã©tÃ© virÃ© de %s par %s%s%s\n
-0xc20,%s virÃ© %s de la party line%s%s
-0xc21,DCC chat refusÃ© (port invalide)
+0xc1f,Vous avez été viré de %s par %s%s%s\n
+0xc20,%s viré %s de la party line%s%s
+0xc21,DCC chat refusé (port invalide)
 0xc22,DCC port invalide
 
 0xd00,Pas d'interaction avec IRC.
 
 # BOTNET
-0xe00,Faux message rejetÃ©
-0xe01,LiÃ© Ã 
+0xe00,Faux message rejeté
+0xe01,Lié à
 0xe02,Mauvais bot--je voulais %s, et j'ai eu %s
-0xe03,a quittÃ© la
+0xe03,a quitté la
 0xe04,a rejoint la
 0xe05,est maintenant absent
 0xe06,n'est plus absent
@@ -386,36 +386,36 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 
 # dcc.c Messages
 0xe08,Rejet de la liaison de %s
-0xe09,ReliÃ© Ã  %s.
+0xe09,Relié à %s.
 0xe0a,Echec lors de la liaison avec %s.
-0xe0b,Mauvais mot de passe lors de la tentative de connexion Ã  %s.
-0xe0c,Mot de passe requis pour se connecter Ã  %s.
+0xe0b,Mauvais mot de passe lors de la tentative de connexion à %s.
+0xe0c,Mot de passe requis pour se connecter à %s.
 0xe0d,ERREUR lors de la liaison avec %s: %s
 0xe0e,Bot perdu: %s
-0xe0f,Timeout: liaison au bot %s Ã  %s:%d
-0xe10,connectÃ©: %s (%s/%d)
+0xe0f,Timeout: liaison au bot %s à %s:%d
+0xe10,connecté: %s (%s/%d)
 0xe11,Mot de passe incorrect: [%s]%s/%d
-0xe12,NÃ©gatif, Houston.\n
+0xe12,Négatif, Houston.\n
 0xe13,*** %s a rejoint la party line.\n
 0xe14,Connexion DCC perdue avec %s (%s/%d)
 0xe15,Mot de passe timeout lors du dcc chat: [%s]%s
-0xe16,Connexion DCC fermÃ©e (%s!%s)
+0xe16,Connexion DCC fermée (%s!%s)
 0xe17,Echec de la tentative de TELNET en cours (%s)
 0xe18,Refus %s/%d (mauvais port source)
 0xe19,*** %s est de retour.\n 
 0xe1a,Refus %s (mauvais hostname)
 0xe1b,Connexion telnet: %s/%d
 0xe1c,Echec de l'ident pour %s: %s
-0xe1d,(!) Port d'Ã©coute %d est brusquement mort.
+0xe1d,(!) Port d'écoute %d est brusquement mort.
 0xe1e,Refus %s (mauvais surnom)
 0xe1f,Refus %s (ce n'est pas un bot)
 0xe20,Refus %s (ce n'est pas un utilisateur)
 0xe21,Refus %s (invalide handle: %s)
-0xe22,Connexion telnet refusÃ©e depuis %s (doublon)
+0xe22,Connexion telnet refusée depuis %s (doublon)
 0xe23,Refus [%s]%s (aucun mot de passe)
 0xe24,Connexion telnet perdue vers %s/%d
 0xe25,Ident timeout lors du telnet: %s
-0xe26,Installation du bot complÃ¨te, le premier maÃ®tre est %s
+0xe26,Installation du bot complète, le premier maître est %s
 0xe27,Nouvel utilisateur via telnet: [%s]%s/%d
 0xe28,Perte du nouvel utilisateur telnet (%s/%d)
 0xe29,Perte du nouvel utilisateur telnet %s (%s/%d)
@@ -426,6 +426,6 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe2e,Connexion perdue pendant l'ident [%s/%d]
 0xe2f,Timeout/EOF ident connection
 0xe30,Lost ident wait telnet socket!!
-0xe31,Telnet refusÃ©: %s, aucun accÃ¨s
+0xe31,Telnet refusé: %s, aucun accès
 0xe32,Refus de la connexion telnet de %s (essai avec mon surnom botnet)
-0xe33,Connexion telnet de %s perdue pendant la vÃ©rification des doublons
+0xe33,Connexion telnet de %s perdue pendant la vérification des doublons

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -4,109 +4,109 @@
 
 # General stuff
 0x001,Utilisation
-0x002,A échoué.\n
+0x002,A Ã©chouÃ©.\n
 
 # MODES_
-0x130,Créé
-0x131,utilisé dernièrement
+0x130,CrÃ©Ã©
+0x131,utilisÃ© derniÃ¨rement
 0x132,inactif
-0x133,placé par
+0x133,placÃ© par
 0x135,non actif sur
 0x137,non actif
-0x138,non placé par le bot
+0x138,non placÃ© par le bot
 
 # BANS_
 0x104,Bans globaux
-0x106,Bans spécifiques au canal
-0x109,Utilisez '.bans all' pour voir la liste complète
+0x106,Bans spÃ©cifiques au canal
+0x109,Utilisez '.bans all' pour voir la liste complÃ¨te
 0x10a,Annulation du ban
 
 # EXEMPTS_
 0x114,Exceptions globales
-0x116,Exceptions spécifiques au canal
-0x119,Utilisez '.exempts all' pour voir la liste complète
+0x116,Exceptions spÃ©cifiques au canal
+0x119,Utilisez '.exempts all' pour voir la liste complÃ¨te
 0x11a,Annulation de l'exception
 
 # INVITES_
 0x124,Invitations globales
-0x126,Invitations spécifiques au canal
-0x129,Utilisez '.invites all' pour voir la liste complète
+0x126,Invitations spÃ©cifiques au canal
+0x129,Utilisez '.invites all' pour voir la liste complÃ¨te
 0x12a,Annulation de l'invitation
 
 # MOD_
-0x200,Déjà chargé.
-0x201,Ne peut pas déterminer le répertoire courant.
-0x202,Aucune fonction de démarrage définie.
+0x200,DÃ©jÃ  chargÃ©.
+0x201,Ne peut pas dÃ©terminer le rÃ©pertoire courant.
+0x202,Aucune fonction de dÃ©marrage dÃ©finie.
 0x204,Requis par un autre module
 0x205,Aucune fonction de fermeture
-0x206,Module déchargé:
+0x206,Module dÃ©chargÃ©:
 0x207,Aucun module de ce nom
 0x209,Erreur pendant le chargement du module:
-0x20a,Erreur pendant le déchargement du module:
+0x20a,Erreur pendant le dÃ©chargement du module:
 0x20b,Ne peut pas charger les modules
-0x20c,Modules stagnant; il va y avoir perte de mémoire!
-0x20d,Vous avez installé des modules, mais n'avez pas choisi de module de cryptage,\n\
+0x20c,Modules stagnant; il va y avoir perte de mÃ©moire!
+0x20d,Vous avez installÃ© des modules, mais n'avez pas choisi de module de cryptage,\n\
 consultez le ficher de configuration initiale pour plus de renseignements.\n
-0x20e,Module Filesys non chargé.
-0x20f,Module chargé: %s \t\t(avec support internationnal)
-0x210,Module chargé: %s
+0x20e,Module Filesys non chargÃ©.
+0x20f,Module chargÃ©: %s \t\t(avec support internationnal)
+0x210,Module chargÃ©: %s
 
 # USERF_
-0x400,Transfert de la liste utilisateurs terminé; liste prise en compte
+0x400,Transfert de la liste utilisateurs terminÃ©; liste prise en compte
 0x402,NE PEUT PAS LIRE LA NOUVELLE LISTE UTILISATEURS
 0x403,Ne peut vous envoyer la liste utilisateurs (erreur interne)
-0x404,Personne ne correspond à ces critères
+0x404,Personne ne correspond Ã  ces critÃ¨res
 0x405,Ancienne liste utilisateurs, utilisez 'tclsh scripts/weed <fichier-usagers> c' pour la convertir
 0x406,Format de liste utilisateurs invalide.
 0x407,Enregistrement utilisateur corrompu
 0x408,Enregistrement utilisateur en double
 0x409,Mot de passe corrompu pour:
-0x40a,Ban(s) ignoré(s) pour le(s) canal(aux):
+0x40a,Ban(s) ignorÃ©(s) pour le(s) canal(aux):
 0x40b,Ecriture de la liste utilisateurs...
-0x40c,ERREUR pendant l'écriture de la liste utilisateurs.
-0x40d,ERREUR pendant l'écriture de la liste utilisateurs à transférer.
-0x40e,Création de la liste utilisateurs inutile--ignorée
+0x40c,ERREUR pendant l'Ã©criture de la liste utilisateurs.
+0x40d,ERREUR pendant l'Ã©criture de la liste utilisateurs Ã  transfÃ©rer.
+0x40e,CrÃ©ation de la liste utilisateurs inutile--ignorÃ©e
 0x40f,Relecture de la configuration...
 0x410,Je ne connais personne de ce nom.\n
 0x411,Aucun enregistrement pour cet utilisateur.
 0x412,Sauvegarde de la liste utilisateurs...
 0x413,Echec de la connexion; interruption du transfert de la liste utilisateurs.
 0x414,Demande de partage (ancienne version) par
-0x415,Demande de partage désuète
-0x416,Liste utilisateurs rejetée par
+0x415,Demande de partage dÃ©suÃ¨te
+0x416,Liste utilisateurs rejetÃ©e par
 
 # MISC_
-0x500,a expiré
+0x500,a expirÃ©
 0x501,au total
-0x502,Supprimé
+0x502,SupprimÃ©
 0x504,sur
 0x505,Recherche
 0x506,je laisse tomber d'abord
-0x507,(plus de %d résultats; liste tronquée)\n
-0x508,--- Trouvé %d résultat%s.\n
-0x509,Commande ambiguë.\n
+0x507,(plus de %d rÃ©sultats; liste tronquÃ©e)\n
+0x508,--- TrouvÃ© %d rÃ©sultat%s.\n
+0x509,Commande ambiguÃ«.\n
 0x50a,Quoi? Essayez '.help'\n
 0x50b,Liaisons de commande:\n
-0x50c,Redémarrage...
+0x50c,RedÃ©marrage...
 0x50d,s
 0x50e,Rotation des fichiers de log...
 0x512,inactif
 0x513,ABSENT
-0x516,Déconnecté
+0x516,DÃ©connectÃ©
 0x517,bot non valide
-0x518,Boucle détectée: déconnection
+0x518,Boucle dÃ©tectÃ©e: dÃ©connection
 0x51a,de
-0x51b,périmé
-0x51c,rejeté
+0x51b,pÃ©rimÃ©
+0x51c,rejetÃ©
 0x51d,imposteur
 0x51e,j'essaie
 0x51f,Fichier MOTD:
 0x520,Aucun fichier MOTD.
 0x521,Utilisez:
-0x522,<addresse> <numéro de port>[/<numéro de port-relais>]
+0x522,<addresse> <numÃ©ro de port>[/<numÃ©ro de port-relais>]
 0x526,en suspens
 0x527,je ne suis pas op
-0x529,arrière plan
+0x529,arriÃ¨re plan
 0x52a,mode terminal
 0x52b,mode statut
 0x52c,mode log
@@ -117,100 +117,100 @@ consultez le ficher de configuration initiale pour plus de renseignements.\n
 0x531,annonce
 0x532,Proprietaire(s) permanent(s)
 0x534,FICHIER DE CONFIGURATION NON CHARGE (INTROUVABLE OU ERREUR)
-0x535,LISTE UTILISATEURS NON TROUVEE!  (essayez './eggdrop -m %s' pour en créer une)\n
+0x535,LISTE UTILISATEURS NON TROUVEE!  (essayez './eggdrop -m %s' pour en crÃ©er une)\n
 0x536,DEMARRAGE DU BOT EN MODE CREATION DE LISTE UTILISATEURS.\n\
 Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x537,OU allez sur IRC et:  /msg %s hello\n
-0x538,Le bot vous reconnaitra alors comme maître.
+0x538,Le bot vous reconnaitra alors comme maÃ®tre.
 0x539,LA LISTE UTILISATEURS EXISTE DEJA (enlevez le '-m')
-# 0x53a - unused / inutilisé
+# 0x53a - unused / inutilisÃ©
 0x53b,Ne peut pas recharger la liste utilisateurs!
-0x53c,La liste utilisateurs est innexistante!
+0x53c,La liste utilisateurs est inexistante!
 0x53e,%B  (%E)\n\nEntrez votre surnom.\n
-0x53f,Rotation du fichier log %s, taille maximale depassée (%d)
-# 0x540 - unused / inutilisé
-0x541,Dernier message repété %d fois.\n
-0x542,bloqué
-0x543,No free sockets available.
+0x53f,Rotation du fichier log %s, taille maximale depassÃ©e (%d)
+# 0x540 - unused / inutilisÃ©
+0x541,Dernier message repÃ©tÃ© %d fois.\n
+0x542,bloquÃ©
+0x543,Pas de socket libre disponible.
 0x544,Tcl version:
 0x545,header version
 
 # IRC_
 0x600,Banni
-0x601,Vous êtes banni
-0x602,Tentative de Ban sur moi-même--évitée.
-0x603,c'était drôle, refaites-le encore une fois!
+0x601,Vous Ãªtes banni
+0x602,Tentative de Ban sur moi-mÃªme--Ã©vitÃ©e.
+0x603,c'Ã©tait drÃ´le, refaites-le encore une fois!
 0x604,Salut
 0x605,Au revoir
-0x606,Vous êtes banni, goober.
-0x607,NOTICE %s :Ton nick était trop longue, j'ai du le changer à '%s'.\n
-0x608,Présenté à
+0x606,Vous Ãªtes banni, goober.
+0x607,NOTICE %s :Ton nick Ã©tait trop long, j'ai du le changer Ã  '%s'.\n
+0x608,PrÃ©sentÃ© Ã 
 0x609,site public
 0x60a,NOTICE %s :Salut %s!  Je suis %s, un bot eggdrop.\n
-0x60b,NOTICE %s :Je vais vous reconnaître par votre hostmask '%s' à partir de maintenant.\n
-0x60c,Etant donné que vous venez d'un site IRC public, vous devriez
+0x60b,NOTICE %s :Je vais vous reconnaÃ®tre par votre hostmask '%s' Ã  partir de maintenant.\n
+0x60c,Etant donnÃ© que vous venez d'un site IRC public, vous devriez
 0x60d,toujours utiliser ce surnom quand vous me parlez.
 0x60e,VOUS ETES MAINTENANT LE PROPRIETAIRE DE CE BOT
-0x60f,Installation du bot terminée, le premier maître est %s
+0x60f,Installation du bot terminÃ©e, le premier maÃ®tre est %s
 0x610,Bienvenue sur Eggdrop! =]
-0x611,présenté à %s de %s
-0x612,Vous avez un mot de passe de défini.
-0x613,Vous n'avez pas de mot de passe de défini.
-0x615,Vous avez déjà un mot de passe de défini.
-0x616,Employez au moins 6 caractères.
-0x617,Mot de passe défini:
+0x611,prÃ©sentÃ© Ã  %s de %s
+0x612,Vous avez un mot de passe de dÃ©fini.
+0x613,Vous n'avez pas de mot de passe de dÃ©fini.
+0x615,Vous avez dÃ©jÃ  un mot de passe de dÃ©fini.
+0x616,Employez au moins 6 caractÃ¨res.
+0x617,Mot de passe dÃ©fini:
 0x618,Mot de passe incorrect.
 0x619,Nouveau mot de passe:
-0x61a,Vous êtes sur un site public; vous n'avez pas accès à IDENT.
-0x61b,NOTICE %s :Vous n'êtes pas %s, vous êtes %s.\n
-0x61c,Accès refusé.
-0x61d,Je vous reconnais là.
-0x61e,Hostmask ajouté
+0x61a,Vous Ãªtes sur un site public; vous n'avez pas accÃ¨s Ã  IDENT.
+0x61b,NOTICE %s :Vous n'Ãªtes pas %s, vous Ãªtes %s.\n
+0x61c,AccÃ¨s refusÃ©.
+0x61d,Je vous reconnais lÃ .
+0x61e,Hostmask ajoutÃ©
 0x620,Actuellement:
 0x621,Maintenant:
 0x622,Pour l'enlever:
-0x624,Votre ligne de renseignements est verrouillée
+0x624,Votre ligne de renseignements est verrouillÃ©e
 0x625,Retrait de votre ligne de renseignements sur
 0x626,Retrait de votre ligne de renseignements.
-0x627,Vous n'avez aucuns renseignements sur
-0x628,Vous n'avez aucuns renseignements.
-0x629,Je ne contrôle pas ce canal.
-0x62a,Reinitialisation des renseignements du canal.
+0x627,Vous n'avez aucun renseignements sur
+0x628,Vous n'avez aucun renseignements.
+0x629,Je ne contrÃ´le pas ce canal.
+0x62a,RÃ©initialisation des renseignements du canal.
 0x62b,Changement de serveur...
-0x62c,Le canal est actuellement caché.
+0x62c,Le canal est actuellement cachÃ©.
 0x62d,Maintenant sur le canal
 0x62e,N'est jamais venu sur l'un de mes canaux.
-0x62f,Vu la dernière fois à
-0x630,Vous n'êtes pas enregistré ; présentez vous d'abord.
+0x62f,Vu la derniÃ¨re fois Ã 
+0x630,Vous n'Ãªtes pas enregistrÃ© ; prÃ©sentez vous d'abord.
 0x631,Aucune aide.
-0x632,Aucune aide disponible là-dessus.
+0x632,Aucune aide disponible lÃ -dessus.
 # 0x633 - unused
 0x634,Pas sur ce canal en ce moment.
-0x635,Je récupère mon surnom (%s)
+0x635,Je rÃ©cupÃ¨re mon surnom (%s)
 0x636,Le serveur me dit que mon surnom est invalide.
 0x637,SURNOM EN UTILISATION: Essai de '%s'
 0x638,Ne peut pas changer de surnom sur %s.  Mon surnom est-il interdit?
-0x639,Surnom bloqué
-0x63a,Le canal %s est bloqué. :(
-0x63b,%s dit que je ne suis pas enregistré, essai du suivant.
+0x639,Surnom bloquÃ©
+0x63a,Le canal %s est bloquÃ©. :(
+0x63b,%s dit que je ne suis pas enregistrÃ©, essai du suivant.
 0x63c,Vous avez un serveur incorrect.
 0x63d,Flood de @%s!  Placement en ignorance!
 0x63f,Flood de JOIN de @%s!  Interdiction.
 0x640,Flood de canal de %s -- je le kick
 0x641,Essai du serveur
-0x642,La requête DNS a échoué
-0x643,Echec de la connexion à
-0x644,Le serveur ne répond plus; changement...
-0x645,Déconnecté de
+0x642,La requÃªte DNS a Ã©chouÃ©
+0x643,Echec de la connexion Ã 
+0x644,Le serveur ne rÃ©pond plus; changement...
+0x645,DÃ©connectÃ© de
 0x646,Aucun serveur actuellement.
-0x647,La file d'attente des modes est à
-0x648,La file d'attente des serveurs est à
-0x649,La file d'attente d'aide est à
-0x64a,Le vhost qu'est configurÃ© dans le fichier de configuration n'est pas capable de connecter Ã  l'addresse du serveur
-0x64b,Le vhost qu'est configurÃ© dans le fichier de configuration n'est pas disponsible en cette machine
+0x647,La file d'attente des modes est Ã 
+0x648,La file d'attente des serveurs est Ã 
+0x649,La file d'attente d'aide est Ã 
+0x64a,Le vhost qui est configurÃ© dans le fichier de configuration n'est pas capable de connecter Ã  l'addresse du serveur
+0x64b,Le vhost qui est configurÃ© dans le fichier de configuration n'est pas disponsible sur cette machine
 0x64c,Traitement du canal
 0x64d,Canal
-0x64e,Je désire le canal
+0x64e,Je dÃ©sire le canal
 0x64f,Sujet du canal
 0x650,+o en suspens -- Je lag
 0x651,-o en suspens -- Je lag
@@ -218,167 +218,167 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0x653,FAUX OPERATEUR DONNE PAR LE SERVEUR
 0x654,Fin de renseigements du canal.
 0x655,Kick massif, va t'asseoir dans un coin
-0x656,Ban annulé
+0x656,Ban annulÃ©
 0x657,Hmm, info sur les modes d'un canal sur lequel je ne suis pas
-0x658,...et merci d'avoir joué.
+0x658,...et merci d'avoir jouÃ©.
 0x659,Changement de serveur (j'ai besoin de %d serveurs, je n'en ai que %d)
 0x65a,changement de serveur
 0x65b,Je suis sur trop de canaux--ne peut rejoindre: %s
 0x65c,Le canal est plein--ne peut rejoindre: %s
-0x65d,Le canal est réservé aux invités--ne peut rejoindre: %s
+0x65d,Le canal est rÃ©servÃ© aux invitÃ©s--ne peut rejoindre: %s
 0x65e,Banni sur le canal--ne peut rejoindre: %s
 0x65f,Le serveur dit que je ne suis pas sur le canal: %s
-0x660,Mauvaise clé--ne peut rejoindre: %s
-0x661,NOTICE %s :Toutes les commandes sont accessibles par /MSG. Pour la liste complète, /MSG %s help   Cya!\n
-0x662,NOTICE %s :Je ne vous reconnais pas de cet hôte.\n
+0x660,Mauvaise clÃ©--ne peut rejoindre: %s
+0x661,NOTICE %s :Toutes les commandes sont accessibles par /MSG. Pour la liste complÃ¨te, /MSG %s help   Cya!\n
+0x662,NOTICE %s :Je ne vous reconnais pas de cet hÃ´te.\n
 0x663,NOTICE %s :Soit vous utilisez le nick de quelqu'un d'autre, soit vous devez taper: /MSG %s IDENT (mot de passe)\n
-0x664,NOTICE %s :En tant que maître, vous devez vraiment définir un mot de passe: avec /MSG %s pass <le-mot-de-passe-que-vous-avez-choisi>.\n
-0x665,NOTICE %s :La majorité des commandes est accessible en DCC chat. Dorénavant, vous n'avez plus besoin de l'option -m quand vous démarrez le bot. Amusez-vous bien !!\n
-0x666,Ceci est l'interface telnet de %s, un bot eggdrop.\nN'en abusez pas, et elle sera ouverte également à tous vos amis.\n
-0x667,Maintenant vous devez trouver un nick à utiliser sur le bot,\net un mot de passe, ainsi personne ne peut prétendre être vous.\nRetenez les!
-0x668,Dorénavant, vous n'avez plus besoin d'utiliser l'option -m pour démarrer le bot.\nAmusez-vous bien !!
+0x664,NOTICE %s :En tant que maÃ®tre, vous devez vraiment dÃ©finir un mot de passe: avec /MSG %s pass <le-mot-de-passe-que-vous-avez-choisi>.\n
+0x665,NOTICE %s :La majoritÃ© des commandes est accessible en DCC chat. DorÃ©navant, vous n'avez plus besoin de l'option -m quand vous dÃ©marrez le bot. Amusez-vous bien !!\n
+0x666,Ceci est l'interface telnet de %s, un bot eggdrop.\nN'en abusez pas, et elle sera ouverte Ã©galement Ã  tous vos amis.\n
+0x667,Maintenant vous devez trouver un nick Ã  utiliser sur le bot,\net un mot de passe, ainsi personne ne peut prÃ©tendre Ãªtre vous.\nRetenez les!
+0x668,DorÃ©navant, vous n'avez plus besoin d'utiliser l'option -m pour dÃ©marrer le bot.\nAmusez-vous bien !!
 0x669,Flood de connexions telnet de %s!  On ignore!
 0x66a,Banni:
 0x66b,avalanche de surnom
-0x66c,touches pas à mon pote
+0x66c,touches pas Ã  mon pote
 0x66d,...pas la peine de revenir.
 0x66e,Retour au surnom alternatif %s
 0x66f,ne deope pas mes amis !
-0x670,Exception enlevée
-0x671,Invitation enlevée
+0x670,Exception enlevÃ©e
+0x671,Invitation enlevÃ©e
 0x672,Flood de SURNOM de @%s! Banni.
 0x673,flood de surnoms
 
 # EGG_
-#0x700 - unused / inutilisé
-0x701,Je détecte que %s est s'exécute déjà depuis ce répertoire.\n
+#0x700 - unused / inutilisÃ©
+0x701,Je dÃ©tecte que %s est s'exÃ©cute dÃ©jÃ  depuis ce rÃ©pertoire.\n
 0x702,Si ce n'est pas le cas, supprimez '%s'\n
-0x703,* Attention! Impossible d'écrire le fichier %s!\n
+0x703,* Attention! Impossible d'Ã©crire le fichier %s!\n
 
 # USER_
 0x800,  (est un op global)
 0x801,  (est un bot)
-0x802,  (est un maître)
+0x802,  (est un maÃ®tre)
 
 # CHAN_
-0x900,Aucun canal de ce nom défini
+0x900,Aucun canal de ce nom dÃ©fini
 0x902,* Changement de mode sur %s pour le non-existant %s!
 0x903,Deop en masse sur %s par %s
 0x904,Deop en masse.  Va t'asseoir dans un coin.
 0x907,Oops. Quelqu'un m'a fait rejoindre %s... j'en pars...
 0x908,Changement de mode par un faux op sur %s!  Annulation...
-0x909,Abus d'un op mal gagné par serveur
+0x909,Abus d'un op mal gagnÃ© par serveur
 0x90a,Changement de mode par un non-op sur %s!  Annulation...
-0x90b,Abus d'une désynchronisation
+0x90b,Abus d'une dÃ©synchronisation
 0x90c,flood
 
-0xa00,Aucun ignoré
+0xa00,Aucun ignorÃ©
 0xa01,Actuellement, j'ignore
 0xa02,Je n'ignore plus
 
-0xb00,Ce bot n'est pas là.\n
-0xb01,C'est un bot.  Vous ne pouvez laisser de notes à un bot.\n
+0xb00,Ce bot n'est pas lÃ .\n
+0xb01,C'est un bot.  Vous ne pouvez laisser de notes Ã  un bot.\n
 0xb02,est absent
-0xb07,Une note est arrivée pour vous
-0xb08,Message stocké
-0xb18,L'arrêt du bot commence....
+0xb07,Une note est arrivÃ©e pour vous
+0xb08,Message stockÃ©
+0xb18,L'arrÃªt du bot commence....
 0xb19,Aucun utilisateur de ce nom
 0xb1a,Aucuns canaux
 0xb1b,Membres de la party line:
-0xb1c,Bots connectés
+0xb1c,Bots connectÃ©s
 0xb1d,Autres personnes sur le bot
-0xb1f,Tentative de liaison à
-0xb20,Non en ligne; note enregistrée.
-0xb21,La boite à messages est pleine, désolé.
-0xb22,est absent; note stockée.
-0xb23,Note envoyée à
-0xb24,Déconnecté de:
+0xb1f,Tentative de liaison Ã 
+0xb20,Non en ligne; note enregistrÃ©e.
+0xb21,La boite Ã  messages est pleine, dÃ©solÃ©.
+0xb22,est absent; note stockÃ©e.
+0xb23,Note envoyÃ©e Ã 
+0xb24,DÃ©connectÃ© de:
 0xb25,Personnes sur le canal
-0xb26,Ne peut me relier là
-0xb27,Ne peux me délier
-0xb28,Boucle détectée
+0xb26,Ne peut me relier lÃ 
+0xb27,Ne peux me dÃ©lier
+0xb28,Boucle dÃ©tectÃ©e
 0xb29,Annonce de lien incorrect de
-0xb2b,Reste deconnecté
-0xb2c,Lié à
-0xb2d,Lien illégal par un leaf
-0xb2e,Vous êtes supposés être un leaf!
-0xb2f,Bot rejeté
-0xb30,Vieux bot détecté (non-supporté)
-0xb31,Résultat de trace
+0xb2b,Reste deconnectÃ©
+0xb2c,LiÃ© Ã 
+0xb2d,Lien illÃ©gal par un leaf
+0xb2e,Vous Ãªtes supposÃ©s Ãªtre un leaf!
+0xb2f,Bot rejetÃ©
+0xb30,Vieux bot dÃ©tectÃ© (non-supportÃ©)
+0xb31,RÃ©sultat de trace
 0xb32,n'existe pas
-0xb33,Les boots distants ne sont pas autorisés.
-0xb34,Je ne peux virer le propriétaire du bot.
+0xb33,Les boots distants ne sont pas autorisÃ©s.
+0xb34,Je ne peux virer le propriÃ©taire du bot.
 0xb35,TRANSFERT DE FICHIER REJETE
-0xb37,Utilisateurs à travers le botnet
+0xb37,Utilisateurs Ã  travers le botnet
 0xb38,Party line
 0xb39,Canal local
 0xb3a,Utilisateurs du canal
-0xb3b,Aucun bot relié.
+0xb3b,Aucun bot reliÃ©.
 0xb3c,Aucunes informations de trace:
 0xb3d,L'arborescence est trop complexe!
-0xb3e,Déconnexion de tous les bots...
-0xb3f,Tentative de terminer le lien à
+0xb3e,DÃ©connexion de tous les bots...
+0xb3f,Tentative de terminer le lien Ã 
 0xb40,Plus aucun essai de lien avec:
-0xb41,Dénouage du lien avec
-0xb42,Délié de:
-0xb43,Non connecté à ce bot.
+0xb41,DÃ©nouage du lien avec
+0xb42,DÃ©liÃ© de:
+0xb43,Non connectÃ© Ã  ce bot.
 0xb44,Vidange de la table des bots et des assocs...
 0xb45,n'est pas un bot connu.
-0xb46,Me relier à moi même?  Heh mon garcon, un grand jour pour Freud.
-0xb47,Ce bot est déja connecté.
-0xb48,Adresse de port telnet invalide:port enregistré pour
+0xb46,Me relier Ã  moi mÃªme?  Heh mon garcon, un grand jour pour Freud.
+0xb47,Ce bot est dÃ©ja connectÃ©.
+0xb48,Adresse de port telnet invalide:port enregistrÃ© pour
 0xb49,Liaison avec
-0xb4a,Ne peut trouver d'utilisateur à relayer!
+0xb4a,Ne peut trouver d'utilisateur Ã  relayer!
 0xb4b,Liaison impossible avec
-0xb4c,Faire un relais sur moi-même?  Quel est l'intérêt?!
-0xb4d,Connexion à
+0xb4c,Faire un relais sur moi-mÃªme?  Quel est l'intÃ©rÃªt?!
+0xb4d,Connexion Ã 
 0xb4e,(Tapez *BYE* seul sur une ligne pour abandonner.)
-0xb4f,Abandon de la tentative de relais à
-0xb50,Vous êtes maintenant de retour sur
-0xb51,Relais abandonné:
+0xb4f,Abandon de la tentative de relais Ã 
+0xb50,Vous Ãªtes maintenant de retour sur
+0xb51,Relais abandonnÃ©:
 0xb53,Perte de la connexion DCC avec
-0xb54,Abandon de la tentative de relais à
-0xb55,Succès!\n\nMAINTENANT CONNECTE AU BOT RELAIS
-0xb56,(Vous pouvez taper *BYE* pour fermer la connexion prématurément.)
+0xb54,Abandon de la tentative de relais Ã 
+0xb55,SuccÃ¨s!\n\nMAINTENANT CONNECTE AU BOT RELAIS
+0xb56,(Vous pouvez taper *BYE* pour fermer la connexion prÃ©maturÃ©ment.)
 0xb57,Liaison relais:
-0xb58,a quitté la party line.
-0xb59,Liaison relais terminée
-0xb5a,ABANDON DE LA CONNEXION RELAIS.\nVous êtes de retour sur
+0xb58,a quittÃ© la party line.
+0xb59,Liaison relais terminÃ©e
+0xb5a,ABANDON DE LA CONNEXION RELAIS.\nVous Ãªtes de retour sur
 0xb5b,a rejoint la party line.
-0xb5c,Abandon de la liaison de relais à
-0xb5d,Arrêt de la connexion à
-0xb5e,Relais cassé
+0xb5c,Abandon de la liaison de relais Ã 
+0xb5d,ArrÃªt de la connexion Ã 
+0xb5e,Relais cassÃ©
 0xb5f,Ping timeout
-0xb60,celà ne ressemble pas à un comportement de leaf
+0xb60,celÃ  ne ressemble pas Ã  un comportement de leaf
 0xb61,Abandon du bot
-0xb62,Connection en cours à ce bot.
+0xb62,Connection en cours Ã  ce bot.
 
-0xc00,Je n'accepte pas les DCC chats des étrangers.
-0xc01,DCC chat refusé (aucun accès)
-0xc02,Aucun accès
-0xc03,Vous devez avoir défini un mot de passe.
-0xc04,DCC chat refusé (pas de mot de passe)
-0xc05,DCC chat refusé (+x mais pas de système de fichiers)
-0xc07,Trop de personnes sont dans le système de fichier pour l'instant.
-0xc0c,Désolé, trop de connexions DCC.
+0xc00,Je n'accepte pas les DCC chats des Ã©trangers.
+0xc01,DCC chat refusÃ© (aucun accÃ¨s)
+0xc02,Aucun accÃ¨s
+0xc03,Vous devez avoir dÃ©fini un mot de passe.
+0xc04,DCC chat refusÃ© (pas de mot de passe)
+0xc05,DCC chat refusÃ© (+x mais pas de systÃ¨me de fichiers)
+0xc07,Trop de personnes sont dans le systÃ¨me de fichier pour l'instant.
+0xc0c,DÃ©solÃ©, trop de connexions DCC.
 0xc0d,Connexions DCC pleines: %s %s (%s!%s)
 0xc19,Echec de la connexion
 0xc1a,Echec de la connexion DCC
 0xc1c,Entrez votre mot de passe.
-0xc1d,%s a été enlevé de force pour flood.\n
+0xc1d,%s a Ã©tÃ© enlevÃ© de force pour flood.\n
 0xc1e,-=- poof -=-\n
-0xc1f,Vous avez été viré de %s par %s%s%s\n
-0xc20,%s viré %s de la party line%s%s
-0xc21,DCC chat refusé (port invalide)
+0xc1f,Vous avez Ã©tÃ© virÃ© de %s par %s%s%s\n
+0xc20,%s virÃ© %s de la party line%s%s
+0xc21,DCC chat refusÃ© (port invalide)
 0xc22,DCC port invalide
 
 0xd00,Pas d'interaction avec IRC.
 
 # BOTNET
-0xe00,Faux message rejeté
-0xe01,Lié à
+0xe00,Faux message rejetÃ©
+0xe01,LiÃ© Ã 
 0xe02,Mauvais bot--je voulais %s, et j'ai eu %s
-0xe03,a quitté la
+0xe03,a quittÃ© la
 0xe04,a rejoint la
 0xe05,est maintenant absent
 0xe06,n'est plus absent
@@ -386,36 +386,36 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 
 # dcc.c Messages
 0xe08,Rejet de la liaison de %s
-0xe09,Relié à %s.
+0xe09,ReliÃ© Ã  %s.
 0xe0a,Echec lors de la liaison avec %s.
-0xe0b,Mauvais mot de passe lors de la tentative de connexion à %s.
-0xe0c,Mot de passe requis pour se connecter à %s.
+0xe0b,Mauvais mot de passe lors de la tentative de connexion Ã  %s.
+0xe0c,Mot de passe requis pour se connecter Ã  %s.
 0xe0d,ERREUR lors de la liaison avec %s: %s
 0xe0e,Bot perdu: %s
-0xe0f,Timeout: liaison au bot %s à %s:%d
-0xe10,connecté: %s (%s/%d)
+0xe0f,Timeout: liaison au bot %s Ã  %s:%d
+0xe10,connectÃ©: %s (%s/%d)
 0xe11,Mot de passe incorrect: [%s]%s/%d
-0xe12,Négatif, Houston.\n
+0xe12,NÃ©gatif, Houston.\n
 0xe13,*** %s a rejoint la party line.\n
 0xe14,Connexion DCC perdue avec %s (%s/%d)
 0xe15,Mot de passe timeout lors du dcc chat: [%s]%s
-0xe16,Connexion DCC fermée (%s!%s)
+0xe16,Connexion DCC fermÃ©e (%s!%s)
 0xe17,Echec de la tentative de TELNET en cours (%s)
 0xe18,Refus %s/%d (mauvais port source)
 0xe19,*** %s est de retour.\n 
 0xe1a,Refus %s (mauvais hostname)
 0xe1b,Connexion telnet: %s/%d
 0xe1c,Echec de l'ident pour %s: %s
-0xe1d,(!) Port d'écoute %d est brusquement mort.
+0xe1d,(!) Port d'Ã©coute %d est brusquement mort.
 0xe1e,Refus %s (mauvais surnom)
 0xe1f,Refus %s (ce n'est pas un bot)
 0xe20,Refus %s (ce n'est pas un utilisateur)
 0xe21,Refus %s (invalide handle: %s)
-0xe22,Connexion telnet refusée depuis %s (doublon)
+0xe22,Connexion telnet refusÃ©e depuis %s (doublon)
 0xe23,Refus [%s]%s (aucun mot de passe)
 0xe24,Connexion telnet perdue vers %s/%d
 0xe25,Ident timeout lors du telnet: %s
-0xe26,Installation du bot complète, le premier maître est %s
+0xe26,Installation du bot complÃ¨te, le premier maÃ®tre est %s
 0xe27,Nouvel utilisateur via telnet: [%s]%s/%d
 0xe28,Perte du nouvel utilisateur telnet (%s/%d)
 0xe29,Perte du nouvel utilisateur telnet %s (%s/%d)
@@ -426,6 +426,6 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe2e,Connexion perdue pendant l'ident [%s/%d]
 0xe2f,Timeout/EOF ident connection
 0xe30,Lost ident wait telnet socket!!
-0xe31,Telnet refusé: %s, aucun accès
+0xe31,Telnet refusÃ©: %s, aucun accÃ¨s
 0xe32,Refus de la connexion telnet de %s (essai avec mon surnom botnet)
-0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
+0xe33,Connexion telnet de %s perdue pendant la vÃ©rification des doublons


### PR DESCRIPTION
Found by: CrazyCat
Patch by: CrazyCat
Fixes: translation

One-line summary:
Small french typos

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
