### PR TITLE
Update strlcpy from openbsd upstream

### DIFF
--- a/src/compat/strlcpy.c
+++ b/src/compat/strlcpy.c
@@ -22,10 +22,10 @@
 #include <config.h>
 
 #ifndef HAVE_STRLCPY
-/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
+/*	$OpenBSD: strlcpy.c,v 1.16 2019/01/25 00:19:25 millert Exp $	*/
 
 /*
- * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -40,7 +40,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stddef.h>
+#include <sys/types.h>
+#include <string.h>
 
 /*
  * Copy string src to buffer dst of size dsize.  At most dsize-1


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
https://github.com/openbsd/src/blob/master/lib/libc/string/strlcpy.c

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
