### PR TITLE
Fix POSIX 2001

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -189,9 +189,9 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
       hp = NULL;
     if (hp) {
       if (hp->h_addrtype == AF_INET)
-        memcpy(&addr->addr.s4.sin_addr, hp->h_addr, hp->h_length);
+        memcpy(&addr->addr.s4.sin_addr, hp->h_addr_list[0], hp->h_length);
       else
-        memcpy(&addr->addr.s6.sin6_addr, hp->h_addr, hp->h_length);
+        memcpy(&addr->addr.s6.sin6_addr, hp->h_addr_list[0], hp->h_length);
       af = hp->h_addrtype;
     }
   }
@@ -243,7 +243,7 @@ but this Eggdrop was not compiled with IPv6 support.");
       } else
         hp = NULL;
       if (hp) {
-        memcpy(&addr->addr.s4.sin_addr, hp->h_addr, hp->h_length);
+        memcpy(&addr->addr.s4.sin_addr, hp->h_addr_list[0], hp->h_length);
         af = hp->h_addrtype;
       }
     } else


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
struct hostent h_addr is not posix 2001

Additional description (if needed):
https://pubs.opengroup.org/onlinepubs/009695399/basedefs/netdb.h.html
https://sourceware.org/git/?p=glibc.git;a=blob;f=resolv/netdb.h;h=575e416dac199f2e588e3af130cff08350334287;hb=HEAD#l96

Test cases demonstrating functionality (if applicable):
