### PR TITLE
Clean / Modern OpenSSL library initialization

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -125,7 +125,7 @@ int ssl_init()
 #if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
   SSL_library_init();
   SSL_load_error_strings();
-  OpenSSL_add_all_algorithms
+  OpenSSL_add_all_algorithms();
 #endif
   if (ssl_seed()) {
     putlog(LOG_MISC, "*", "ERROR: TLS: unable to seed PRNG. Disabling SSL");

--- a/src/tls.c
+++ b/src/tls.c
@@ -120,10 +120,13 @@ static int ssl_seed(void)
  */
 int ssl_init()
 {
-  /* Load SSL and crypto error strings; register SSL algorithms */
-  SSL_load_error_strings();
+  /* OpenSSL library initialization
+   * If you are using 1.1.0 or above then you don't need to take any further steps. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
   SSL_library_init();
-
+  SSL_load_error_strings();
+  OpenSSL_add_all_algorithms
+#endif
   if (ssl_seed()) {
     putlog(LOG_MISC, "*", "ERROR: TLS: unable to seed PRNG. Disabling SSL");
     ERR_free_strings();


### PR DESCRIPTION
Found by: eggheads/eggdrop
Patch by: eggheads/eggdrop
Fixes: 

One-line summary:
Clean / Modern OpenSSL library initialization

Additional description (if needed):
See also: https://wiki.openssl.org/index.php/Library_Initialization

Test cases demonstrating functionality (if applicable):
A small developer test linking two eggdrop bots via ssl was successful for OpenSSL 1.1.1e and 1.0.2p.