### PR TITLE
Fix got432()

### DIFF
--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -65,6 +65,10 @@
 #define BADNICKCHARS "-,+*=:!.@#;$%&"
 #define BADHANDCHARS "-,+*=:!.@#;$%&"
 
+/* And now valid characters! */
+#define CHARSET_ALPHA "abcdefghijklmnopqrstuvwxyz"
+#define CHARSET_ALPHANUM "0123456789abcdefghijklmnopqrstuvwxyz"
+
 
 /* Language stuff */
 #define LANGDIR  "./language" /* language file directory                   */

--- a/src/misc.c
+++ b/src/misc.c
@@ -1445,7 +1445,7 @@ void make_rand_str_from_chars(char *s, const int len, char *chars)
  */
 void make_rand_str(char *s, const int len)
 {
-  make_rand_str_from_chars(s, len, "0123456789abcdefghijklmnopqrstuvwxyz");
+  make_rand_str_from_chars(s, len, CHARSET_ALPHANUM);
 }
 
 /* Convert an octal string into a decimal integer value.  If the string

--- a/src/misc.c
+++ b/src/misc.c
@@ -1445,7 +1445,7 @@ void make_rand_str_from_chars(char *s, const int len, char *chars)
  */
 void make_rand_str(char *s, const int len)
 {
-  make_rand_str_from_chars(s, len - 1, "0123456789abcdefghijklmnopqrstuvwxyz");
+  make_rand_str_from_chars(s, len, "0123456789abcdefghijklmnopqrstuvwxyz");
 }
 
 /* Convert an octal string into a decimal integer value.  If the string

--- a/src/misc.c
+++ b/src/misc.c
@@ -1432,16 +1432,20 @@ void show_banner(int idx)
   fclose(vv);
 }
 
+void make_rand_str_from_chars(char *s, const int len, char *chars)
+{
+  int i;
+
+  for (i = 0; i < len; i++)
+    s[i] = chars[randint(strlen(chars))];
+  s[len] = 0;
+}
+
 /* Create a string with random lower case letters and digits
  */
 void make_rand_str(char *s, const int len)
 {
-  int i;
-  static const char chars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-
-  for (i = 0; i < len; i++)
-    s[i] = chars[randint((sizeof chars) - 1)];
-  s[len] = 0;
+  make_rand_str_from_chars(s, len - 1, "0123456789abcdefghijklmnopqrstuvwxyz");
 }
 
 /* Convert an octal string into a decimal integer value.  If the string

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -506,6 +506,8 @@
 # define b64_pton ((int (*) (const char *, u_char *, size_t))global[306])
 #endif
 #define check_validpass ((char *(*) (struct userrec *, char *))global[307])
+/* 308 - 311 */
+#define make_rand_str_from_chars ((void (*) (char *, int, char *))global[308])
 
 
 /* hostmasking */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -860,10 +860,9 @@ static int got432(char *from, char *msg)
   else {
     putlog(LOG_MISC, "*", IRC_BADBOTNICK);
     if (!keepnick) {
-      make_rand_str_from_chars(nick, sizeof nick - 1, "ABCDEFGHIJKLMNOPQRSTUVWX"
-                               "YZabcdefghijklmnopqrstuvwxyz");
-      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (keep-nick is 0, so im "
-             "trying random nick '%s').", erroneous, nick);
+      make_rand_str_from_chars(nick, sizeof nick - 1, CHARSET_ALPHA);
+      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (using %s instead)",
+              erroneous, nick);
       dprintf(DP_MODE, "NICK %s\n", nick);
     }
     return 0;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -850,19 +850,21 @@ static void got303(char *from, char *msg)
  */
 static int got432(char *from, char *msg)
 {
-  char *erroneous;
+  char *erroneous, nick[10]; /* NICKLEN 9 + \0 */
 
   newsplit(&msg);
   erroneous = newsplit(&msg);
   if (server_online)
-    putlog(LOG_MISC, "*", "NICK IS INVALID: %s (keeping '%s').", erroneous,
+    putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (keeping '%s').", erroneous,
            botname);
   else {
     putlog(LOG_MISC, "*", IRC_BADBOTNICK);
     if (!keepnick) {
-      makepass(erroneous);
-      erroneous[NICKMAX] = 0;
-      dprintf(DP_MODE, "NICK %s\n", erroneous);
+      make_rand_str_from_chars(nick, sizeof nick - 1, "ABCDEFGHIJKLMNOPQRSTUVWX"
+                               "YZabcdefghijklmnopqrstuvwxyz");
+      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (keep-nick is 0, so im "
+             "trying random nick '%s').", erroneous, nick);
+      dprintf(DP_MODE, "NICK %s\n", nick);
     }
     return 0;
   }

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -861,7 +861,7 @@ static int got432(char *from, char *msg)
     putlog(LOG_MISC, "*", IRC_BADBOTNICK);
     if (!keepnick) {
       make_rand_str_from_chars(nick, sizeof nick - 1, CHARSET_ALPHA);
-      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (using %s instead)",
+      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (using '%s' instead)",
               erroneous, nick);
       dprintf(DP_MODE, "NICK %s\n", nick);
     }

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -850,7 +850,7 @@ static void got303(char *from, char *msg)
  */
 static int got432(char *from, char *msg)
 {
-  char *erroneous, nick[10]; /* NICKLEN 9 + \0 */
+  char *erroneous, nick[nick_len + 1];
 
   newsplit(&msg);
   erroneous = newsplit(&msg);

--- a/src/modules.c
+++ b/src/modules.c
@@ -606,7 +606,9 @@ Function global_table[] = {
   (Function) 0,
   (Function) 0,
 #endif
-  (Function) check_validpass
+  (Function) check_validpass,
+  /* 308 - 311 */
+  (Function) make_rand_str_from_chars
 };
 
 void init_modules(void)

--- a/src/proto.h
+++ b/src/proto.h
@@ -250,6 +250,7 @@ void debug_help(int);
 void reload_help_data(void);
 char *extracthostname(char *);
 void show_banner(int i);
+void make_rand_str_from_chars(char *, int, char *);
 void make_rand_str(char *, int);
 int oatoi(const char *);
 int is_file(const char *);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
- got432() was broken in several ways:
1. I could not proof the following line buffer overflow free:
https://github.com/eggheads/eggdrop/blob/48688f10fe406733452f9e7accb4b2a8703a5e30/src/mod/server.mod/servmsg.c#L864
(Good thing is, the buffer it writes to is somehow longer than strlen(), no gcc nor clang flags, even sanitizer doesn't catch it and i was not able to exploit it)
2. It should not use makepass(), because that function generated PASSWORDLEN nicknames, which could be too long for the server and thus invalid and it also generates invalid nicknames, starting with 0..9
- The broken code can be triggered by:
1. `eggdrop.conf: set nick "<"`  (or any other illegal nick)
2. `eggdrop.conf: set keep-nick 0`
3. `'CC=clang -fsanitize=address' ./configure`
4. `ASAN_OPTIONS=detect_odr_violation=0 ./eggdrop -nt eggdrop.conf`
- This patch adds a generic make_rand_str_from_chars() function. I am conservative about adding anything to eggdrops module api. From my other password PRs and pending PRs i see, that we really need a better function to generate random "strings". At the same time, i don't want to overenginer it.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
**Before:**
```
[01:01:44] Trying server 127.0.0.1:6667
[01:01:44] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[01:01:44] net: connect! sock 9
[01:01:44] Connected to 127.0.0.1
[01:01:45] Server says my nickname is invalid.
[01:01:45] Server says my nickname is invalid.
```
Note: the second `Server says my nickname is invalid.` line will only be printed for the case that the random nick generated is starting with 0..9 and also invalid.
**After:**
```
[01:08:31] Trying server 127.0.0.1:6667
[01:08:31] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[01:08:31] net: connect! sock 9
[01:08:31] Connected to 127.0.0.1
[01:08:31] Server says my nickname is invalid.
[01:08:31] NICK IS INVALID: '<' (keep-nick is 0, so im trying random nick 'UVMJmOiKmcJt').
[01:08:31] -NOTICE- Server is currently in split-mode.
.set nicklen
[01:08:34] tcl: builtin dcc call: *dcc:set -HQ 1 nicklen
[01:08:34] #-HQ# set nicklen
Currently: 12
```