### PR TITLE
ident mod - remove oidentd.conf after use

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -52,8 +52,8 @@ static cmd_t ident_raw_builtin_off[] = {
 };
 
 static cmd_t ident_raw_oident_off[] = {
-  {"001", "",   (IntFunc) ident_oident_off,  "ident:001"},
-  {NULL,  NULL, NULL,                        NULL       }
+  {"001", "",   (IntFunc) ident_oident_off, "ident:001"},
+  {NULL,  NULL, NULL,                       NULL       }
 };
 
 char path[121]; /* oidentd.conf */

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -181,7 +181,7 @@ static void ident_builtin_off()
 static void ident_oident_off()
 {
   debug1("Ident: Removing %s.", path);
-  if (remove(path) < 0)
+  if (unlink(path) < 0)
     putlog(LOG_MISC, "*", "Ident error: %s", strerror(errno));
   rem_builtins(H_raw, ident_raw_oident_off);
 }


### PR DESCRIPTION
Found by: PeGaSuS-Coder
Patch by: michaelortmann
Fixes: #942

One-line summary:
Remove oidentd.conf after use

Additional description (if needed):
So far so good, but note, that this opens a tiny race for when another user / process writes .oidentd.conf between eggies creation / writing and removing. No problem for eggdrop, but the other user / process could have its file removed. We could do a sanity check before removing the file. That would minimize the race time window, but its not possible to close it. Let me know, if you want that sanity check which means, eggdrop would check, if the file it will remove looks like the one it created / wrote.

Test cases demonstrating functionality (if applicable):
```
[01:11:29] Trying server 127.0.0.1:6667
[01:11:29] Ident: Creating / writing /home/michael/.oidentd.conf.
[01:11:29] net: open_telnet_raw(): idx 3 host 127.0.0.1 port 6667 ssl 0
[01:11:29] net: connect! sock 8
[01:11:29] Connected to 127.0.0.1
[01:11:30] Ident: Removing /home/michael/.oidentd.conf.
[01:11:30] triggering bind quotepass_unbind
[01:11:30] triggered bind quotepass_unbind, user 0.027ms sys 0.000ms
[01:11:30] triggering bind evnt:init_server
[01:11:30] triggered bind evnt:init_server, user 0.076ms sys 0.000ms
```