### PR TITLE
Fix write() error handling

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -75,7 +75,7 @@ static void ident_activity(int idx, char *buf, int len)
     if (i < 0)
       putlog(LOG_MISC, "*", "Ident error: %s", strerror(errno));
     else
-      putlog(LOG_MISC, "*", "Ident error: could not write response. Wrote %i instead of %i bytes.", i, count);
+      putlog(LOG_MISC, "*", "Ident error: Wrote %i bytes instead of %i bytes.", i, count);
     return;
   }
   putlog(LOG_MISC, "*", "Ident: Responded.");

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -54,6 +54,7 @@ static void ident_activity(int idx, char *buf, int len)
 {
   int s;
   char buf2[IDENT_SIZE + sizeof " : USERID : UNIX : \r\n" + NICKLEN], *pos;
+  size_t count;
   ssize_t i;
 
   s = answer(dcc[idx].sock, &dcc[idx].sockname, 0, 0);
@@ -69,8 +70,12 @@ static void ident_activity(int idx, char *buf, int len)
     return;
   } 
   snprintf(pos, (sizeof buf2) - (pos - buf2), " : USERID : UNIX : %s\r\n", botname);
-  if ((i = write(s, buf2, strlen(buf2) + 1)) < 0) {
-    putlog(LOG_MISC, "*", "Ident error: %s", strerror(errno));
+  count = strlen(buf2) + 1;
+  if ((i = write(s, buf2, count)) != count) {
+    if (i < 0)
+      putlog(LOG_MISC, "*", "Ident error: %s", strerror(errno));
+    else
+      putlog(LOG_MISC, "*", "Ident error: could not write response. Wrote %i instead of %i bytes.", i, count);
     return;
   }
   putlog(LOG_MISC, "*", "Ident: Responded.");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix write() error handling

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Developer test with ident-method 1 was successful:
```
./eggdrop -nt BotA.conf
[...]
[23:00:52] Trying server 127.0.0.1:6667
[23:00:52] Ident: Starting ident server.
[23:00:52] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[23:00:52] net: connect! sock 9
[23:00:52] Connected to 127.0.0.1
[23:00:52] net: connect! sock 10
[23:00:52] Ident: Responded.
[23:00:52] Ident: Stopping ident server.
```