### PR TITLE
Password: Please do not use + as first character.

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -407,6 +407,10 @@ static void cmd_newpass(struct userrec *u, int idx, char *par)
     dprintf(idx, "Please use at least 6 characters.\n");
     return;
   }
+  if (new[0] == '+') {
+    dprintf(idx, "Please do not use + as first character.\n");
+    return;
+  }
   set_user(&USERENTRY_PASS, u, new);
   putlog(LOG_CMDS, "*", "#%s# newpass...", dcc[idx].nick);
   dprintf(idx, "Changed password to '%s'.\n", new);
@@ -1055,14 +1059,18 @@ static void cmd_chpass(struct userrec *u, int idx, char *par)
       l = strlen(new = newsplit(&par));
       if (l > 16)
         new[16] = 0;
-      if (l < 6)
+      if (l < 6) {
         dprintf(idx, "Please use at least 6 characters.\n");
-      else {
-        set_user(&USERENTRY_PASS, u, new);
-        putlog(LOG_CMDS, "*", "#%s# chpass %s [something]", dcc[idx].nick,
-               handle);
-        dprintf(idx, "Changed password.\n");
+        return;
       }
+      if (new[0] == '+') {
+        dprintf(idx, "Please do not use + as first character.\n");
+        return;
+      }
+      set_user(&USERENTRY_PASS, u, new);
+      putlog(LOG_CMDS, "*", "#%s# chpass %s [something]", dcc[idx].nick,
+             handle);
+      dprintf(idx, "Changed password.\n");
     }
   }
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix for passwords starting with +

Additional description (if needed):
Eggdrop distinguishes plain from encrypted passwords (in pass_set()) with first char == '+'. At the same time it allows users to enter such + passwords. Those would not only end up as plain text in userfile, but would also forbid the user to use it / login.

With this PR, + passwords will be rejected.

Test cases demonstrating functionality (if applicable):
**Before:**
```
.chpass testuser +12345
Changed password.

Userfile:
testuser   - hp
--PASS +12345
--XTRA created 1585178624

$ telnet 127.0.0.1 3333
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.


Nickname.
testuser

Enter your password.
Negative on that, Houston.
Connection closed by foreign host.
```
**After:**
```
.chpass testuser +12345
[00:28:17] tcl: builtin dcc call: *dcc:chpass -HQ 1 [something]
Please do not use + as first character.
```