### PR TITLE
Fix u_char->uint8_t, because it is not c99 nor POSIX, fix for diet libc

### DIFF
--- a/src/compat/base64.c
+++ b/src/compat/base64.c
@@ -150,10 +150,10 @@ static const char Pad64 = '=';
    */
 
 int
-b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize) {
+b64_ntop(uint8_t const *src, size_t srclength, char *target, size_t targsize) {
 	size_t datalength = 0;
-	u_char input[3];
-	u_char output[4];
+	uint8_t input[3];
+	uint8_t output[4];
 	size_t i;
 
 	while (2 < srclength) {
@@ -216,10 +216,10 @@ b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize) {
  */
 
 int
-b64_pton(const char *src, u_char *target, size_t targsize)
+b64_pton(const char *src, uint8_t *target, size_t targsize)
 {
 	int tarindex, state, ch;
-	u_char nextbyte;
+	uint8_t nextbyte;
 	char *pos;
 
 	state = 0;

--- a/src/compat/base64.h
+++ b/src/compat/base64.h
@@ -24,8 +24,8 @@
 #define _EGG_COMPAT_BASE64_H_
 
 #ifndef HAVE_BASE64
-int b64_ntop(u_char const *, size_t, char *, size_t);
-int b64_pton(const char *, u_char *, size_t);
+int b64_ntop(uint8_t const *, size_t, char *, size_t);
+int b64_pton(const char *, uint8_t *, size_t);
 #endif /* HAVE_BASE64 */
 
 #endif /* _EGG_COMPAT_BASE64_H_ */

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -502,8 +502,8 @@
 /* 304 - 307 */
 #define strncpyz ((size_t (*) (char *, const char *, size_t))global[304])
 #ifndef HAVE_BASE64
-# define b64_ntop ((int (*) (u_char const *, size_t, char *, size_t))global[305])
-# define b64_pton ((int (*) (const char *, u_char *, size_t))global[306])
+# define b64_ntop ((int (*) (uint8_t const *, size_t, char *, size_t))global[305])
+# define b64_pton ((int (*) (const char *, uint8_t *, size_t))global[306])
 #endif
 #define check_validpass ((char *(*) (struct userrec *, char *))global[307])
 /* 308 - 311 */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -20,6 +20,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#undef answer /* before resolv.h because it could collide with src/mod/module.h
+		 (dietlibc) */
 #include <resolv.h> /* base64 encode b64_ntop() and base64 decode b64_pton() */
 #ifdef TLS
   #include <openssl/err.h>


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
This patch helps portability, esp. for diet libc.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
