### PR TITLE
Fix make error - Add -lnetwork if needed for b64

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -321,6 +321,24 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
     if test "x$found_b64_ntop" = xno; then
       LIBS="$OLD_LIBS"
       AC_MSG_RESULT(no)
+
+      AC_MSG_CHECKING(for b64_ntop with -lnetwork)
+      OLD_LIBS="$LIBS"
+      LIBS="-lnetwork"
+      AC_TRY_LINK(
+      [
+        #include <sys/types.h>
+        #include <netinet/in.h>
+        #include <resolv.h>
+        ],
+        [b64_ntop(NULL, 0, NULL, 0);],
+        found_b64_ntop=yes,
+        found_b64_ntop=no
+      )
+      if test "x$found_b64_ntop" = xno; then
+        LIBS="$OLD_LIBS"
+        AC_MSG_RESULT(no)
+      fi
     fi
   fi
   if test "x$found_b64_ntop" = xyes; then


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix make error - Add -lnetwork if needed for b64

Additional description (if needed):
Fix make error under Haiku R1/beta2
Don't forget **misc/runautotools**


Test cases demonstrating functionality (if applicable):
Before:
```
$ ./configure
[...]
checking for b64_ntop... no
checking for b64_ntop with -lresolv... no
[...]
$ make
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/boot/michael/opt/tcl-8.6.10/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o  -L/boot/michael/opt/tcl-8.6.10/lib -ltcl8.6 -lroot -lz -lpthread -lnetwork -lssl -lcrypto  md5/md5c.o compat/*.o `cat mod/mod.xlibs`
/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/8.3.0/../../../../x86_64-unknown-haiku/bin/ld: modules.o:(.data.rel+0x988): undefined reference to `b64_ntop'
/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/8.3.0/../../../../x86_64-unknown-haiku/bin/ld: modules.o:(.data.rel+0x990): undefined reference to `b64_pton'
collect2: error: ld returned 1 exit status
Makefile:44: recipe for target 'link' failed
make[2]: *** [link] Error 1
make[2]: Leaving directory '/boot/michael/usr/src/eggdrop/src'
Makefile:53: recipe for target '../eggdrop' failed
make[1]: *** [../eggdrop] Error 2
make[1]: Leaving directory '/boot/michael/usr/src/eggdrop/src'
Makefile:251: recipe for target 'debug' failed
make: *** [debug] Error 2
```
After:
```
$ ./configure
[...]
checking for b64_ntop... no
checking for b64_ntop with -lresolv... no
checking for b64_ntop with -lnetwork... yes
[...]
$ make
[...]
Eggdrop successfully compiled:
[...]
```