### PR TITLE
Fix for the explicit_bzero commit

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -594,7 +594,7 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
   ret = strcmp(digest_string, remote_digest);
   explicit_bzero(digest_string, sizeof digest_string);
   explicit_bzero(digest, sizeof digest);
-  explicit_bzero(password, sizeof password);
+  explicit_bzero(password, strlen(password));
 
   if (!ret)
     return 1;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
sizeof -> strlen

Additional description (if needed):
Fix another shot into my own knee.

Test cases demonstrating functionality (if applicable):
