### PR TITLE
Let also dcc_telnet_pw() use check_validpass()

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -401,6 +401,7 @@ static void cmd_back(struct userrec *u, int idx, char *par)
  */
 char *check_validpass(struct userrec *u, char *new) {
   int l;
+  unsigned char *p = (unsigned char *) new;
 
   l = strlen(new);
   if (l < 6)
@@ -409,6 +410,11 @@ char *check_validpass(struct userrec *u, char *new) {
     return "Passwords cannot be longer than " STRINGIFY(PASSWORDMAX) " characters, please try again.";
   if (new[0] == '+') /* See also: userent.c:pass_set() */
     return "Password cannot start with '+', please try again.";
+  while (*p) {
+    if ((*p <= 32) || (*p == 127))
+      return "Password cannot use weird symbols, please try again.";
+    p++;
+  }
   set_user(&USERENTRY_PASS, u, new);
   return NULL;
 }

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1876,30 +1876,17 @@ static void dcc_telnet_new(int idx, char *buf, int x)
       add_note(buf, botnetnick, "Welcome to eggdrop! :)", -1, 0);
     }
     dprintf(idx, "\nOkay, now choose and enter a password:\n");
-    dprintf(idx, "(Only the first 15 letters are significant.)\n");
   }
 }
 
-static void dcc_telnet_pw(int idx, char *buf, int x)
+static void dcc_telnet_pw(int idx, char *new, int x)
 {
-  char *newpass;
-  int ok;
+  char *s;
 
   if (dcc[idx].status & STAT_TELNET)
-    strip_telnet(dcc[idx].sock, buf, &x);
-  buf[16] = 0;
-  ok = 1;
-  if (strlen(buf) < 4) {
-    dprintf(idx, "\nTry to use at least 4 characters in your password.\n");
-    dprintf(idx, "Choose and enter a password:\n");
-    return;
-  }
-  for (x = 0; x < strlen(buf); x++)
-    if ((buf[x] <= 32) || (buf[x] == 127))
-      ok = 0;
-  if (!ok) {
-    dprintf(idx, "\nYou can't use weird symbols in your password.\n");
-    dprintf(idx, "Try another one please:\n");
+    strip_telnet(dcc[idx].sock, new, &x);
+  if ((s = check_validpass(dcc[idx].user, new))) {
+    dprintf(idx, "%s\nChoose and enter a password:\n", s);
     return;
   }
   putlog(LOG_MISC, "*", DCC_NEWUSER, dcc[idx].nick, dcc[idx].host,
@@ -1918,10 +1905,8 @@ static void dcc_telnet_pw(int idx, char *buf, int x)
     rmspace(s1);
     add_note(s1, botnetnick, s, -1, 0);
   }
-  newpass = newsplit(&buf);
-  set_user(&USERENTRY_PASS, dcc[idx].user, newpass);
-  dprintf(idx, "\nRemember that!  You'll need it next time you log in.\n");
-  dprintf(idx, "You now have an account on %s...\n\n\n", botnetnick);
+  dprintf(idx, "\nRemember that!  You'll need it next time you log in.\n"
+               "You now have an account on %s...\n\n\n", botnetnick);
   dcc[idx].type = &DCC_CHAT;
   dcc[idx].u.chat->channel = -2;
   dcc_chatter(idx);

--- a/src/proto.h
+++ b/src/proto.h
@@ -122,6 +122,7 @@ int check_dcc_chanattrs(struct userrec *, char *, int, int);
 int check_int_range(char *value, int min, int max);
 int stripmodes(char *);
 char *stripmasktype(int);
+char *check_validpass(struct userrec *, char *);
 
 /* dcc.c */
 void failed_link(int);


### PR DESCRIPTION
Found by: wilkowy
Patch by: michaelortmann
Fixes: 

One-line summary:
Let also dcc_telnet_pw() use check_validpass()

Additional description (if needed):
Follow up to 7b8a454a73a59b06927db767fd6d66f3ca28ff30
Moved check for char < 32 and char == 127 into check_validpass()
(Those characters were silently converted to '?' in pass_set() in the other password setting methods)

Test cases demonstrating functionality (if applicable):
```
$ ./eggdrop -m eggdrop.conf
telnet 127.0.0.1 3333
NEW
```