### PR TITLE
Update cap cmds

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -155,10 +155,10 @@ clearqueue <queue>
   Module: server
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-cap <active/available/raw> [arg]
+cap <list/req/enabled/raw> [arg]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: displays CAP status or sends a raw CAP command to the server. "available" will list the capabilities supported by the server, "active" will list the capabilities Eggdrop has negotiated with the server, and raw will send a raw CAP command to the server. If sending a raw command, it must be submitted in arg as a single string. For example, to request capabilities foo and bar, you would use [cap raw "REQ :foo bar"]. 
+  Description: displays CAP status or sends a raw CAP command to the server. "list" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and to for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -158,7 +158,7 @@ clearqueue <queue>
 cap <ls/req/enabled/raw> [arg]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and to for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
+  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -155,10 +155,10 @@ clearqueue <queue>
   Module: server
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-cap <list/req/enabled/raw> [arg]
+cap <ls/req/enabled/raw> [arg]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: displays CAP status or sends a raw CAP command to the server. "list" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and to for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
+  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and to for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -158,7 +158,7 @@ clearqueue <queue>
 cap <ls/req/enabled/raw> [arg]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, req will request the capabilities listed in arg, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
+  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities Eggdrop is internally tracking as supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, "req" will request the capabilities listed in "arg" from the server, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
 
   Returns: nothing
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1611,7 +1611,7 @@ static int gotcap(char *from, char *msg) {
       splitstr = strtok(NULL, " ");
     }
     update_cap_negotiated(); /* TODO: do we really need this call here? */
-    putlog(LOG_SERV, "*", "CAP: Current Negotiations %s with %s", cap.negotiated, from);
+    putlog(LOG_SERV, "*", "CAP: Current negotiations with %s: %s", from, cap.negotiated);
     /* If a negotiated capability requires immediate action by Eggdrop, add it
      * here. However, that capability must take responsibility for sending an
      * END. Future eggheads: add support for more than 1 of these async

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -207,10 +207,22 @@ static int tcl_cap STDVAR {
   char s[CAPMAX];
   BADARGS(2, 3, " sub-cmd ?arg?");
 
-  if (!strcasecmp(argv[1], "available")) {
+  /* List capabilities available on server */
+  if (!strcasecmp(argv[1], "ls")) {
     Tcl_AppendResult(irp, cap.supported, NULL);
-  } else if (!strcasecmp(argv[1], "active")) {
+  /* List capabilities Eggdrop is internally tracking as enabled with server */
+  } else if (!strcasecmp(argv[1], "enabled")) {
     Tcl_AppendResult(irp, cap.negotiated, NULL);
+  /* Send a request to negotiate a capability with server */
+  } else if (!strcasecmp(argv[1], "req")) {
+    if (argc != 3) {
+      Tcl_AppendResult(irp, "No CAP request provided", NULL);
+      return TCL_ERROR;
+    } else {
+      simple_sprintf(s, "CAP REQ :%s", argv[2]);
+      dprintf(DP_SERVER, "%s\n", s);
+    }
+  /* Send a raw CAP command to the server */
   } else if (!strcasecmp(argv[1], "raw")) {
     if (argc == 3) {
       simple_sprintf(s, "CAP %s", argv[2]);


### PR DESCRIPTION
Update Tcl commands to more closely match with actual commands used, for clarity.

Test cases demonstrating functionality (if applicable):
```
.tcl cap req "away-notify invite-notify"
[04:21:02] tcl: builtin dcc call: *dcc:tcl -HQ 1 cap req "away-notify invite-notify"
[04:21:02] tcl: evaluate (.tcl): cap req "away-notify invite-notify"
[04:21:02] [!s] CAP REQ :away-notify invite-notify
Tcl: 
[04:21:03] [s->] CAP REQ :away-notify invite-notify
[04:21:04] [@] :oragono.test CAP BeerBot ACK :away-notify invite-notify
[04:21:04] CAP: ACK :away-notify invite-notify
[04:21:04] CAP: Adding cape away-notify to negotiated list
[04:21:04] CAP: Adding cape invite-notify to negotiated list
[04:21:04] CAP: Current negotiations with oragono.test: away-notify invite-notify
[04:21:04] [!m] CAP END
[04:21:04] [m->] CAP END

.tcl cap ls
Tcl: account-notify account-tag away-notify batch cap-notify chghost draft/chathistory draft/event-playback draft/languages draft/multiline draft/rename draft/resume-0.5 draft/setname echo-message extended-join invite-notify labeled-response message-tags multi-prefix oragono.io/nope sasl server-time sts userhost-in-names znc.in/playback znc.in/self-message
.tcl cap enabled
Tcl: away-notify invite-notify
```