### PR TITLE
Fix channel name loading from userfile

### DIFF
--- a/src/users.c
+++ b/src/users.c
@@ -756,7 +756,7 @@ int readuserfile(char *file, struct userrec **ret)
 
                 cr->next = u->chanrec;
                 u->chanrec = cr;
-                strlcpy(cr->channel, chname, 80);
+                strlcpy(cr->channel, chname, sizeof cr->channel);
                 cr->laston = atoi(st);
                 cr->flags = fr.chan;
                 cr->flags_udef = fr.udef_chan;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix channel name loading from userfile / fix off-by-one error

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.+chan #1234567890123456789012345678901234567890123456789012345678901234567890123456789
.+user testuser
.chattr testuser +o #1234567890123456789012345678901234567890123456789012345678901234567890123456789
.whois testuser
HANDLE                           PASS NOTES FLAGS           LAST
testuser                         no       0 -               never (nowhere)
                         #1234567890123456789012345678901234567890123456789012345678901234567890123456789 lo              never
.save
.rehash
.whois testuser
HANDLE                           PASS NOTES FLAGS           LAST
testuser                         no       0 -               never (nowhere)
                         #123456789012345678901234567890123456789012345678901234567890123456789012345678 lo              never
```
