### PR TITLE
ifdef out IPv6 specific code

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -984,7 +984,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
             && !IN6_IS_ADDR_UNSPECIFIED(ip)
 #endif
             && strcmp(ip, ""))) {
-      Tcl_AppendResult(irp, "WARNING: port is already bound to :: or 0.0.0.0, "
+      Tcl_AppendResult(irp, "port is already bound to :: or 0.0.0.0, "
             "first remove that entry with 'off' before adding the one just "
             "entered", NULL);
       return TCL_ERROR;

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -961,8 +961,11 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     }
     /* Block trying to listen on all IPv4 interfaces if there is already a
      * specific IP listening on that port */
-    if (((!strcasecmp(ip, "0.0.0.0")) || (IN6_IS_ADDR_UNSPECIFIED(ip))) &&
-            strcasecmp(type, "off")) {
+    if (((!strcasecmp(ip, "0.0.0.0"))
+#ifdef IPV6
+        || (IN6_IS_ADDR_UNSPECIFIED(ip))
+#endif
+        ) && strcasecmp(type, "off")) {
       Tcl_AppendResult(irp, "this port is already bound to a specific IP on "
           "this machine, remove it before trying bind to all interfaces", NULL);
       return TCL_ERROR;
@@ -971,10 +974,15 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
      * all interfaces. Check the IP for 0.0.0.0, :: and "" too, in case this is a
      * rehash
      */
-    if (((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0")) ||
-            IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.sa)) &&
-            (dcc[i].port == port) && strcasecmp(type, "off") &&
-            (strcmp(ip, "0.0.0.0") && !IN6_IS_ADDR_UNSPECIFIED(ip)
+    if (((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0"))
+#ifdef IPV6
+            || IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.sa)
+#endif
+            ) && (dcc[i].port == port) && strcasecmp(type, "off") &&
+            (strcmp(ip, "0.0.0.0")
+#ifdef IPV6
+            && !IN6_IS_ADDR_UNSPECIFIED(ip)
+#endif
             && strcmp(ip, ""))) {
       Tcl_AppendResult(irp, "WARNING: port is already bound to :: or 0.0.0.0, "
             "first remove that entry with 'off' before adding the one just "
@@ -1014,8 +1022,11 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     /* If we didn't find a listening ip/port, or we did but it isn't all
      * interfaces
      */
-    if ((!tryagain) || (strcmp(ip, "") && strcmp(ip, "::") &&
-            strcmp(ip, "0.0.0.0"))) {
+    if ((!tryagain) || (strcmp(ip, "") && strcmp(ip, "0.0.0.0")
+#ifdef IPV6
+            && !IN6_IS_ADDR_UNSPECIFIED(ip)
+#endif
+            )) {
       if (strlen(ip)) {
         setsockname(&name, ip, port, 1);
         i = open_address_listen(&name);


### PR DESCRIPTION
Creating a PR to document the testing on the extensive logic branching... phew. Final (?) fix to #935 .

First, without IPv6. Allows multiple IPv4 IPs to bind to the same port, prevents a specific IP from binding to a port already attached to all interfaces, prevents binding all interfaces to a port already bound to a single IP, rehash does not crash.
```
.dcc
[04:04:37] #-HQ# dccstat
IDX ADDR                                     + PORT NICK      TYPE  INFO
--- ---------------------------------------- ------ --------- ----- ---------
5   0.0.0.0                                    4183 (telnet)  lstn  4183
1   0.0.0.0                                       0 -HQ       chat  flags: cptEp/0
9   159.65.18.165                              6667 (server)  serv  (lag: 0)

.tcl listen 127.0.0.1 4444 all
[04:04:44] Listening for telnet connections on 127.0.0.1 port 4444 (all).
Tcl: 4444
.tcl listen 192.168.1.5 4444 all
[04:04:53] Listening for telnet connections on 192.168.1.5 port 4444 (all).
Tcl: 4444
.dcc
[04:04:54] #-HQ# dccstat
IDX ADDR                                     + PORT NICK      TYPE  INFO
--- ---------------------------------------- ------ --------- ----- ---------
5   0.0.0.0                                    4183 (telnet)  lstn  4183
1   0.0.0.0                                       0 -HQ       chat  flags: cptEp/0
9   159.65.18.165                              6667 (server)  serv  (lag: 0)
10  127.0.0.1                                  4444 (telnet)  lstn  4444
12  192.168.1.5                                4444 (telnet)  lstn  4444

.tcl listen 127.0.0.1 4183 all
Tcl error: WARNING: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered

.tcl listen 0.0.0.0 4444 all
Tcl error: this port is already bound to a specific IP on this machine, remove it before trying bind to all interfaces

.rehash
[04:05:02] #-HQ# rehash
Rehashing.
.tcl listen ::1 4444 all
Tcl error: invalid ip address
```

Now, with IPv6 enabled. Allows same port on different IPv4, IPv6 addresses; prevents binding specific IPv6 address to port already bound to all IPv6 interfaces; prevents binding all IPv6 address to port already bound to specific IPv6 address, does not crash on rehash
```
.tcl listen ::1 3333 all
[04:17:20] Listening for telnet connections on ::1 port 3333 (all).
Tcl: 3333
.tcl listen 192.168.1.5 3333 all
[04:17:35] Listening for telnet connections on 192.168.1.5 port 3333 (all).
Tcl: 3333
.dcc
[04:17:36] #-HQ# dccstat
IDX ADDR                                     + PORT NICK      TYPE  INFO
--- ---------------------------------------- ------ --------- ----- ---------
5   0.0.0.0                                    4183 (telnet)  lstn  4183
1   0.0.0.0                                       0 -HQ       chat  flags: cptEp/0
9   159.65.18.165                              6667 (server)  serv  (lag: 0)
11  ::                                         4444 (telnet)  lstn  4444
12  ::1                                        3333 (telnet)  lstn  3333
13  192.168.1.5                                3333 (telnet)  lstn  3333

.tcl listen ::2 4444 all
Tcl error: Couldn't listen on port '4444' on the given address: Cannot assign requested address. Please check that the port is not already in use
.tcl listen :: 3333 all
Tcl error: Couldn't listen on port '3333' on the given address: Address already in use. Please check that the port is not already in use

.rehash
[04:21:52] #-HQ# rehash
Rehashing.
```
