### PR TITLE
Fix incorrect missing-EC logic branches

### DIFF
--- a/doc/sphinx_source/firstinstall/firstinstall.rst
+++ b/doc/sphinx_source/firstinstall/firstinstall.rst
@@ -253,3 +253,34 @@ By default, it should create an entry that looks similar to::
     0,10,20,30,40,50 * * * * /home/user/bot/scripts/YourEggdrop.botchk 2>&1
 
 This will run the generated botchk script every ten minutes and restart your Eggdrop if it is not running during the check. Also note that if you run autobotchk from the scripts directory, you'll have to manually specify your config file location with the -dir option. To remove a crontab entry, use ``crontab -e`` to open the crontab file in your system's default editor and remove the crontab line.
+
+Setting up SASL authentication
+------------------------------
+
+Simple Authentication and Security Layer (SASL) is becoming a prevelant method of authenticating with IRC services such as NickServ prior to your client finalizing a connection to the IRC server, eliminating the need to /msg NickServ to identify yourself. In other words, you can authenticate with NickServ and do things like receive a cloaked hostmask before your client ever appears on the IRC server. Eggdrop supports three methods of SASL authentication, set via the sasl-mechanism setting:
+
+* PLAIN: To use this method, set sasl-mechanism to 0. This method passes the username and password (set in the sasl-username and sasl-password config file settings) to the IRC server in plaintext. If you only connect to the IRC server using a connection protected by SSL/TLS this is a generally safe method of authentication; however you probably want to avoid this method if you connect to a server on a non-protected port as the exchange itself is not encrypted.
+
+* ECDSA-NIST256P-CHALLENGE: To use this method, set sasl-method to 1. This method uses a public/private keypair to authenticate, so no username/password is required. Not all servers support this method. If your server does support this, you you must generate a certificate pair using::
+
+    openssl ecparam -genkey -name prime256v1 -out eggdrop-ecdsa.pem
+
+You will need to determine your public key fingerprint by using::
+
+    openssl ec -noout -text -conv_form compressed -in eggdrop-ecdsa.pem | grep '^pub:' -A 3 | tail -n 3 | tr -d ' \n:' | xxd -r -p | base64
+
+Then, authenticate with your NickServ service and register your public certificate with NickServ. You can view your public key  On Freenode for example, it is done by::
+
+    /msg NickServ set pubkey <fingerprint string from above goes here>
+
+* EXTERNAL: To use this method, set sasl-method to 2. This method allows you to use other TLS certificates to connect to the IRC server, if the IRC server supports it. An EXTERNAL authentication method usually requires you to connect to the IRC server using SSL/TLS. There are many ways to generate certificates; one such way is generating your own certificate using::
+
+    openssl req -new -x509 -nodes -keyout eggdrop.key -out eggdrop.crt
+
+You will need to determine yoru public key fingerprint by using::
+
+    openssl x509 -in eggdrop.crt -outform der | sha1sum -b | cut -d' ' -f1
+
+Then, ensure you have those keys loaded in the ssl-privatekey and ssl-certificate settings in the config file. Finally, to add this certificate to your NickServ account, type::
+
+    /msg NickServ cert add <fingerprint string from above goes here>

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1074,13 +1074,20 @@ addserver ssl.example.net +7000
 #set sasl 0
 
 # Set SASL mechanism to authenticate with.
-# For the ECDSA-NIST256P method, set the certificate location in the ecdsa-key
-# setting below. For the EXTERNAL method, the ssl certificates to use are set
-# via the ssl-certificate and ssl-privatekey settings in the SSL section above.
 # Options are:
-#   0 = PLAIN
-#   1 = ECDSA-NIST256P-CHALLENGE
-#   2 = EXTERNAL
+#   0 = PLAIN                       (normal user/pass exchange, only encrypted
+#                                    if connected to the IRC server with a
+#                                    SSL/TLS connection)
+#
+#   1 = ECDSA-NIST256P-CHALLENGE    (Uses a certificate; usually requires a
+#                                    public key to be registered with NickServ
+#                                    or other similar service. Set certificate
+#                                    to use in sasl-ecdsa-key setting below)
+#
+#   2 = EXTERNAL                    (Some other method you set up. Certificates
+#                                    used are defined in ssl-certificate and
+#                                    ssl-privatekey settings in SSL section)
+#
 #set sasl-mechanism 0
 
 # Set username to authenticate to IRC NickServ with
@@ -1093,7 +1100,7 @@ addserver ssl.example.net +7000
 # ecdsa-nist256p-challenge. An ECDSA certificate can be generated with the
 # command:
 #   openssl ecparam -genkey -name prime256v1 -out eggdrop-ecdsa.pem
-#set sasl-ecdsa-key "/home/user/eggdrop/eggdrop-ecdsa.pem"
+#set sasl-ecdsa-key "eggdrop-ecdsa.pem"
 
 # Set SASL failure action
 # If SASL authentication fails, do you want to connect to the server anyway?

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2295,13 +2295,22 @@ char *server_start(Function *global_funcs)
   add_tcl_ints(my_tcl_ints);
 #ifdef TLS
 #ifndef HAVE_EVP_PKEY_GET1_EC_KEY
