### PR TITLE
vprintf() is POSIX.1-2001

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -332,24 +332,6 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
 ])
 
 
-dnl EGG_FUNC_VPRINTF()
-dnl
-AC_DEFUN([EGG_FUNC_VPRINTF],
-[
-  AC_FUNC_VPRINTF
-  if test "$ac_cv_func_vprintf" = no; then
-    cat << 'EOF' >&2
-configure: error:
-
-  Your system does not have the vprintf/vsprintf/sprintf libraries.
-  These are required to compile almost anything. Sorry.
-
-EOF
-    exit 1
-  fi
-])
-
-
 dnl
 dnl Checks for programs.
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,6 @@ AX_CREATE_STDINT_H([eggint.h])
 AC_CHECK_FUNCS([dprintf explicit_bzero explicit_memset getrandom getrusage inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_B64_NTOP
-EGG_FUNC_VPRINTF
 AC_FUNC_MMAP
 
 

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -94,10 +94,6 @@
 #  include "Error: Your system must have standard ANSI C headers."
 #endif
 
-#ifndef HAVE_VPRINTF
-#  include "Error: You need vsprintf to compile eggdrop."
-#endif
-
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif


### PR DESCRIPTION
Found by: vanosg
Patch by: michaelortmann
Fixes: 

One-line summary:
vprintf() is POSIX.1-2001, so old code can be cleaned up.

Additional description (if needed):
This was a real dinosaur, see AC_FUNC_VPRINTF in https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Particular-Functions.html
Fixes part of #226, don't close #226 yet.
Please **misc/runautotools** after merge

Test cases demonstrating functionality (if applicable):
