### PR TITLE
Fix definition of userfile

### DIFF
--- a/src/userrec.c
+++ b/src/userrec.c
@@ -36,15 +36,15 @@ extern int default_flags, default_uflags, quiet_save, dcc_total, share_greet;
 extern char ver[], botnetnick[];
 extern time_t now;
 
-int noshare = 1;                   /* don't send out to sharebots   */
-struct userrec *userlist = NULL;   /* user records are stored here  */
-struct userrec *lastuser = NULL;   /* last accessed user record     */
+int noshare = 1;                   /* don't send out to sharebots       */
+struct userrec *userlist = NULL;   /* user records are stored here      */
+struct userrec *lastuser = NULL;   /* last accessed user record         */
 maskrec *global_bans = NULL, *global_exempts = NULL, *global_invites = NULL;
 struct igrec *global_ign = NULL;
-int cache_hit = 0, cache_miss = 0; /* temporary cache accounting    */
-int userfile_perm = 0600;         /* Userfile permissions
-                                   * (default rw-------) */
-char userfile[121];
+int cache_hit = 0, cache_miss = 0; /* temporary cache accounting        */
+int userfile_perm = 0600;          /* Userfile permissions
+                                    * (default rw-------)               */
+char userfile[121];                /* where the user records are stored */
 
 void *_user_malloc(int size, const char *file, int line)
 {

--- a/src/users.c
+++ b/src/users.c
@@ -46,8 +46,7 @@ extern char botnetnick[];
 extern Tcl_Interp *interp;
 extern time_t now;
 
-char userfile[121] = "";        /* where the user records are stored */
-int ignore_time = 10;           /* how many minutes will ignores last? */
+int ignore_time = 10; /* how many minutes will ignores last? */
 
 /* is this nick!user@host being ignored? */
 int match_ignore(char *uhost)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #911 

One-line summary:
Fix definition of userfile / make error with gcc 10.0.0 20191208

Additional description (if needed):
Fix comment indention

Test cases demonstrating functionality (if applicable):
```
CC=/home/michael/opt/gcc-10-20191208/bin/gcc make
[...]
/home/michael/opt/gcc-10-20191208/bin/gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o  -L/usr/lib -ltcl8.6  -lz -lpthread -lm -lssl -lcrypto -ldl  -lresolv md5/md5c.o compat/*.o `cat mod/mod.xlibs`
/usr/bin/ld: users.o:/home/michael/projects/eggdrop/src/users.c:49: multiple definition of `userfile'; userrec.o:/home/michael/projects/eggdrop/src/userrec.c:47: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:44: link] Error 1
make[2]: Leaving directory '/home/michael/projects/eggdrop/src'
make[1]: *** [Makefile:53: ../eggdrop] Error 2
make[1]: Leaving directory '/home/michael/projects/eggdrop/src'
make: *** [Makefile:251: debug] Error 2
```