### PR TITLE
Clear servers prior to rehash

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1900,7 +1900,14 @@ static void server_5minutely()
 
 static void server_prerehash()
 {
+  struct server_list *x = serverlist;
+  char port[7];
+
   strlcpy(oldnick, botname, sizeof oldnick);
+  for (; x; x = x->next) {
+    egg_snprintf(port, sizeof port, "%d", x->port);
+    del_server(x->name, port);
+  }
 }
 
 static void server_postrehash()

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -85,8 +85,8 @@
 #define exclusive_binds (*(int *)(server_funcs[39]))
 /* 40 - 43 */
 #define H_out (*(p_tcl_bind_list *)(server_funcs[40]))
-#define addserver ((void(*)(char *))server_funcs[41])
-#define delserver ((void(*)(char *))server_funcs[42])
+/* Was (briefly!) addserver */
+/* Was (briefly!) delserver */
 #define net_type_int (*(int *)(server_funcs[43]))
 #endif /* MAKING_SERVER */
 


### PR DESCRIPTION
Found by: tabb
Patch by: Geo
Fixes: 

Additional description (if needed):
Because of the new addserver command (instead of old 'set servers {} ), everytime a bot was rehashed, the config file was re-read and addserver would re-add the servers listed to the server list. Restart and reload are not affected.

Test cases demonstrating functionality (if applicable):
```
.servers
Server list:
  irc.doo.com:19999 (password)
  chat.freenode.net:+7000 
  barjavel.freenode.net:+7000 
End of server list.
.rehash
Rehashing.
[05:48:49] Writing user file...
[05:48:48] Writing channel file...
[05:48:48] Rehashing ...
[05:48:48] Userfile loaded, unpacking...
.servers
Server list:
  irc.doo.com:19999 (password)
  chat.freenode.net:+7000 
  barjavel.freenode.net:+7000 
End of server list.
