### PR TITLE
Restrict b/e/I to <63 char hostmask

### DIFF
--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -56,6 +56,7 @@
 
 
 /* Handy string lengths */
+#define HOSTMAX     63            /* DNS RFC 1035, IRC RFC 2812          */
 #define UHOSTMAX    291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
 #define DIRMAX      512           /* paranoia                            */
 #define LOGLINEMAX  9000          /* for misc.c/putlog() <cybah>         */

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1,5 +1,4 @@
 /*
- * cmdschan.c -- part of channels.mod
  *   commands from a user via dcc that cause server interaction
  */
 /*
@@ -27,15 +26,16 @@ static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
 
-/* RFC 2812, hostmasks can't be longer than 63 characters */
-void truncate_host(char *s) {
+/* RFC 1035/2812- hostmasks can't be longer than 63 characters */
+void truncate_mask_hostname(char *s) {
 char *r = NULL;
 
   if ( (r = strchr(s, '@')) ) {
     r++;
-    if (strlen(r)  > 64) { /* 63 + NULL */
-      strcpy(r+62, "*");   /* 63rd character of string */
-      strcpy(r+63, "");    /* 64th character null terminated */
+    if (strlen(r)  > (HOSTMAX + 1)) { /* 63 + NULL */
+      r[62] = '*';
+      r[63] = 0;
+      putlog(LOG_MISC, "*", "Maximum hostlength exceeded, truncating");
     }
   }
 }
@@ -142,7 +142,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
         return;
       }
     }
-    truncate_host(s);
+    truncate_mask_hostname(s);
     if (chan) {
       u_addban(chan, s, dcc[idx].nick, par,
                expire_time ? now + expire_time : 0, 0);
@@ -272,7 +272,7 @@ static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
     else
       strlcpy(s, who, sizeof s);
 
-    truncate_host(s);
+    truncate_mask_hostname(s);
     if (chan) {
       u_addexempt(chan, s, dcc[idx].nick, par,
                   expire_time ? now + expire_time : 0, 0);
@@ -396,7 +396,7 @@ static void cmd_pls_invite(struct userrec *u, int idx, char *par)
     else
       strlcpy(s, who, sizeof s);
 
-    truncate_host(s);
+    truncate_mask_hostname(s);
     if (chan) {
       u_addinvite(chan, s, dcc[idx].nick, par,
                   expire_time ? now + expire_time : 0, 0);

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -32,7 +32,7 @@ char *r = NULL;
 
   if ( (r = strchr(s, '@')) ) {
     r++;
-    if (strlen(r)  > (HOSTMAX + 1)) { /* 63 + NULL */
+    if (strlen(r)  > HOSTMAX) {
       r[62] = '*';
       r[63] = 0;
       putlog(LOG_MISC, "*", "Maximum hostlength exceeded, truncating");

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -27,9 +27,22 @@ static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
 
+/* RFC 2812, hostmasks can't be longer than 63 characters */
+void truncate_host(char *s) {
+char *r = NULL;
+
+  if ( (r = strchr(s, '@')) ) {
+    r++;
+    if (strlen(r)  > 64) { /* 63 + NULL */
+      strcpy(r+62, "*");   /* 63rd character of string */
+      strcpy(r+63, "");    /* 64th character null terminated */
+    }
+  }
+}
+
 static void cmd_pls_ban(struct userrec *u, int idx, char *par)
 {
-  char *chname, *who, s[UHOSTLEN], s1[UHOSTLEN], *p, *p_expire, *r;
+  char *chname, *who, s[UHOSTLEN], s1[UHOSTLEN], *p, *p_expire;
   long expire_foo;
   unsigned long expire_time = 0;
   int sticky = 0;
@@ -129,14 +142,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
         return;
       }
     }
-    /* RFC 2812, hostmasks can't be longer than 63 characters */
-    if ( (r = strchr(s, '@')) ) {
-      r++;
-      if (strlen(r)  > 64) { /* 63 + NULL */
-        strcpy(r+62, "*");   /* 63rd character of string */
-        strcpy(r+63, "");    /* 64th character null terminated */
-      }
-    }
+    truncate_host(s);
     if (chan) {
       u_addban(chan, s, dcc[idx].nick, par,
                expire_time ? now + expire_time : 0, 0);
@@ -179,7 +185,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
 
 static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
 {
-  char *chname, *who, s[UHOSTLEN], *p, *p_expire, *r;
+  char *chname, *who, s[UHOSTLEN], *p, *p_expire;
   long expire_foo;
   unsigned long expire_time = 0;
   struct chanset_t *chan = NULL;
@@ -266,14 +272,7 @@ static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
     else
       strlcpy(s, who, sizeof s);
 
-    /* RFC 2812, hostmasks can't be longer than 63 characters */
-    if ( (r = strchr(s, '@')) ) {
-      r++;
-      if (strlen(r)  > 64) { /* 63 + NULL */
-        strcpy(r+62, "*");   /* 63rd character of string */
-        strcpy(r+63, "");    /* 64th character null terminated */
-      }
-    }
+    truncate_host(s);
     if (chan) {
       u_addexempt(chan, s, dcc[idx].nick, par,
                   expire_time ? now + expire_time : 0, 0);
@@ -309,7 +308,7 @@ static void cmd_pls_exempt(struct userrec *u, int idx, char *par)
 
 static void cmd_pls_invite(struct userrec *u, int idx, char *par)
 {
-  char *chname, *who, s[UHOSTLEN], *p, *p_expire, *r;
+  char *chname, *who, s[UHOSTLEN], *p, *p_expire;
   long expire_foo;
   unsigned long expire_time = 0;
   struct chanset_t *chan = NULL;
@@ -397,14 +396,7 @@ static void cmd_pls_invite(struct userrec *u, int idx, char *par)
     else
       strlcpy(s, who, sizeof s);
 
-    /* RFC 2812, hostmasks can't be longer than 63 characters */
-    if ( (r = strchr(s, '@')) ) {
-      r++;
-      if (strlen(r)  > 64) { /* 63 + NULL */
-        strcpy(r+62, "*");   /* 63rd character of string */
-        strcpy(r+63, "");    /* 64th character null terminated */
-      }
-    }
+    truncate_host(s);
     if (chan) {
       u_addinvite(chan, s, dcc[idx].nick, par,
                   expire_time ? now + expire_time : 0, 0);


### PR DESCRIPTION
Found by: @michaelortmann 
Patch by: Geo
Fixes: #887 

One-line summary:
Restrict b/e/I to <63 char hostmask

Additional description (if needed):
As pointed out in the thread started by @michaelortmann that led to spirited discussion in channel, the ban/exempt/invite maximum of 70 did not seem to reflect the rfc. 2812 states 
```<hostname> has a maximum length of 63 characters.  This is a limitation of the protocol as internet hostnames (in particular) can be longer.  Such restriction is necessary because IRC messages are limited to 512 characters in length. Clients connecting from a host which name is longer than 63 characters are  registered using the host (numeric) address instead of the host name.``` 
As previously written, eggdrop was checking a ban mask length in its entirety, to include nick and ident, and then truncating to a 70-char length for the mask as a whole. This patch updates the check to only look at the hostname portion of a mask, not the mask in its entirety, and then truncate appropriately. 


Test cases demonstrating functionality (if applicable):
```
.+ban 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.623456789
New ban: 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.62* (requested)

```
```
.+invite 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.623456789
New invite: 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.62* (requested)
```
```
.+exempt 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.623456789
New exempt: 123456789!987654321@023456789.123456789.223456789.323456789.423456789.523456789.62* (requested)
```