### PR TITLE
Handle 396 (HOSTHIDDEN)

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1253,7 +1253,6 @@ static int got396orchghost(char *nick, char *user, char *uhost)
 static int gotchghost(char *from, char *msg){
   char *nick, *user;
 
-putlog(LOG_DEBUG, "*", "from is %s |||  msg is %s", from, msg);
   nick = splitnick(&from); /* Get the nick */
   user = newsplit(&msg);  /* Get the user */
   got396orchghost(nick, user, msg);
@@ -1269,7 +1268,6 @@ static int got396(char *from, char *msg)
     uhost = newsplit(&msg);
     strncpy(userbuf, botuserhost, sizeof user);
     user = strtok(userbuf, "@");
-putlog(LOG_DEBUG, "*", "!!!!!    this is %s", user);
     got396orchghost(nick, user, uhost);
   }
   return 0;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1235,6 +1235,31 @@ static int got311(char *from, char *msg)
   return 0;
 }
 
+static int got396(char *from, char *msg)
+{
+  char *nick, *uhost, *user, s1[UHOSTLEN];
+  struct chanset_t *chan;
+  memberlist *m;
+
+  nick = newsplit(&msg);
+  if (match_my_nick(nick)) {  /* Double check this really is for me */
+    uhost = newsplit(&msg);
+    for (chan = chanset; chan; chan = chan->next) {
+      if (m) {  /* Just in case? */
+        m = ismember(chan, nick);
+putlog(LOG_DEBUG, "*", "old m.userhost is %s", m->userhost);
+        strncpy(s1, m->userhost, sizeof s1);
+        user = strtok(s1, "@");
+putlog(LOG_DEBUG, "*", "user is now %s", user);
+        snprintf(m->userhost, sizeof m->userhost, "%s@%s", user, uhost);
+putlog(LOG_DEBUG, "*", "m.userhost is now %s, manually its %s@%s", m->userhost, user, uhost);
+        strcpy(botuserhost, m->userhost);
+      }
+    }
+  }
+  return 0;
+}
+
 static int tryauthenticate(char *from, char *msg) 
 {
   char src[(sizeof sasl_username) + (sizeof sasl_username) +
@@ -1665,6 +1690,7 @@ static cmd_t my_raw_binds[] = {
   {"303",          "",   (IntFunc) got303,          NULL},
   {"311",          "",   (IntFunc) got311,          NULL},
   {"318",          "",   (IntFunc) whoispenalty,    NULL},
+  {"396",          "",   (IntFunc) got396,          NULL},
   {"410",          "",   (IntFunc) got410,          NULL},
   {"417",          "",   (IntFunc) got417,          NULL},
   {"421",          "",   (IntFunc) got421,          NULL},

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1253,8 +1253,8 @@ static int got396orchghost(char *nick, char *user, char *uhost)
 
 /* React to IRCv3 CHGHOST command. CHGHOST changes the hostname and/or
  * ident of the user. Format:
- * :geo!awesome@eggdrop.com CHGHOST tehgeo oragono.io
- * changes user hostmask to tehgeo@oragono.io
+ * :geo!awesome@eggdrop.com CHGHOST tehgeo foo.io
+ * changes user hostmask to tehgeo@foo.io
  */
 static int gotchghost(char *from, char *msg){
   char *nick, *user;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1276,15 +1276,12 @@ static int got396(char *from, char *msg)
   nick = newsplit(&msg);
   if (match_my_nick(nick)) {  /* Double check this really is for me */
     uhost = newsplit(&msg);
-    strncpy(userbuf, botuserhost, sizeof user);
+    strlcpy(userbuf, botuserhost, sizeof userbuf);
     user = strtok(userbuf, "@");
     got396orchghost(nick, user, uhost);
   }
   return 0;
 }
-
-//[@] :geo!vanosg@zt53d279eqs7u.oragono CHGHOST vanosg oragono.io
-//[@] :barjavel.freenode.net 396 _LeafBlower unaffiliated/geo/bot/beerbot :is now your hidden host (set by services.)
 
 static int tryauthenticate(char *from, char *msg) 
 {

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1250,6 +1250,12 @@ static int got396orchghost(char *nick, char *user, char *uhost)
   return 0;
 }
 
+
+/* React to IRCv3 CHGHOST command. CHGHOST changes the hostname and/or
+ * ident of the user. Format:
+ * :geo!awesome@eggdrop.com CHGHOST tehgeo oragono.io
+ * changes user hostmask to tehgeo@oragono.io
+ */
 static int gotchghost(char *from, char *msg){
   char *nick, *user;
 
@@ -1259,6 +1265,10 @@ static int gotchghost(char *from, char *msg){
   return 0;
 }
 
+/* React to 396 numeric (HOSTHIDDEN), sent when user mode +x (hostmasking) was
+ * successfully set. Format:
+ * :barjavel.freenode.net 396 BeerBot unaffiliated/geo/bot/beerbot :is now your hidden host (set by services.)
+ */
 static int got396(char *from, char *msg)
 {
   char *nick, *uhost, *user, userbuf[UHOSTLEN];

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1247,12 +1247,9 @@ static int got396(char *from, char *msg)
     for (chan = chanset; chan; chan = chan->next) {
       if (m) {  /* Just in case? */
         m = ismember(chan, nick);
-putlog(LOG_DEBUG, "*", "old m.userhost is %s", m->userhost);
         strncpy(s1, m->userhost, sizeof s1);
         user = strtok(s1, "@");
-putlog(LOG_DEBUG, "*", "user is now %s", user);
         snprintf(m->userhost, sizeof m->userhost, "%s@%s", user, uhost);
-putlog(LOG_DEBUG, "*", "m.userhost is now %s, manually its %s@%s", m->userhost, user, uhost);
         strcpy(botuserhost, m->userhost);
       }
     }


### PR DESCRIPTION
Found by: maimizuno, Geo
Patch by: Geo
It does not f-i-x #522 , (522 describes CHGHOST and CHGIDENT, an IRCv3 thing which Eggdrop doesn't currently support), but a 'normal' 396 message creates the same situation, which is addressed here. So kinda the same, but different.

Update bot hostmask in channel records when a 396 (HOSTHIDDEN) message is received

Test cases demonstrating functionality (if applicable):
```
[06:15:47] [@] :barjavel.freenode.net 396 MyBot unaffiliated/foo/bot/foobot :is now your hidden host (set by services.)
[06:15:47] old m.userhost is foober@foo.com
[06:15:47] user is now foober
[06:15:47] m.userhost is now foober@unaffiliated/foo/bot/foobot

.tcl getchanhost _Leafblower
Tcl: foober@unaffiliated/foo/bot/foobot

```