### PR TITLE
Fix me stupid

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -594,7 +594,6 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
   ret = strcmp(digest_string, remote_digest);
   explicit_bzero(digest_string, sizeof digest_string);
   explicit_bzero(digest, sizeof digest);
-  explicit_bzero(password, strlen(password));
 
   if (!ret)
     return 1;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #964

One-line summary:
explicit_bzero() as not erasing a copy of password, but the password in the userstruct itself.

Additional description (if needed):
Must take good care of every single explicit_bzero()!

Test cases demonstrating functionality (if applicable):
