### PR TITLE
Enhance mem / status report

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -23,7 +23,7 @@
  */
 
 #define MEMTBLSIZE_START (1 << 12) /* 4096    */
-#define MEMTBLSIZE_MAX   (1 << 20) /* 1048576 */
+#define MEMTBLSIZE_MAX   1048576   /* (1 << 20), must be STRINGIFY()able */
 #define COMPILING_MEM
 
 #include "main.h"
@@ -97,9 +97,10 @@ void tell_mem_status(char *nick)
 #ifdef DEBUG_MEM
   float per;
 
-  per = ((lastused * 1.0) / (memtbl_size * 1.0)) * 100.0;
-  dprintf(DP_HELP, "NOTICE %s :Memory table usage: %d/%d (%.1f%% full)\n",
-          nick, lastused, memtbl_size, per);
+  per = 100.0 * (lastused * 1.0) / (MEMTBLSIZE_MAX * 1.0);
+  dprintf(DP_HELP, "NOTICE %s :Memory table usage: %d/%d (%.1f%% of max "
+          STRINGIFY(MEMTBLSIZE_MAX) " full)\n", nick, lastused, memtbl_size,
+          per);
 #endif
   dprintf(DP_HELP, "NOTICE %s :Think I'm using about %dk.\n", nick,
           (int) (expected_memory() / 1024));
@@ -112,9 +113,9 @@ void tell_mem_status_dcc(int idx)
   float per;
 
   exp = expected_memory();      /* in main.c ? */
-  per = ((lastused * 1.0) / (memtbl_size * 1.0)) * 100.0;
-  dprintf(idx, "Memory table: %d/%d (%.1f%% full)\n", lastused, memtbl_size,
-          per);
+  per = 100.0 * (lastused * 1.0) / (MEMTBLSIZE_MAX * 1.0);
+  dprintf(idx, "Memory table: %d/%d (%.1f%% of max " STRINGIFY(MEMTBLSIZE_MAX)
+          " full)\n", lastused, memtbl_size, per);
   per = ((exp * 1.0) / (memused * 1.0)) * 100.0;
   if (per != 100.0)
     dprintf(idx, "Memory fault: only accounting for %d/%ld (%.1f%%)\n",


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance mem / status report

Additional description (if needed):
Before:
`Memory table: 3605/4096 (88.0% full)`
After:
`Memory table: 3616/4096 (0.3% of max 1048576 full)`

`max == mem.c:MEMTBLSIZE_MAX`

Test cases demonstrating functionality (if applicable):
Before:
```
$ ./eggdrop -nc BotA.conf
I am BotA, running eggdrop v1.9.0+msgtags: 17 users (mem: 266k).
Online for 00:00 (status mode) - CPU: 00:00.02 - Cache hit:  0.0%
Configured with: 'CC=clang -fsanitize=address'
Admin: Lamer <email: lamer@lamest.lame.org>
Config file: BotA.conf
OS: Linux 5.5.11-arch1-1
Process ID: 699526 (parent 558778)
Tcl library: /usr/lib/tcl8.6
Tcl version: 8.6.10 (header version 8.6.10)
Tcl is threaded.
TLS support is enabled.
TLS library: OpenSSL 1.1.1e  17 Mar 2020
IPv6 support is enabled.
Socket table: 20/100
    No server currently.
    Active CAP negotiations: None
Memory table: 3605/4096 (88.0% full)
Memory table itself occupies an additional 160k static
```
After:
```
$ ./eggdrop -nc BotA.conf
I am BotA, running eggdrop v1.9.0+msgtags: 17 users (mem: 266k).
Online for 00:00 (status mode) - CPU: 00:00.01 - Cache hit:  0.0%
Configured with: 
Admin: Lamer <email: lamer@lamest.lame.org>
Config file: BotA.conf
OS: Linux 5.5.11-arch1-1
Process./eggdrop -nc BotA.conf ID: 708312 (parent 707370)
Tcl library: /usr/lib/tcl8.6
Tcl version: 8.6.10 (header version 8.6.10)
Tcl is threaded.
TLS support is enabled.
TLS library: OpenSSL 1.1.1e  17 Mar 2020
IPv6 support is enabled.
Socket table: 20/100
    No server currently.
    Active CAP negotiations: None
Memory table: 3616/4096 (0.3% of max 1048576 full)
Memory table itself occupies an additional 160k static

$ ./eggdrop -nc BotA.conf
.status
I am BotA, running eggdrop v1.9.0+msgtags: 18 users (mem: 266k).
Online for 00:00 (terminal mode) - CPU: 00:00.01 - Cache hit: 66.7%
Configured with: 
Admin: Lamer <email: lamer@lamest.lame.org>
Config file: BotA.conf
OS: Linux 5.5.11-arch1-1
Process ID: 708464 (parent 707370)
Tcl library: /usr/lib/tcl8.6
Tcl version: 8.6.10 (header version 8.6.10)
Tcl is threaded.
TLS support is enabled.
TLS library: OpenSSL 1.1.1e  17 Mar 2020
IPv6 support is enabled.
Socket table: 20/100
Memory table: 3625/4096 (0.3% of max 1048576 full)
Memory table itself occupies an additional 160k static
Loaded module information:
    No server currently.
    Active CAP negotiations: None
```