### PR TITLE
don't mutilate cap-request

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1548,7 +1548,7 @@ void add_req(char *cape) {
 
 static int gotcap(char *from, char *msg) {
   char *cmd, *splitstr;
-  char *cape, *p;
+  char cape[CAPMAX], *p;
   int listlen = 0;
 
   newsplit(&msg);
@@ -1574,7 +1574,7 @@ static int gotcap(char *from, char *msg) {
     if (message_tags)
       add_req("message-tags");
 /* Add any custom capes the user listed */
-    cape = cap_request;
+    strncpy(cape, cap_request, sizeof cape);
     if ( (p = strtok(cape, " ")) ) {
       while (p != NULL) {
         add_req(p);


### PR DESCRIPTION
Patch by: Geo

One-line summary:
Strcpy cap_request before using strtok on it

Additional description (if needed):
Previously, a ptr was copied instead of the entire string. When strtok was used, it mutilated the (same) string. By leaving cap_request unchanged, it can be viewed/used by other scripts as it was originally set in the config