### PR TITLE
fix listen

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -950,7 +950,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
   ret = getaddrinfo(ip, NULL, &hint, &ipaddr);
   if (!ret) {
     if (ipaddr->ai_family == AF_INET6) {
-      ret = inet_pton(AF_INET6, ip, &ipaddr2);
+      inet_pton(AF_INET6, ip, &ipaddr2);
     }
   }
 #endif

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -935,10 +935,24 @@ static int tcl_connect STDVAR
 }
 
 static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *maskproc, char *flag) {
-  int i, idx = -1, port, realport, tryagain=0;
+  int ret, i, idx = -1, port, realport, tryagain=0;
   char s[11], msg[256];
   struct portmap *pmap = NULL, *pold = NULL;
   sockname_t name;
+  struct addrinfo hint, *ipaddr = NULL;
+#ifdef IPV6
+  char ipaddr2[sizeof(struct in6_addr)];
+#endif
+
+  memset(&hint, '\0', sizeof hint);
+  hint.ai_family = PF_UNSPEC;
+  hint.ai_flags = AI_NUMERICHOST;
+  ret = getaddrinfo(ip, NULL, &hint, &ipaddr);
+  if (!ret) {
+    if (ipaddr->ai_family == AF_INET6) {
+      ret = inet_pton(AF_INET6, ip, ipaddr2);
+    }
+  }
 
   port = realport = atoi(portp);
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next)
@@ -950,44 +964,53 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     if ((dcc[i].type == &DCC_TELNET) && (dcc[i].port == port)) {
       idx = i;
       tryagain = 1; /* Reset; we may want to listen on this port on a different IP */
-    }
-    /* This specific IP/port pair is already in use, set tryagain to 0 so we don't
-     * try to listen again on this ip/port and cause a Tcl error
-     */
-    if ((!strcasecmp(iptostr(&dcc[idx].sockname.addr.sa), ip)) && (dcc[i].port == port) &&
-           strcasecmp(type, "off")) {
-      tryagain = 0;
-      break;
-    }
-    /* Block trying to listen on all IPv4 interfaces if there is already a
-     * specific IP listening on that port */
-    if (((!strcasecmp(ip, "0.0.0.0"))
+      /* Block trying to listen on all IPvX interfaces if there is already a
+       * specific IP listening on that port */
+      if (((!strcmp(ip, "0.0.0.0")) && (strcasecmp(type, "off")) &&
+            !((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0"))
 #ifdef IPV6
-        || (IN6_IS_ADDR_UNSPECIFIED(ip))
+            || (IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))))
+            || ((IN6_IS_ADDR_UNSPECIFIED(ipaddr2)) && (strcasecmp(type, "off")) &&
+            !((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0"))
+            || (IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))))
+#else
+            )
 #endif
-        ) && strcasecmp(type, "off")) {
-      Tcl_AppendResult(irp, "this port is already bound to a specific IP on "
-          "this machine, remove it before trying bind to all interfaces", NULL);
-      return TCL_ERROR;
-    }
-    /* Block trying to listen on a specific IP if the port is already bound to
-     * all interfaces. Check the IP for 0.0.0.0, :: and "" too, in case this is a
-     * rehash
-     */
-    if (((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0"))
+            ) {
+        Tcl_AppendResult(irp, "this port is already bound to a specific IP on "
+                "this machine, remove it before trying bind to all interfaces",
+                NULL);
+        return TCL_ERROR;
+      }
+
+      /* Block trying to listen on a specific IP if the port is already bound to
+       * all interfaces. Check the IP for 0.0.0.0, :: and "" too, in case this is a
+       * rehash
+       */
+      if (((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), "0.0.0.0"))
 #ifdef IPV6
-            || IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.sa)
+            || IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr)
 #endif
             ) && (dcc[i].port == port) && strcasecmp(type, "off") &&
             (strcmp(ip, "0.0.0.0")
 #ifdef IPV6
-            && !IN6_IS_ADDR_UNSPECIFIED(ip)
+            && !IN6_IS_ADDR_UNSPECIFIED(ipaddr2)
 #endif
             && strcmp(ip, ""))) {
-      Tcl_AppendResult(irp, "port is already bound to :: or 0.0.0.0, "
+        Tcl_AppendResult(irp, "port is already bound to :: or 0.0.0.0, "
             "first remove that entry with 'off' before adding the one just "
             "entered", NULL);
-      return TCL_ERROR;
+        return TCL_ERROR;
+      }
+
+      /* This specific IP/port pair is already in use, set tryagain to 0 so we
+       * don't try to listen again on this ip/port and cause a Tcl error
+       */
+      if ((!strcmp(iptostr(&dcc[idx].sockname.addr.sa), ip)) &&
+            (dcc[i].port == port) && strcasecmp(type, "off")) {
+        tryagain = 0;
+        break;
+      }
     }
   }
   if (!strcasecmp(type, "off")) {
@@ -1022,11 +1045,10 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     /* If we didn't find a listening ip/port, or we did but it isn't all
      * interfaces
      */
-    if ((!tryagain) || (strcmp(ip, "") && strcmp(ip, "0.0.0.0")
 #ifdef IPV6
-            && !IN6_IS_ADDR_UNSPECIFIED(ip)
+    if (((strcmp(ip, "") || strcmp(ip, "0.0.0.0")) && strcmp("0.0.0.0", iptostr(&dcc[idx].sockname.addr.sa))) || 
+        (IN6_IS_ADDR_UNSPECIFIED(ipaddr2) && strcmp("::", iptostr(&dcc[idx].sockname.addr.sa))))  {
 #endif
-            )) {
       if (strlen(ip)) {
         setsockname(&name, ip, port, 1);
         i = open_address_listen(&name);
@@ -1047,7 +1069,9 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       dcc[idx].port = port;
       dcc[idx].sock = i;
       dcc[idx].timeval = now;
+#ifdef IPV6
     }
+#endif
   }
 #ifdef TLS
   if (portp[0] == '+')


### PR DESCRIPTION
Fixed a bad cast for in6_addr, and learned that IN6_IS_ADDR_UNSPECIFIED does not check the family, thus occassionally giving false positives on an IPv4 address

```
.tcl listen :: 4444 all
[04:40:18] Listening for telnet connections on :: port 4444 (all).
Tcl: 4444
.tcl listen 0.0.0.0 4444 all
Tcl error: Couldn't listen on port '4444' on the given address: Address already in use. Please check that the port is not already in use
.tcl listen 127.0.0.1 4444 all
Tcl error: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered
.tcl listen ::1 4444 all
Tcl error: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered
.tcl listen 0.0.0.0 5555 all
[04:40:52] Listening for telnet connections on 0.0.0.0 port 5555 (all).
Tcl: 5555
.tcl listen :: 5555 all
Tcl error: Couldn't listen on port '5555' on the given address: Address already in use. Please check that the port is not already in use
.tcl listen 127.0.0.1 5555 all
Tcl error: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered
.tcl listen ::1 5555 all
Tcl error: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered
.tcl listen 127.0.0.1 6666 all
[04:41:09] Listening for telnet connections on 127.0.0.1 port 6666 (all).
Tcl: 6666
.tcl listen 192.168.1.4 6666 all
[04:43:22] Listening for telnet connections on 192.168.1.4 port 6666 (all).
Tcl: 6666
.tcl listen ::1 6666 all
[04:41:13] Listening for telnet connections on ::1 port 6666 (all).
Tcl: 6666
.tcl listen 0.0.0.0 6666 all
Tcl error: this port is already bound to a specific IP on this machine, remove it before trying bind to all interfaces
.tcl listen :: 6666 all
Tcl error: this port is already bound to a specific IP on this machine, remove it before trying bind to all interfaces
.rehash
[04:41:24] #-HQ# rehash
Rehashing.
.dcc
[04:43:25] #-HQ# dccstat
IDX ADDR                                     + PORT NICK      TYPE  INFO
--- ---------------------------------------- ------ --------- ----- ---------
5   0.0.0.0                                    3183 (telnet)  lstn  3183
1   0.0.0.0                                       0 -HQ       chat  flags: cptEp/0
9   159.65.18.165                              6667 (server)  serv  (lag: 0)
11  ::                                         4444 (telnet)  lstn  4444
12  0.0.0.0                                    5555 (telnet)  lstn  5555
13  127.0.0.1                                  6666 (telnet)  lstn  6666
14  ::1                                        6666 (telnet)  lstn  6666
15  192.168.1.4                                6666 (telnet)  lstn  6666

```


With --disable-ipv6:
```
.tcl listen 0.0.0.0 4444 all
[03:15:04] Listening for telnet connections on 0.0.0.0 port 4444 (all).
Tcl: 4444
.tcl listen 127.0.0.1 4444 all
Tcl error: port is already bound to :: or 0.0.0.0, first remove that entry with 'off' before adding the one just entered
.tcl listen 127.0.0.1 5555 all
[03:15:23] Listening for telnet connections on 127.0.0.1 port 5555 (all).
Tcl: 5555
.tcl listen 0.0.0.0 5555 all
Tcl error: this port is already bound to a specific IP on this machine, remove it before trying bind to all interfaces
.tcl listen 192.168.1.0 5555 all
[03:15:52] Listening for telnet connections on 192.168.1.7 port 5555 (all).
Tcl: 5555
```