### PR TITLE
Cleanup: setpgid() is POSIX.1-2001

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AX_TYPE_SOCKLEN_T
 AX_CREATE_STDINT_H([eggint.h])
 
 # Checks for functions and their arguments.
-AC_CHECK_FUNCS([clock dprintf explicit_bzero explicit_memset getrandom getrusage inet_aton isascii memset_s random rand lrand48 setpgid snprintf strlcpy vsnprintf])
+AC_CHECK_FUNCS([clock dprintf explicit_bzero explicit_memset getrandom getrusage inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_B64_NTOP
 EGG_FUNC_VPRINTF

--- a/src/bg.c
+++ b/src/bg.c
@@ -118,9 +118,7 @@ static void bg_do_detach(pid_t p)
   } else
     printf(EGG_NOWRITE, pid_file);
   printf("Launched into the background  (pid: %li)\n\n", (long) p);
-#ifdef HAVE_SETPGID
   setpgid(p, p);
-#endif
   exit(0);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1216,9 +1216,7 @@ int main(int arg_c, char **arg_v)
   use_stderr = 0;               /* Stop writing to stderr now */
   if (backgrd) {
     /* Ok, try to disassociate from controlling terminal (finger cross) */
-#ifdef HAVE_SETPGID
     setpgid(0, 0);
-#endif
     /* Tcl wants the stdin, stdout and stderr file handles kept open. */
     if (freopen("/dev/null", "r", stdin) == NULL) {
       putlog(LOG_MISC, "*", "Error renaming stdin file handle: %s", strerror(errno));


### PR DESCRIPTION
Found by: vanosg
Patch by: michaelortmann
Fixes: 

One-line summary:
setpgid() is POSIX.1-2001, so old code can be cleaned up.

Additional description (if needed):
Fixes part of #226, don't close #226 yet.
Please misc/runautotools and misc/makedepend after merge

Test cases demonstrating functionality (if applicable):
