### PR TITLE
More sprintf() -> snprintf()

### DIFF
--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -732,10 +732,10 @@ static char *mktempfile(char *filename)
 
 static void filesys_dcc_send_hostresolved(int i)
 {
-  char *s1, *param, prt[100], *tempf;
+  char *s1, *param, prt[6], *tempf;
   int len = dcc[i].u.dns->ibuf, j;
 
-  sprintf(prt, "%d", dcc[i].port);
+  snprintf(prt, sizeof prt "%d", dcc[i].port);
   if (!hostsanitycheck_dcc(dcc[i].nick, dcc[i].u.dns->host, &dcc[i].sockname,
                            dcc[i].u.dns->host, prt)) {
     lostdcc(i);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
More sprintf() -> snprintf()

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
