### PR TITLE
Remove deprecated RAND_status() check

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1683,7 +1683,6 @@ AC_DEFUN([EGG_TLS_DETECT],
           AC_DEFINE([__int64], [long long], [Define this to a 64-bit type on Cygwin to satisfy OpenSSL dependencies.])
         ])
       fi
-      AC_CHECK_FUNCS([RAND_status])
       AC_DEFINE(TLS, 1, [Define this to enable SSL support.])
       AC_CHECK_FUNC(ASN1_STRING_get0_data,
         AC_DEFINE([egg_ASN1_string_data], [ASN1_STRING_get0_data], [Define this to ASN1_STRING_get0_data when using OpenSSL 1.1.0+, ASN1_STRING_data otherwise.])

--- a/src/tls.c
+++ b/src/tls.c
@@ -79,15 +79,14 @@ static int ssl_seed(void)
   static char rand_file[120];
   FILE *fh;
 
-#ifdef HAVE_RAND_STATUS
   if (RAND_status())
     return 0;     /* Status OK */
-#endif
   /* If '/dev/urandom' is present, OpenSSL will use it by default.
    * Otherwise we'll have to generate pseudorandom data ourselves,
    * using system time, our process ID and some uninitialized static
    * storage.
    */
+  putlog(LOG_MISC, "*", "WARNING: TLS: PRNG has not been sufficiently seeded. Seeding now.");
   if ((fh = fopen("/dev/urandom", "r"))) {
     fclose(fh);
     return 0;
@@ -105,10 +104,8 @@ static int ssl_seed(void)
     RAND_seed(&c, sizeof(c));
     RAND_seed(stackdata, sizeof(stackdata));
   }
-#ifdef HAVE_RAND_STATUS
   if (!RAND_status())
     return 2; /* pseudo random data still not enough */
-#endif
   return 0;
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Remove deprecated RAND_status() check

Additional description (if needed):
RAND_status() have been added in OpenSSL 0.9.5 (Year 2000)
Eggdrop depends on openssl 0.9.8+, see https://github.com/eggheads/eggdrop/blob/develop/aclocal.m4#L1677

Test cases demonstrating functionality (if applicable):
Simple compile and run test was fine.