### PR TITLE
Only configure modules, that have at least one .c file

### DIFF
--- a/misc/modconfig
+++ b/misc/modconfig
@@ -274,7 +274,7 @@ xdetect-modules)
 				mc_new_mod_state=enabled
 			fi
 		fi
-		if test "${mc_new_mod_state}" = enabled; then
+		if test "${mc_new_mod_state}" = enabled && [[ -n $(find $mc_mod_bin_dir/${mc_mod}".mod" -name \*.c) ]]; then
 			${mc_self_call} -q add ${mc_mod}
 		else
 			${mc_self_call} -q del ${mc_mod}


### PR DESCRIPTION
Found by: Geo
Patch by: michaelortmann
Fixes: 

One-line summary:
Workaround for design issue with current built-system

Additional description (if needed):
`make config` picks up any folder under src/mod and later `make` tries to execute the Makefile in  that folder
If you manually copy a module into src/mod `make config` will find it
And if you remove .c files under src/mod/*/ `make` will fail
That is what also happens when `git checkout` checks out a branch that has one module less than the current branch and that has been configured. Stale folder under src/mod remains, but with no source inside
This Patch detects this case (folder, but without a single .c) and filters it out in `make config`

We could also add debug log for this case in that if-statement.

See also #72

Test cases demonstrating functionality (if applicable):
Works for pbkdf2 in my case, but its only a proof of concept patch, someone with more bash and modconfig knowledge should look at the code i wrote.