### PR TITLE
Rip out starttls.

### DIFF
--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -1,5 +1,5 @@
 TLS support
-Last revised: Oct 17, 2010
+Last revised: Jan 2, 2020
 
 ===========
 TLS support
@@ -36,9 +36,9 @@ custom one, as they take precedence over any system-wide paths.
 Usage
 -----
 
-By default, without additional configuration, TLS support will provide
-opportunistic encryption for botnet links. For other connection types,
-TLS must be requested explicitly.
+By default and before 1.9.0, without additional configuration, TLS support
+will provide opportunistic encryption for botnet links. From 1.9.0 onward
+or for other connection types, TLS must be requested explicitly.
 
 Secure connections are created the same way as plaintext ones. The only
 difference is that you must prefix the port number with a plus sign.
@@ -62,23 +62,23 @@ ssl-certificate for authentication.
 Botnet
 ^^^^^^
 
-Eggdrop can use TLS connections to protect botnet links if it is compiled with TLS support. TLS-enabled 1.8 bots are backwards compatible with bots that do not have TLS, whether because they are an earlier version or they were not compiled with TLS libraries. Depending on how the user configures the botnet, Eggdrop will use one of two methods to create a TLS connection: raw TLS sockets, and starttls. The difference is that a socket listening for TLS will first create a TLS connection before exchanging any eggdrop-specific data; a starttls connection will first establish the botnet link in the clear, then upgrade to a TLS connection (This means the nickname and, since v1.3.29, a challenge/response password hash are sent before TLS negotiation takes place- not the actual plaintext password).
+Eggdrop can use TLS connections to protect botnet links if it is compiled with TLS support. TLS-enabled 1.9 bots are backwards compatible with bots that do not have TLS, whether because they are an earlier version or they were not compiled with TLS libraries. Before 1.9 two methods were used to create a TLS connection, depending on how the user configured the botnet: raw TLS sockets, and starttls. The difference was that a socket listening for TLS will first create a TLS connection before exchanging any eggdrop-specific data; a starttls connection will first establish the botnet link in the clear, then upgrade to a TLS connection (This means the nickname and, since v1.3.29, a challenge/response password hash are sent before TLS negotiation takes place- not the actual plaintext password). Since 1.9 only raw TLS sockets are used.
 
-By prefixing a listen port in the Eggdrop configuration with a plus (+), that specifies that port as a TLS-enabled port, and will only accept TLS connections (no plain text connections will be allowed). Additionally, Eggdrop 1.8 has starttls functionality, where a plain text connection can first be made to a non-TLS port (ie, one that is not prefixed with a plus) and then upgraded to a TLS connection. Currently, Eggdrop automatically attempts a starttls upgrade on all botnet connections. With two TLS-enabled Eggdrops, it graphically looks like this:
+By prefixing a listen port in the Eggdrop configuration with a plus (+), that specifies that port as a TLS-enabled port, and will only accept TLS connections (no plain text connections will be allowed). Additionally, Eggdrop 1.8 has starttls functionality, where a plain text connection can first be made to a non-TLS port (ie, one that is not prefixed with a plus) and then upgraded to a TLS connection. In Eggdrop 1.8 an automatic attempt for a starttls upgrade on all botnet connections was made, since 1.9 this can only be done with the starttls Tcl/bot command. With two TLS-enabled Eggdrops, it graphically looks like this:
 
 +------------------------------+----------------------------+------------------------------+
 | Leaf bot sets hub port as... | and Hub bot config uses... | the connection will...       |
 +------------------------------+----------------------------+------------------------------+
-| port                         | listen port                | upgrade to TLS with starttls |
+| port                         | listen port                | be plain but can be upgraded |
+|                              |                            | to TLS manually with the     |
+|                              |                            | starttls Tcl/bot command     |
 +------------------------------+----------------------------+------------------------------+
-| port                         | listen +port               | connect with TLS             |
+| port                         | listen +port               | fail as hub only wants TLS   |
 +------------------------------+----------------------------+------------------------------+
-| +port                        | listen port                | fail. This is a known issue. |
+| +port                        | listen port                | fail as leaf only wants TLS  |
 +------------------------------+----------------------------+------------------------------+
 | +port                        | listen +port               | connect with TLS             |
 +------------------------------+----------------------------+------------------------------+
