### PR TITLE
Fix volatile int

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -134,7 +134,7 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
   long val;
   IP ip;
   struct hostent *hp;
-  int af = AF_UNSPEC;
+  volatile int af = AF_UNSPEC;
 #ifdef IPV6
   char ip2[INET6_ADDRSTRLEN];
   char *src2 = src;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Compiler warning 24 in #703

One-line summary:
Fix volatile int / Compiler warning 24 in #703

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`CFLAGS="-Wclobbered -O2" ./configure`
Before:
```
gcc -Wclobbered -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c net.c
net.c: In function ‘setsockname’:
net.c:137:7: warning: variable ‘af’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
  137 |   int af = AF_UNSPEC;
      |       ^~
```
After:
`gcc -Wclobbered -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c net.c`