### PR TITLE
(Low Prio) Fix missing-field-initializers

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1605,6 +1605,7 @@ struct dcc_table DCC_RELAY = {
   display_relay,
   expmem_relay,
   kill_relay,
+  NULL,
   NULL
 };
 
@@ -1628,7 +1629,8 @@ struct dcc_table DCC_RELAYING = {
   display_relaying,
   expmem_relay,
   kill_relay,
-  out_relay
+  out_relay,
+  NULL
 };
 
 struct dcc_table DCC_FORK_RELAY = {
@@ -1641,6 +1643,7 @@ struct dcc_table DCC_FORK_RELAY = {
   display_tandem_relay,
   expmem_relay,
   kill_relay,
+  NULL,
   NULL
 };
 
@@ -1654,6 +1657,7 @@ struct dcc_table DCC_PRE_RELAY = {
   display_pre_relay,
   expmem_relay,
   kill_relay,
+  NULL,
   NULL
 };
 

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -458,7 +458,8 @@ struct dcc_table DCC_BOT_NEW = {
   display_dcc_bot_new,
   expmem_dcc_bot_,
   free_dcc_bot_,
-  out_dcc_bot
+  out_dcc_bot,
+  NULL
 };
 
 /* Hash function for tandem bot commands */
@@ -542,7 +543,8 @@ struct dcc_table DCC_BOT = {
   display_dcc_bot,
   expmem_dcc_bot_,
   free_dcc_bot_,
-  out_dcc_bot
+  out_dcc_bot,
+  NULL
 };
 
 struct dcc_table DCC_FORK_BOT = {
@@ -555,7 +557,8 @@ struct dcc_table DCC_FORK_BOT = {
   display_dcc_fork_bot,
   expmem_dcc_bot_,
   free_dcc_bot_,
-  out_dcc_bot
+  out_dcc_bot,
+  NULL
 };
 
 /* This function generates a digest by combining a challenge consisting
@@ -946,7 +949,8 @@ struct dcc_table DCC_CHAT_PASS = {
   display_dcc_chat_pass,
   expmem_dcc_general,
   kill_dcc_general,
-  out_dcc_general
+  out_dcc_general,
+  NULL
 };
 
 /* Make sure ANSI code is just for color-changing */
@@ -1167,7 +1171,8 @@ struct dcc_table DCC_CHAT = {
   display_dcc_chat,
   expmem_dcc_general,
   kill_dcc_general,
-  out_dcc_general
+  out_dcc_general,
+  NULL
 };
 
 static int lasttelnets;
@@ -1411,6 +1416,7 @@ struct dcc_table DCC_TELNET = {
   display_telnet,
   NULL,
   NULL,
+  NULL,
   NULL
 };
 
@@ -1483,7 +1489,8 @@ struct dcc_table DCC_DUPWAIT = {
   display_dupwait,
   expmem_dupwait,
   kill_dupwait,
-  out_dcc_bot
+  out_dcc_bot,
+  NULL
 };
 
 /* This function is called if a bot gets removed from the list. It checks
@@ -1809,7 +1816,8 @@ struct dcc_table DCC_TELNET_ID = {
   display_dcc_telnet_id,
   expmem_dcc_general,
   kill_dcc_general,
-  out_dcc_general
+  out_dcc_general,
+  NULL
 };
 
 static void dcc_telnet_new(int idx, char *buf, int x)
@@ -1970,7 +1978,8 @@ struct dcc_table DCC_TELNET_NEW = {
   display_dcc_telnet_new,
   expmem_dcc_general,
   kill_dcc_general,
-  out_dcc_general
+  out_dcc_general,
+  NULL
 };
 
 struct dcc_table DCC_TELNET_PW = {
@@ -1983,7 +1992,8 @@ struct dcc_table DCC_TELNET_PW = {
   display_dcc_telnet_pw,
   expmem_dcc_general,
   kill_dcc_general,
-  out_dcc_general
+  out_dcc_general,
+  NULL
 };
 
 static int call_tcl_func(char *name, int idx, char *args)
@@ -2114,7 +2124,8 @@ struct dcc_table DCC_SCRIPT = {
   display_dcc_script,
   expmem_dcc_script,
   kill_dcc_script,
-  out_dcc_script
+  out_dcc_script,
+  NULL
 };
 
 static void dcc_socket(int idx, char *buf, int len)
@@ -2142,6 +2153,7 @@ struct dcc_table DCC_SOCKET = {
   display_dcc_socket,
   NULL,
   NULL,
+  NULL,
   NULL
 };
 
@@ -2158,6 +2170,7 @@ struct dcc_table DCC_LOST = {
   NULL,
   NULL,
   display_dcc_lost,
+  NULL,
   NULL,
   NULL,
   NULL
@@ -2202,6 +2215,7 @@ struct dcc_table DCC_IDENTWAIT = {
   NULL,
   NULL,
   display_dcc_identwait,
+  NULL,
   NULL,
   NULL,
   NULL
@@ -2272,6 +2286,7 @@ struct dcc_table DCC_IDENT = {
   &identtimeout,
   timeout_dcc_ident,
   display_dcc_ident,
+  NULL,
   NULL,
   NULL,
   NULL

--- a/src/dns.c
+++ b/src/dns.c
@@ -103,7 +103,8 @@ struct dcc_table DCC_DNSWAIT = {
   display_dcc_dnswait,
   expmem_dcc_dnswait,
   kill_dcc_dnswait,
-  0
+  0,
+  NULL
 };
 
 

--- a/src/flags.c
+++ b/src/flags.c
@@ -854,5 +854,6 @@ struct user_entry_type USERENTRY_BOTFL = {
   botfl_tcl_set,
   botfl_expmem,
   botfl_display,
-  "BOTFL"
+  "BOTFL",
+  NULL
 };

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -379,9 +379,9 @@ static uff_table_t compress_uff_table[] = {
  */
 
 static tcl_ints my_tcl_ints[] = {
-  {"share-compressed", (int *)&share_compressed},
-  {"compress-level",     (int *)&compress_level},
-  {NULL,                                   NULL}
+  {"share-compressed", (int *)&share_compressed, 0},
+  {"compress-level",     (int *)&compress_level, 0},
+  {NULL,                                   NULL, 0}
 };
 
 static int compress_expmem(void)

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -241,8 +241,8 @@ static tcl_strings mystrings[] = {
 };
 
 static tcl_ints myints[] = {
-  {"ctcp-mode", &ctcp_mode},
-  {NULL,              NULL}
+  {"ctcp-mode", &ctcp_mode, 0},
+  {NULL,              NULL, 0}
 };
 
 static char *ctcp_close()

--- a/src/mod/dns.mod/dns.c
+++ b/src/mod/dns.mod/dns.c
@@ -119,6 +119,7 @@ static struct dcc_table DCC_DNS = {
   display_dns_socket,
   NULL,
   NULL,
+  NULL,
   NULL
 };
 

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -585,10 +585,10 @@ static tcl_strings mystrings[] = {
 };
 
 static tcl_ints myints[] = {
-  {"max-filesize",    &dcc_maxsize},
-  {"max-file-users",    &dcc_users},
-  {"upload-to-pwd",  &upload_to_cd},
-  {NULL,                      NULL}
+  {"max-filesize",    &dcc_maxsize, 0},
+  {"max-file-users",    &dcc_users, 0},
+  {"upload-to-pwd",  &upload_to_cd, 0},
+  {NULL,                      NULL, 0}
 };
 
 static struct dcc_table DCC_FILES_PASS = {

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -112,7 +112,8 @@ static struct dcc_table DCC_FILES = {
   disp_dcc_files,
   expmem_dcc_files,
   kill_dcc_files,
-  out_dcc_files
+  out_dcc_files,
+  NULL
 };
 
 static struct user_entry_type USERENTRY_DCCDIR = {
@@ -600,7 +601,8 @@ static struct dcc_table DCC_FILES_PASS = {
   disp_dcc_files_pass,
   expmem_dcc_files,
   kill_dcc_files,
-  out_dcc_files
+  out_dcc_files,
+  NULL
 };
 
 

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -92,6 +92,7 @@ static struct dcc_table DCC_IDENTD = {
   ident_display,
   NULL,
   NULL,
+  NULL,
   NULL
 };
 

--- a/src/mod/notes.mod/notes.c
+++ b/src/mod/notes.mod/notes.c
@@ -1111,12 +1111,12 @@ static cmd_t notes_msgs[] = {
 };
 
 static tcl_ints notes_ints[] = {
-  {"note-life",         &note_life},
-  {"max-notes",          &maxnotes},
-  {"allow-fwd",         &allow_fwd},
-  {"notify-users",   &notify_users},
-  {"notify-onjoin", &notify_onjoin},
-  {NULL,                      NULL}
+  {"note-life",         &note_life, 0},
+  {"max-notes",          &maxnotes, 0},
+  {"allow-fwd",         &allow_fwd, 0},
+  {"notify-users",   &notify_users, 0},
+  {"notify-onjoin", &notify_onjoin, 0},
+  {NULL,                      NULL, 0}
 };
 
 static tcl_strings notes_strings[] = {

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1105,6 +1105,7 @@ static struct dcc_table SERVER_SOCKET = {
   display_server,
   NULL,
   kill_server,
+  NULL,
   NULL
 };
 

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -2126,12 +2126,12 @@ static void cancel_user_xfer(int idx, void *x)
 }
 
 static tcl_ints my_ints[] = {
-  {"allow-resync",      &allow_resync},
-  {"resync-time",        &resync_time},
-  {"private-global",  &private_global},
-  {"private-user",      &private_user},
-  {"override-bots", &overr_local_bots},
-  {NULL,                         NULL}
+  {"allow-resync",      &allow_resync, 0},
+  {"resync-time",        &resync_time, 0},
+  {"private-global",  &private_global, 0},
+  {"private-user",      &private_user, 0},
+  {"override-bots", &overr_local_bots, 0},
+  {NULL,                         NULL, 0}
 };
 
 static tcl_strings my_strings[] = {

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -1105,11 +1105,11 @@ static int ctcp_DCC_RESUME(char *nick, char *from, char *handle,
 }
 
 static tcl_ints myints[] = {
-  {"max-dloads",       &dcc_limit},
-  {"dcc-block",        &dcc_block},
-  {"xfer-timeout", &wait_dcc_xfer},
-  {"sharefail-unlink",  &shunlink},
-  {NULL,                     NULL}
+  {"max-dloads",       &dcc_limit, 0},
+  {"dcc-block",        &dcc_block, 0},
+  {"xfer-timeout", &wait_dcc_xfer, 0},
+  {"sharefail-unlink",  &shunlink, 0},
+  {NULL,                     NULL, 0}
 };
 
 static cmd_t transfer_ctcps[] = {

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -802,7 +802,8 @@ static struct dcc_table DCC_SEND = {
   display_dcc_send,
   expmem_dcc_xfer,
   kill_dcc_xfer,
-  out_dcc_xfer
+  out_dcc_xfer,
+  NULL
 };
 
 /* Send TO the bot from outside of the transfer module - Wcc */
@@ -816,7 +817,8 @@ static struct dcc_table DCC_FORK_SEND = {
   display_dcc_fork_send,
   expmem_dcc_xfer,
   kill_dcc_xfer,
-  out_dcc_xfer
+  out_dcc_xfer,
+  NULL
 };
 
 /* Send FROM the bot, don't know why this isn't called DCC_SEND - Wcc */
@@ -845,7 +847,8 @@ static struct dcc_table DCC_GET_PENDING = {
   display_dcc_get_p,
   expmem_dcc_xfer,
   kill_dcc_xfer,
-  out_dcc_xfer
+  out_dcc_xfer,
+  NULL
 };
 
 static void dcc_fork_send(int idx, char *x, int y)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
(Low Prio) Fix all missing-field-initializers

Additional description (if needed):
Found with clang -Wmissing-field-initializers

Test cases demonstrating functionality (if applicable):
