### PR TITLE
More strncpy() -> strlcpy()

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -889,7 +889,7 @@ void parserespacket(uint8_t *response, int len)
       ptrstring(&rp->sockname.addr.sa, stackstring, sizeof stackstring);
       break;
     case STATE_AREQ:
-      strncpy(stackstring, rp->hostn, 1024);
+      strlcpy(stackstring, rp->hostn, sizeof stackstring);
   }
   c = response + HFIXEDSZ;
   r = dn_expand(response, response + len, c, namestring, MAXDNAME);

--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -345,9 +345,8 @@ static void cmd_chdir(int idx, char *msg)
     my_free(s);
     return;
   }
-  strncpy(dcc[idx].u.file->dir, s, 160);
+  strlcpy(dcc[idx].u.file->dir, s, sizeof dcc[idx].u.file->dir);
   my_free(s);
-  dcc[idx].u.file->dir[160] = 0;
   set_user(&USERENTRY_DCCDIR, dcc[idx].user, dcc[idx].u.file->dir);
   putlog(LOG_FILES, "*", "files: #%s# cd /%s", dcc[idx].nick,
          dcc[idx].u.file->dir);

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -262,8 +262,7 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
       return 0;
   }
   if (rfc_casecmp(chan->floodwho[which], p)) {  /* new */
-    strncpy(chan->floodwho[which], p, 80);
-    chan->floodwho[which][80] = 0;
+    strlcpy(chan->floodwho[which], p, sizeof chan->floodwho[which]);
     chan->floodtime[which] = now;
     chan->floodnum[which] = 1;
     return 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
More strncpy() -> strlcpy()

Additional description (if needed):
Fix possible null termination bug in dns mod

Test cases demonstrating functionality (if applicable):