-
-* Currently, adding a bot with +port and connecting to a hub listening on port does not work. This will be remedied in a future release.
 
 To explicitly require all links to a hub be TLS-only (ie, prevent any plain text connection from being allowed), prefix the listen port in the hub configuration file with a plus (+) sign. Conversely, to force a leaf to only allow TLS (not plain text) connections with a hub, you must prefix the hub's listen port with a plus when adding it to the leaf via +bot/chaddr commands. If TLS negotiation fails and either the hub or leaf is set to require TLS, the connection is deliberately aborted and no clear text is ever sent by the TLS-requiring party.
 

--- a/doc/sphinx_source/mainDocs/tls.rst
+++ b/doc/sphinx_source/mainDocs/tls.rst
@@ -1,5 +1,5 @@
 TLS support
-Last revised: Jan 2, 2020
+Last revised: Jan 26, 2020
 
 ===========
 TLS support
@@ -36,15 +36,19 @@ custom one, as they take precedence over any system-wide paths.
 Usage
 -----
 
-By default and before 1.9.0, without additional configuration, TLS support
-will provide opportunistic encryption for botnet links. From 1.9.0 onward
-or for other connection types, TLS must be requested explicitly.
+As of v1.9.0, TLS support must be requested explicitly for botnet links.
+To create a TLS-enabled listening port or connect to a TLS-enabled listening
+port, you must prefix the port with a plus sign (+). If a port number could
+normally be omitted as part of a command syntax must be included (and prefixed)
+to enable TLS.
 
-Secure connections are created the same way as plaintext ones. The only
-difference is that you must prefix the port number with a plus sign.
-A port number that could be normally omitted, would have to be included
-to enable TLS. Scripts can also switch a regular, plaintext connection
-to TLS, using the starttls Tcl command.
+Scripts can also upgrade a regular plaintext connection to TLS via STARTTLS
+using the starttls Tcl command.
+
+Prior to v1.9.0, Eggdrop would use STARTTLS to automatically attempt to upgrade a 
+plain connection to an encrypted connection for botnet links, without any
+additional configuration (This was changed to provide users the flexibility
+to configure their own environments and assist in debugging).
 
 ^^^
 IRC
@@ -62,25 +66,27 @@ ssl-certificate for authentication.
 Botnet
 ^^^^^^
 
-Eggdrop can use TLS connections to protect botnet links if it is compiled with TLS support. TLS-enabled 1.9 bots are backwards compatible with bots that do not have TLS, whether because they are an earlier version or they were not compiled with TLS libraries. Before 1.9 two methods were used to create a TLS connection, depending on how the user configured the botnet: raw TLS sockets, and starttls. The difference was that a socket listening for TLS will first create a TLS connection before exchanging any eggdrop-specific data; a starttls connection will first establish the botnet link in the clear, then upgrade to a TLS connection (This means the nickname and, since v1.3.29, a challenge/response password hash are sent before TLS negotiation takes place- not the actual plaintext password). Since 1.9 only raw TLS sockets are used.
+Eggdrop can use TLS connections to protect botnet links if it is compiled with TLS support. As of version 1.9.0, only raw TLS sockets are used to protect a connection. By prefixing a listen port in the Eggdrop configuration with a plus (+), that specifies that port as a TLS-enabled port, and will only accept TLS connections (no plain text connections will be allowed). With two TLS-enabled Eggdrops, it graphically looks like this:
 
-By prefixing a listen port in the Eggdrop configuration with a plus (+), that specifies that port as a TLS-enabled port, and will only accept TLS connections (no plain text connections will be allowed). Additionally, Eggdrop 1.8 has starttls functionality, where a plain text connection can first be made to a non-TLS port (ie, one that is not prefixed with a plus) and then upgraded to a TLS connection. In Eggdrop 1.8 an automatic attempt for a starttls upgrade on all botnet connections was made, since 1.9 this can only be done with the starttls Tcl/bot command. With two TLS-enabled Eggdrops, it graphically looks like this:
++------------------------------+----------------------------+-------------------------------+
+| Leaf bot sets hub port as... | and Hub bot config uses... | the connection will...        |
++------------------------------+----------------------------+-------------------------------+
+| port                         | listen port                | be plain, but can be upgraded |
+|                              |                            | to TLS manually with the      |
+|                              |                            | starttls Tcl/bot command      |
++------------------------------+----------------------------+-------------------------------+
+| +port                        | listen +port               | connect with TLS              |
++------------------------------|----------------------------|-------------------------------+
+| port                         | listen +port               | fail as hub only wants TLS    |
++------------------------------+----------------------------+-------------------------------+
+| +port                        | listen port                | fail as leaf only wants TLS   |
++------------------------------+----------------------------+-------------------------------+
 
