### PR TITLE
Fix make error under macos

### DIFF
--- a/src/compat/explicit_bzero.c
+++ b/src/compat/explicit_bzero.c
@@ -45,6 +45,7 @@
 
 #include <stddef.h>
 #include <string.h>
+#include "main.h"
 
 /* LCOV_EXCL_START */
 #ifdef HAVE_WEAK_SYMBOLS
@@ -68,7 +69,7 @@ explicit_bzero(void *const pnt, const size_t len)
     SecureZeroMemory(pnt, len);
 #elif defined(HAVE_MEMSET_S)
     if (len > 0U && memset_s(pnt, (rsize_t) len, 0, (rsize_t) len) != 0) {
-        sodium_misuse(); /* LCOV_EXCL_LINE */
+        fatal("explicit_bzero misuse", 0); /* LCOV_EXCL_LINE */
     }
 #elif defined(HAVE_EXPLICIT_MEMSET)
     explicit_memset(pnt, 0, len);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
```
$ make
[...]
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/Users/michael/opt/openssl-1.1.1g/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c explicit_bzero.c
explicit_bzero.c:71:9: warning: implicit declaration of function 'sodium_misuse' is invalid in C99
      [-Wimplicit-function-declaration]
        sodium_misuse(); /* LCOV_EXCL_LINE */
[...]
gcc -g -O2 -pipe -Wall -I.. -I.. -I/Users/michael/opt/openssl-1.1.1g/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o mod/*.o -L/Users/michael/opt/openssl-1.1.1g/lib -F/System/Library/Frameworks -framework Tcl -lpthread -framework CoreFoundation -lssl -lcrypto  -lresolv md5/md5c.o compat/*.o `cat mod/mod.xlibs`
Undefined symbols for architecture x86_64:
  "_sodium_misuse", referenced from:
      _explicit_bzero in explicit_bzero.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [link] Error 1
make[1]: *** [../eggdrop] Error 2
make: *** [static] Error 2
```

Test cases demonstrating functionality (if applicable):
```
.status
[07:02:20] tcl: builtin dcc call: *dcc:status -HQ 1 
[07:02:20] #-HQ# status
I am BotA, running eggdrop v1.9.0+newcaps: 3 users (mem: 264k).
Online for 00:00 (terminal mode) - CPU: 00:00.03 - Cache hit: 66.7%
Configured with: '--with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh' '--with-sslinc=/Users/michael/opt/openssl-1.1.1g/include' '--with-ssllib=/Users/michael/opt/openssl-1.1.1g/lib'
Admin: Lamer <email: lamer@lamest.lame.org>
Config file: BotA.conf
OS: Darwin 19.5.0
Process ID: 29626 (parent 29620)
Tcl library: /System/Library/Frameworks/Tcl.framework/Versions/8.5/Resources/Scripts
Tcl version: 8.5.9 (header version 8.5.9)
Tcl is threaded.
TLS support is enabled.
TLS library: OpenSSL 1.1.1g  21 Apr 2020
IPv6 support is enabled.
Socket table: 20/100
Loaded module information:
    Account tracking: Disabled
      (Missing capabilities: use-354 extended-join account-notify)
    No server currently.
    Active CAP negotiations: None
```