### PR TITLE
Fix colon for sasl gotauthenticate()

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1253,7 +1253,7 @@ static int tryauthenticate(char *from, char *msg)
 
 static int gotauthenticate(char *from, char *msg)
 {
-  fixcolon(msg);
+  fixcolon(msg); /* Because Inspircd does its own thing */
   if (tryauthenticate(from, msg) && !sasl_continue) {
     putlog(LOG_DEBUG, "*", "SASL: Aborting connection and retrying");
     nuke_server("Quitting...");

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1253,6 +1253,7 @@ static int tryauthenticate(char *from, char *msg)
 
 static int gotauthenticate(char *from, char *msg)
 {
+  fixcolon(msg);
   if (tryauthenticate(from, msg) && !sasl_continue) {
     putlog(LOG_DEBUG, "*", "SASL: Aborting connection and retrying");
     nuke_server("Quitting...");


### PR DESCRIPTION
Found by: PeGaSuS
Patch by: michaelortmann
Fixes: 

One-line summary:
Seems like fixcolon(msg) was missing for gotauthenticate()

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
**I didnt test this patch**, can you take it from here?