### PR TITLE
Respect LDFLAGS

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -16,6 +16,7 @@ LD = @CC@
 STRIP = @STRIP@
 CFLAGS = @CFLAGS@ -I.. -I$(top_srcdir) @SSL_INCLUDES@ @DEFS@ $(CFLGS)
 CPPFLAGS = @CPPFLAGS@
+LDFLAGS = @LDFLAGS@
 
 eggdrop_objs = bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o \
 dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o \
@@ -41,7 +42,7 @@ linkstart:
 	touch mod/mod.xlibs
 
 link:
-	$(LD) $(CFLAGS) -o ../$(EGGEXEC) $(eggdrop_objs) $(MODOBJS) $(XLIBS) md5/md5c.o compat/*.o `cat mod/mod.xlibs`
+	$(LD) $(CFLAGS) $(LDFLAGS) -o ../$(EGGEXEC) $(eggdrop_objs) $(MODOBJS) $(XLIBS) md5/md5c.o compat/*.o `cat mod/mod.xlibs`
 
 linkfinish:
 	@$(STRIP) ../$(EGGEXEC) && \
@@ -63,7 +64,7 @@ clean:
 main.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) \
 	'-DCCFLAGS="$(CC) $(CFLAGS) $(CPPFLAGS)"' \
-	'-DLDFLAGS="$(LD)"' \
+	'-DLDFLAGS="$(LD) $(LDFLAGS)"' \
 	'-DSTRIPFLAGS="$(STRIP)"' -c $(srcdir)/main.c
 
 compatibility:


### PR DESCRIPTION
Found by: Agostino Sarubbo
Patch by: michaelortmann
Fixes: https://bugs.gentoo.org/724948

One-line summary:
Respect LDFLAGS

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
[michael@zen eggdrop]$ LDFLAGS="-Wl,--as-needed" ./configure 
[...]
[michael@zen eggdrop]$ make config
[...]
[michael@zen eggdrop]$ make
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  \
'-DCCFLAGS="gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS "' \
'-DLDFLAGS="gcc -Wl,--as-needed"' \
'-DSTRIPFLAGS="touch"' -c ./main.c
[...]
---------- Yeah! That's the compiling, now the linking! ----------

Linking eggdrop (debug build).

make[2]: Leaving directory '/home/michael/projects/eggdrop/src'
make[2]: Entering directory '/home/michael/projects/eggdrop/src'
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -Wl,--as-needed -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o  -L/usr/lib -ltcl8.6  -lz -lpthread -lm -lssl -lcrypto -ldl  -lresolv md5/md5c.o compat/*.o `cat mod/mod.xlibs`
make[2]: Leaving directory '/home/michael/projects/eggdrop/src'
make[2]: Entering directory '/home/michael/projects/eggdrop/src'
[...]