-+------------------------------+----------------------------+------------------------------+
-| Leaf bot sets hub port as... | and Hub bot config uses... | the connection will...       |
-+------------------------------+----------------------------+------------------------------+
-| port                         | listen port                | be plain but can be upgraded |
-|                              |                            | to TLS manually with the     |
-|                              |                            | starttls Tcl/bot command     |
-+------------------------------+----------------------------+------------------------------+
-| port                         | listen +port               | fail as hub only wants TLS   |
-+------------------------------+----------------------------+------------------------------+
-| +port                        | listen port                | fail as leaf only wants TLS  |
-+------------------------------+----------------------------+------------------------------+
-| +port                        | listen +port               | connect with TLS             |
-+------------------------------+----------------------------+------------------------------+
+In short, a bot added to your Eggdrop with a +port in the address can only connect to a bot listening with a +port in the config. Conversely, a bot added to your eggdrop without a + prefix can only connect to a bot listening without a + prefix in the config.
 
-To explicitly require all links to a hub be TLS-only (ie, prevent any plain text connection from being allowed), prefix the listen port in the hub configuration file with a plus (+) sign. Conversely, to force a leaf to only allow TLS (not plain text) connections with a hub, you must prefix the hub's listen port with a plus when adding it to the leaf via +bot/chaddr commands. If TLS negotiation fails and either the hub or leaf is set to require TLS, the connection is deliberately aborted and no clear text is ever sent by the TLS-requiring party.
+If TLS negotiation fails, the connection is deliberately aborted and no clear text is ever sent by the TLS-requiring party.
+
+Eggdrop can also upgrade a plaintext connection with the starttls Tcl command. To use this, a plaintext connection is first made to a non-TLS port (ie, one that is not prefixed with a plus), then the starttls command is issued to upgrade that link to a TLS connection. In the Eggdrop 1.8 series, Eggdrop automatically attempted a starttls upgrade on all botnet connections. As such, if a 1.8 Eggdrop connects to a plain listening port on a 1.9.0 or later Eggdrop, it will automatically attempt to upgrade the link to TLS.
 
 ^^^^^^^^^^
 Secure DCC

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -362,22 +362,6 @@ static void dcc_bot_new(int idx, char *buf, int x)
   else if (!strcasecmp(code, "passreq")) {
     char *pass = get_user(&USERENTRY_PASS, u);
 
-#ifdef TLS
-    /* We got a STARTTLS request earlier. Switch to ssl NOW. Doing this
-     * in two steps is necessary in order to synchronize the handshake.
-     */
-    if (dcc[idx].status & STAT_STARTTLS) {
-      dcc[idx].ssl = 1;
-      if (ssl_handshake(dcc[idx].sock, TLS_CONNECT, tls_vfybots, LOG_BOTS,
-                    dcc[idx].host, NULL)) {
-        putlog(LOG_BOTS, "*", "STARTTLS failed while linking to %s",
-               dcc[idx].nick);
-        if (!ssl_files_loaded)
-          putlog(LOG_BOTS, "*", "SSL cert and/or key file not loaded");
-      }
-      dcc[idx].status &= ~STAT_STARTTLS;
-    }
-#endif
     if (!pass || !strcmp(pass, "-")) {
       putlog(LOG_BOTS, "*", DCC_PASSREQ, dcc[idx].nick);
       dprintf(idx, "-\n");
@@ -390,18 +374,6 @@ static void dcc_bot_new(int idx, char *buf, int x)
       else
         dprintf(idx, "%s\n", pass);
     }
-#ifdef TLS
-  } else if (!strcasecmp(code, "starttls") && !dcc[idx].ssl) {
-    /* Mark the connection for secure communication, but don't switch yet.
-     * The hub has to send a plaintext passreq right after the starttls command
-     * and if we switch now, we'll break the handshake. Instead, we'll only
-     * send a confirmation to the peer and wait for the passreq.
-     */
-    putlog(LOG_BOTS, "*", "Got STARTTLS from %s. Replying...", dcc[idx].nick);
-    dcc[idx].status |= STAT_STARTTLS;
-    /* needs to have space to be distinguished from a plaintext password */
-    dprintf(idx, "starttls -\n");
-#endif
   } else if (!strcasecmp(code, "error"))
     putlog(LOG_BOTS, "*", DCC_LINKERROR, dcc[idx].nick, buf);
   /* Ignore otherwise */