-if (sasl) {
-  if (sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) {
-    fatal("ERROR: NIST256P functionality missing from OpenSSL libs, please "\
-        "choose a different SASL method", 0);
+  if (sasl) {
+    if (sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) {
+      fatal("ERROR: NIST256 functionality missing from your TLS libs, please "
+          "choose a different SASL method", 0);
+    }
   }
-}
 #endif /* HAVE_EVP_PKEY_GET1_EC_KEY */
+#else  /* TLS */
+  if (sasl) {
+    if ((sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) ||
+            (sasl_mechanism == SASL_MECHANISM_EXTERNAL)) {
+        fatal("ERROR: The selected SASL authentication method requires TLS "
+                "libraries which are not installed on this machine. Please "
+                "choose the PLAIN method in your config.");
+    }
+  }
 #endif /* TLS */
   add_tcl_commands(my_tcl_cmds);
   add_tcl_coups(my_tcl_coups);

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1606,7 +1606,7 @@ static int gotcap(char *from, char *msg) {
       }
 #else
         if (sasl_mechanism != SASL_MECHANISM_PLAIN)
-	  return sasl_error("TLS libs not present, try PLAIN method, aborting authentication");
+	      return sasl_error("TLS libs not present, try PLAIN method, aborting authentication");
 #endif
       }
 #endif

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1241,6 +1241,9 @@ static int tryauthenticate(char *from, char *msg)
   unsigned char *dst2;
   FILE *fp;
   EVP_PKEY *privateKey;
+#else /* HAVE_EVP_PKEY_GET1_EC_KEY */
+  putlog(LOG_DEBUG, "*", "SASL: TLS libs missing EC support, try PLAIN or EXTERNAL method");
+  return 1;
 #endif /* HAVE_EVP_PKEY_GET1_EC_KEY */
   putlog(LOG_SERV, "*", "SASL: got AUTHENTICATE %s", msg);
   if (msg[0] == '+') {
@@ -1324,9 +1327,6 @@ static int tryauthenticate(char *from, char *msg)
     nfree(dst2);
     putlog(LOG_SERV, "*", "SASL: put AUTHENTICATE Response %s", dst);
     dprintf(DP_MODE, "AUTHENTICATE %s\n", dst);
-#else /* HAVE_EVP_PKEY_GET1_EC_KEY */
-    putlog(LOG_DEBUG, "*", "SASL: TLS libs missing EC support, try PLAIN or EXTERNAL method");
-    return 1;
 #endif /* HAVE_EVP_PKEY_GET1_EC_KEY */
 #else /* TLS */
     putlog(LOG_DEBUG, "*", "SASL: TLS libs not present, try PLAIN method");

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1588,13 +1588,6 @@ static int gotcap(char *from, char *msg) {
 #ifndef HAVE_EVP_PKEY_GET1_EC_KEY
       if (sasl_mechanism != SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) {
 #endif
-        /*
-        TODO: the old sasl code, before cap pr, was doing cap request only
-        under certain conditions, see the if TLS statement
-        above.
-        putlog(LOG_SERV, "*", "CAP: put CAP REQ :sasl");
-        dprintf(DP_MODE, "CAP REQ :sasl\n");
-        */
         putlog(LOG_SERV, "*", "SASL: put AUTHENTICATE %s",
             SASL_MECHANISMS[sasl_mechanism]);
         dprintf(DP_MODE, "AUTHENTICATE %s\n", SASL_MECHANISMS[sasl_mechanism]);
@@ -1604,12 +1597,13 @@ static int gotcap(char *from, char *msg) {
 #ifdef TLS
         return sasl_error("TLS libs missing EC support, try PLAIN or EXTERNAL method, aborting authentication");
       }
-#else
-        if (sasl_mechanism != SASL_MECHANISM_PLAIN)
+#else /* TLS */
+        if (sasl_mechanism != SASL_MECHANISM_PLAIN) {
 	      return sasl_error("TLS libs not present, try PLAIN method, aborting authentication");
-#endif
+        }
       }
-#endif
+#endif /* TLS */
+#endif /* HAVE_EVP_PKEY */
     } else {
       dprintf(DP_MODE, "CAP END\n");
       return 0;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1279,9 +1279,9 @@ static int tryauthenticate(char *from, char *msg)
     }
     putlog(LOG_SERV, "*", "SASL: put AUTHENTICATE %s", dst);
     dprintf(DP_MODE, "AUTHENTICATE %s\n", dst);
+  } else {
 #ifdef TLS
 #ifdef HAVE_EVP_PKEY_GET1_EC_KEY
-  } else {
     putlog(LOG_SERV, "*", "SASL: got AUTHENTICATE Challenge");
     olen = b64_pton(msg, dst, sizeof dst);
     if (olen == -1) {

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1602,8 +1602,8 @@ static int gotcap(char *from, char *msg) {
 #ifndef HAVE_EVP_PKEY_GET1_EC_KEY
       } else {
 #ifdef TLS
-        if (sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE)
-          return sasl_error("TLS libs missing EC support, try PLAIN or EXTERNAL method, aborting authentication");
+        return sasl_error("TLS libs missing EC support, try PLAIN or EXTERNAL method, aborting authentication");
+      }
 #else
         if (sasl_mechanism != SASL_MECHANISM_PLAIN)
 	  return sasl_error("TLS libs not present, try PLAIN method, aborting authentication");


### PR DESCRIPTION
Found by: PeGaSuS
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
Fix for:
```
[21:23:18] SASL: put AUTHENTICATE PLAIN
[21:23:18] SASL: got AUTHENTICATE +
[21:23:18] SASL: put AUTHENTICATE ********
[21:23:18] SASL: TLS libs missing EC support, try PLAIN or EXTERNAL method
```

Test cases demonstrating functionality (if applicable):
**Test 1:**
compiled fine with and without --disable-tls
**Test 2:**
test under system without ec (fedora 10)
```
.set sasl-mechanism
Currently: 1
.jump chat.freenode.net
[...]
[05:06:48] CAP: Current Negotiations sasl with verne.freenode.net
[05:06:48] SASL: TLS libs missing EC support, try PLAIN or EXTERNAL method, aborting authentication
```