### PR TITLE
Fix Crash in dns module

### DIFF
--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -312,8 +312,10 @@ set mod-path "modules/"
 ## In case your bot has trouble finding dns servers or you want to use
 ## specific ones, you can set them here. The value is a list of dns servers.
 ## The order doesn't matter. You can also specify a non-standard port.
-## The default is to use the system specified dns servers. 
-#set dns-servers "8.8.8.8 8.8.4.4"
+## The default is to use the system specified dns servers. You don't need to
+## modify this setting normally. Up to MAXNS (currently 3, see resolv.conf(3))
+## name servers may be listed.
+#set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
 
 #### CHANNELS MODULE ####
 

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -313,8 +313,8 @@ set mod-path "modules/"
 ## specific ones, you can set them here. The value is a list of dns servers.
 ## The order doesn't matter. You can also specify a non-standard port.
 ## The default is to use the system specified dns servers. You don't need to
-## modify this setting normally. Up to MAXNS (currently 3, see resolv.conf(3))
-## name servers may be listed.
+## modify this setting normally. Default kernel implementations limit this list
+## to 3 servers.
 #set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
 
 #### CHANNELS MODULE ####

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -648,8 +648,9 @@ loadmodule dns
 # specific ones, you can set them here. The value is a list of dns servers.
 # The order doesn't matter. You can also specify a non-standard port.
 # The default is to use the system specified dns servers. You don't need to
-# modify this setting normally.
-#set dns-servers "8.8.8.8 8.8.4.4"
+# modify this setting normally. Up to MAXNS (currently 3, see resolv.conf(3))
+# name servers may be listed.
+#set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
 
 # Specify how long should the DNS module cache replies at maximum. The value
 # must be in seconds.

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -648,8 +648,8 @@ loadmodule dns
 # specific ones, you can set them here. The value is a list of dns servers.
 # The order doesn't matter. You can also specify a non-standard port.
 # The default is to use the system specified dns servers. You don't need to
-# modify this setting normally. Up to MAXNS (currently 3, see resolv.conf(3))
-# name servers may be listed.
+# modify this setting normally. Default kernel implementations limit this list
+## to 3 servers.
 #set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
 
 # Specify how long should the DNS module cache replies at maximum. The value

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -161,14 +161,14 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
     code = Tcl_SplitList(interp, slist, &lc, &list);
     if (code == TCL_ERROR)
       return "variable must be a list";
-    if (lc > MAXNS) {
-      putlog(LOG_MISC, "*", "WARNING: %i dns-servers configured but MAXNS is "
-             "%i.\n         Surplus dns-servers ignored.", lc, MAXNS);
-      lc = MAXNS;
-    }
     /* reinitialize the list */
     myres.nscount = 0;
     for (i = 0; i < lc; i++) {
+      if (myres.nscount >= MAXNS) {
+        putlog(LOG_MISC, "*", "WARNING: %i dns-servers configured but MAXNS is "
+               "%i\n         Surplus dns-servers ignored", lc, MAXNS);
+        break;
+      }
       if ((p = strchr(list[i], ':'))) {
         *p++ = 0;
         /* allow non-standard ports */
@@ -181,6 +181,8 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
         myres.nsaddr_list[myres.nscount].sin_family = AF_INET;
         myres.nscount++;
       }
+      else
+        putlog(LOG_MISC, "*", "WARNING: invalid dns-server %s", list[i]);
     }
     Tcl_Free((char *) list);
   }

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -37,7 +37,7 @@ static int dns_retrydelay = 3;
 static int dns_cache = 86400;
 static int dns_negcache = 600;
 
-static char dns_servers[121] = "";
+static char dns_servers[144] = "";
 
 #include "coredns.c"
 
@@ -131,7 +131,7 @@ static tcl_ints dnsints[] = {
 };
 
 static tcl_strings dnsstrings[] = {
-  {"dns-servers", dns_servers, 120,           0},
+  {"dns-servers", dns_servers, 143,           0},
   {NULL,          NULL,          0,           0}
 };
 
@@ -139,7 +139,7 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
                            EGG_CONST char *name1,
                            EGG_CONST char *name2, int flags)
 {
-  char buf[121], *p;
+  char buf[sizeof dns_servers], *p;
   unsigned short port;
   int i, lc, code;
   EGG_CONST char **list, *slist;

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -161,6 +161,11 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
     code = Tcl_SplitList(interp, slist, &lc, &list);
     if (code == TCL_ERROR)
       return "variable must be a list";
+    if (lc > MAXNS) {
+      putlog(LOG_MISC, "*", "WARNING: %i dns-servers configured but MAXNS is "
+             "%i.\n         Surplus dns-servers ignored.", lc, MAXNS);
+      lc = MAXNS;
+    }
     /* reinitialize the list */
     myres.nscount = 0;
     for (i = 0; i < lc; i++) {
@@ -291,7 +296,7 @@ char *dns_start(Function *global_funcs)
 
   global = global_funcs;
 
-  module_register(MODULE_NAME, dns_table, 1, 1);
+  module_register(MODULE_NAME, dns_table, 1, 2);
   if (!module_depend(MODULE_NAME, "eggdrop", 108, 0)) {
     module_undepend(MODULE_NAME);
     return "This module requires Eggdrop 1.8.0 or later.";

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -165,8 +165,8 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
     myres.nscount = 0;
     for (i = 0; i < lc; i++) {
       if (myres.nscount >= MAXNS) {
-        putlog(LOG_MISC, "*", "WARNING: %i dns-servers configured but MAXNS is "
-               "%i\n         Surplus dns-servers ignored", lc, MAXNS);
+        putlog(LOG_MISC, "*", "WARNING: %i dns-servers configured but kernel-defined"
+               "limit is %i, ignoring extra servers\n", lc, MAXNS);
         break;
       }
       if ((p = strchr(list[i], ':'))) {

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -182,7 +182,7 @@ static char *dns_change(ClientData cdata, Tcl_Interp *irp,
         myres.nscount++;
       }
       else
-        putlog(LOG_MISC, "*", "WARNING: invalid dns-server %s", list[i]);
+        putlog(LOG_MISC, "*", "WARNING: Invalid dns-server %s", list[i]);
     }
     Tcl_Free((char *) list);
   }


### PR DESCRIPTION
Found by: weweilep
Patch by: michaelortmann
Fixes: #901 

One-line summary:
Prevent possible crash, seen under CentOS 8, don't overflow system resolver nsaddr_list; fix size of dns-servers; fix doc and default settings; enhance logging

Additional description (if needed):
Thanks vanosg for helping with this one
sizeof dns servers was 120 and weweilep noted in IRC: 3 ipv6 addresses with full ports could hit that, IE: [aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa]:65000 [aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa]:65000 [aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa]:65000

Test cases demonstrating functionality (if applicable):
BotA.conf:
```
loadmodule dns
set dns-servers "1.1.1.1 foo 9.9.9.9 8.8.8.8 4.2.2.1"
```
$ ./eggdrop -nt BotA.conf
```
Module loaded: dns             
WARNING: Invalid dns-server foo
WARNING: 5 dns-servers configured but MAXNS is 3
         Surplus dns-servers ignored

.status all
  Module: dns, v 1.2
    Async DNS resolver is active.
    DNS server list: 1.1.1.1:53 9.9.9.9:53 8.8.8.8:53
    Using 0 bytes of memory
```