@@ -644,17 +616,6 @@ static void dcc_chat_pass(int idx, char *buf, int atr)
       else
         putlog(LOG_BOTNETIN, "*", "[b<-%s] %s", dcc[idx].nick, buf);
     }
-#ifdef TLS
-    if (!strncasecmp(buf, "starttls ", 9)) {
-      dcc[idx].ssl = 1;
-      if (ssl_handshake(dcc[idx].sock, TLS_LISTEN, tls_vfybots, LOG_BOTS,
-                        dcc[idx].host, NULL)) {
-        killsock(dcc[idx].sock);
-        lostdcc(idx);
-      }
-      return;
-    }
-#endif
     /* No password set? */
     if (u_pass_match(dcc[idx].user, "-")) {
       makepass(pass);
@@ -1775,22 +1736,6 @@ static void dcc_telnet_pass(int idx, int atr)
     /* change here temp to use bot output */
     struct dcc_table *old = dcc[idx].type;
     dcc[idx].type = &DCC_BOT_NEW;
-#ifdef TLS
-  /* Ask the peer to switch to ssl communication. We'll continue using plain
-   * text, until it replies with starttls itself. Bots which don't support ssl
-   * will simply ignore the request and everything will go on as usual.
-   */
-    if (!dcc[idx].ssl) {
-      /* find number in socklist */
-      int i = findsock(dcc[idx].sock);
-      struct threaddata *td = threaddata();
-      /* mark socket to read next incoming at reduced len */
-      td->socklist[i].flags |= SOCK_SENTTLS;
-      /* Prefix with \n in case of newline-less ending stealth_prompt */
-      dprintf(idx, "\nstarttls\n");
-      putlog(LOG_BOTS, "*", "Sent STARTTLS to %s...", dcc[idx].nick);
-    }
-#endif
     /* Must generate a string consisting of our process ID and the current
      * time. The bot will add it's password to the end and use it to generate
      * an MD5 checksum (always 128bit). The checksum is sent back and this

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -559,9 +559,6 @@ struct dupwait_info {
 #define STAT_LINKING 0x00100    /* the bot is currently going through
                                  * the linking stage                     */
 #define STAT_AGGRESSIVE 0x00200 /* aggressively sharing with this bot    */
-#ifdef TLS
-#define STAT_STARTTLS   0x00400 /* have we sent a starttls request?      */
-#endif
 
 /* Flags for listening sockets */
 #define LSTN_PUBLIC  0x000001   /* No access restrictions               */
@@ -649,10 +646,6 @@ typedef struct {
 #define SOCK_VIRTUAL    0x0200  /* not-connected socket (dont read it!) */
 #define SOCK_BUFFER     0x0400  /* buffer data; don't notify dcc funcs  */
 #define SOCK_TCL        0x0800  /* tcl socket, don't do anything on it  */
-#ifdef TLS
-#  define SOCK_SENTTLS  0x1000  /* Socket that awaits a starttls in the
-                                 * next read                            */
-#endif
 
 /* Flags to sock_has_data
  */

--- a/src/net.c
+++ b/src/net.c
@@ -952,12 +952,6 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
                      ERR_error_string(ERR_get_error(), 0), err);
             x = -1;
           }
-        } else if (slist[i].flags & SOCK_SENTTLS) {
-          /* We are awaiting a reply on our "starttls", only read
-           * strlen("starttls -\n") bytes so we don't accidentally
-           * read the Client Hello from the ssl handshake */
-          x = read(slist[i].sock, s, strlen("starttls -\n"));
-          slist[i].flags &= ~SOCK_SENTTLS;
         } else
           x = read(slist[i].sock, s, grab);
       }


### PR DESCRIPTION
Found by:
Patch by: Cizzle
Fixes: #535 

One-line summary: Now only TLS-to-TLS and plain-to-plain botlinks are allowed; although plain links can still be upgraded manually.

Also see #552. 