### PR TITLE
Prevent double-tap of raw/t actions

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2500,7 +2500,44 @@ static int gotnotice(char *from, char *msg)
   return 0;
 }
 
+static int dummy() {
+  return 0;
+}
+
 static cmd_t irc_raw[] = {
+  {"324",     "",   (IntFunc) dummy,       NULL},
+  {"352",     "",   (IntFunc) dummy,       NULL},
+  {"354",     "",   (IntFunc) dummy,       NULL},
+  {"315",     "",   (IntFunc) dummy,       NULL},
+  {"367",     "",   (IntFunc) dummy,       NULL},
+  {"368",     "",   (IntFunc) dummy,       NULL},
+  {"403",     "",   (IntFunc) dummy,       NULL},
+  {"405",     "",   (IntFunc) dummy,       NULL},
+  {"471",     "",   (IntFunc) dummy,       NULL},
+  {"473",     "",   (IntFunc) dummy,       NULL},
+  {"474",     "",   (IntFunc) dummy,       NULL},
+  {"475",     "",   (IntFunc) dummy,       NULL},
+  {"INVITE",  "",   (IntFunc) dummy,       NULL},
+  {"TOPIC",   "",   (IntFunc) dummy,       NULL},
+  {"331",     "",   (IntFunc) dummy,       NULL},
+  {"332",     "",   (IntFunc) dummy,       NULL},
+  {"JOIN",    "",   (IntFunc) dummy,       NULL},
+  {"PART",    "",   (IntFunc) dummy,       NULL},
+  {"KICK",    "",   (IntFunc) dummy,       NULL},
+  {"NICK",    "",   (IntFunc) dummy,       NULL},
+  {"QUIT",    "",   (IntFunc) dummy,       NULL},
+  {"PRIVMSG", "",   (IntFunc) dummy,       NULL},
+  {"NOTICE",  "",   (IntFunc) dummy,       NULL},
+  {"MODE",    "",   (IntFunc) dummy,       NULL},
+  {"346",     "",   (IntFunc) dummy,       NULL},
+  {"347",     "",   (IntFunc) dummy,       NULL},
+  {"348",     "",   (IntFunc) dummy,       NULL},
+  {"349",     "",   (IntFunc) dummy,       NULL},
+  {NULL,      NULL, NULL,                  NULL}
+};
+
+
+static cmd_t irc_rawt[] = {
   {"324",     "",   (IntFunc) got324,       "irc:324"},
   {"352",     "",   (IntFunc) got352,       "irc:352"},
   {"354",     "",   (IntFunc) got354,       "irc:354"},

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1183,7 +1183,7 @@ static char *irc_close()
   rem_builtins(H_dcc, irc_dcc);
   rem_builtins(H_msg, C_msg);
   rem_builtins(H_raw, irc_raw);
-  rem_builtins(H_rawt, irc_raw);
+  rem_builtins(H_rawt, irc_rawt);
   rem_tcl_commands(tclchan_cmds);
   rem_help_reference("irc.help");
   del_hook(HOOK_MINUTELY, (Function) check_expired_chanstuff);
@@ -1286,7 +1286,7 @@ char *irc_start(Function *global_funcs)
   add_builtins(H_dcc, irc_dcc);
   add_builtins(H_msg, C_msg);
   add_builtins(H_raw, irc_raw);
-  add_builtins(H_rawt, irc_raw);
+  add_builtins(H_rawt, irc_rawt);
   add_tcl_commands(tclchan_cmds);
   add_help_reference("irc.help");
   H_topc = add_bind_table("topc", HT_STACKABLE, channels_5char);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2061,7 +2061,7 @@ static char *server_close()
   clearq(serverlist);
   rem_builtins(H_dcc, C_dcc_serv);
   rem_builtins(H_raw, my_raw_binds);
-  rem_builtins(H_rawt, my_raw_binds);
+  rem_builtins(H_rawt, my_rawt_binds);
   rem_builtins(H_ctcp, my_ctcps);
   /* Restore original commands. */
   del_bind_table(H_wall);
@@ -2284,6 +2284,7 @@ char *server_start(Function *global_funcs)
   H_ctcp = add_bind_table("ctcp", HT_STACKABLE, server_6char);
   H_out = add_bind_table("out", HT_STACKABLE, server_out);
   add_builtins(H_raw, my_raw_binds);
+  add_builtins(H_rawt, my_rawt_binds);
   add_builtins(H_dcc, C_dcc_serv);
   add_builtins(H_ctcp, my_ctcps);
   add_help_reference("server.help");

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1597,7 +1597,50 @@ static int gotcap(char *from, char *msg) {
   return 1;
 }
 
+static int dummy() {
+  return 0;
+}
+
 static cmd_t my_raw_binds[] = {
+  {"PRIVMSG",      "",   (IntFunc) dummy,           NULL},
+  {"NOTICE",       "",   (IntFunc) dummy,           NULL},
+  {"MODE",         "",   (IntFunc) dummy,           NULL},
+  {"PING",         "",   (IntFunc) dummy,           NULL},
+  {"PONG",         "",   (IntFunc) dummy,           NULL},
+  {"WALLOPS",      "",   (IntFunc) dummy,           NULL},
+  {"001",          "",   (IntFunc) dummy,           NULL},
+  {"303",          "",   (IntFunc) dummy,           NULL},
+  {"311",          "",   (IntFunc) dummy,           NULL},
+  {"318",          "",   (IntFunc) dummy,           NULL},
+  {"410",          "",   (IntFunc) dummy,           NULL},
+  {"417",          "",   (IntFunc) dummy,           NULL},
+  {"421",          "",   (IntFunc) dummy,           NULL},
+  {"432",          "",   (IntFunc) dummy,           NULL},
+  {"433",          "",   (IntFunc) dummy,           NULL},
+  {"437",          "",   (IntFunc) dummy,           NULL},
+  {"438",          "",   (IntFunc) dummy,           NULL},
+  {"451",          "",   (IntFunc) dummy,           NULL},
+  {"442",          "",   (IntFunc) dummy,           NULL},
+  {"465",          "",   (IntFunc) dummy,           NULL},
+  {"900",          "",   (IntFunc) dummy,           NULL},
+  {"903",          "",   (IntFunc) dummy,           NULL},
+  {"904",          "",   (IntFunc) dummy,           NULL},
+  {"905",          "",   (IntFunc) dummy,           NULL},
+  {"906",          "",   (IntFunc) dummy,           NULL},
+  {"908",          "",   (IntFunc) dummy,           NULL},
+  {"NICK",         "",   (IntFunc) dummy,           NULL},
+  {"ERROR",        "",   (IntFunc) dummy,           NULL},
+/* ircu2.10.10 has a bug when a client is throttled ERROR is sent wrong */
+  {"ERROR:",       "",   (IntFunc) dummy,           NULL},
+  {"KICK",         "",   (IntFunc) dummy,           NULL},
+  {"CAP",          "",   (IntFunc) dummy,           NULL},
+  {"AUTHENTICATE", "",   (IntFunc) dummy,           NULL},
+  {"TAGMSG",       "",   (IntFunc) dummy,           NULL},
+  {NULL,           NULL, NULL,                      NULL}
+};
+
+
+static cmd_t my_rawt_binds[] = {
   {"PRIVMSG",      "",   (IntFunc) gotmsg,          NULL},
   {"NOTICE",       "",   (IntFunc) gotnotice,       NULL},
   {"MODE",         "",   (IntFunc) gotmode,         NULL},


### PR DESCRIPTION
Found by: Geo, tabb
Patch by: Geo
Fixes: 

One-line summary:
Don't double-tap check_tcl_raw* sub-calls

Additional description (if needed):
calling both check_tcl_raw and check_tcl_rawt led to double-execution of things like gotmode, gotmsg, etc. This replaces the _raw function with a dummy set of values to prevent calling the got* functions, but still allows the bind to function. 

Test cases demonstrating functionality (if applicable):
```
.tcl proc rawproc {from key text} {putlog "raw proc says $text"}
.tcl proc rawtproc {from key text tag} {putlog "rawt proc says $text"}
.tcl bind raw - PRIVMSG rawproc
.tcl bind rawt - PRIVMSG rawtproc 


[05:06:28] [@] :foo!bar@unaffiliated/goo PRIVMSG #eggdroptest :sdf
[05:06:28] triggering bind rawtproc
[05:06:28] rawt proc says #eggdroptest :sdf
[05:06:28] triggering bind rawproc
[05:06:28] raw proc says #eggdroptest :sdf
[05:10:55] <foo> sdf
```
RAW and RAWT both work, only a single instance of the text is displayed

