### PR TITLE
Add B64_NTOP_CALCULATE_SIZE and B64_PTON_CALCULATE_SIZE macros

### DIFF
--- a/src/compat/base64.h
+++ b/src/compat/base64.h
@@ -23,6 +23,9 @@
 #ifndef _EGG_COMPAT_BASE64_H_
 #define _EGG_COMPAT_BASE64_H_
 
+#define B64_NTOP_CALCULATE_SIZE(x) ((x + 2) / 3 * 4)
+#define B64_PTON_CALCULATE_SIZE(x) (x * 3 / 4)
+
 #ifndef HAVE_BASE64
 int b64_ntop(u_char const *, size_t, char *, size_t);
 int b64_pton(const char *, u_char *, size_t);

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1148,12 +1148,8 @@ static int tryauthenticate(char *from, char *msg)
   char src[(sizeof sasl_username) + (sizeof sasl_username) +
            (sizeof sasl_password)] = "";
   char *s;
-  /* 400-byte chunk, see: https://ircv3.net/specs/extensions/sasl-3.1.html
-   * base64 padding */
-  #ifndef MAX
-    #define MAX(a,b) (((a)>(b))?(a):(b))
-  #endif
-  unsigned char dst[((MAX((sizeof src), 400) + 2) / 3) << 2] = "";
+  /* 400-byte chunk, see: https://ircv3.net/specs/extensions/sasl-3.1.html */
+  unsigned char dst[400] = "";
 #ifdef TLS
   size_t olen;
   unsigned char *dst2;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Simplify sasl code (400 is enough for everybody :P), add general B64_NTOP_CALCULATE_SIZE and B64_PTON_CALCULATE_SIZE macros to base64.h, will be used by pbkdf2 module later.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
No change in behaviour expected whatsoever