### PR TITLE
Fix dead assignment, more strlcpy() / snprintf() and fix format secifiers to make Codacy happy

### DIFF
--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -471,17 +471,17 @@ targetcont:
   work = now - laston;
   if (work >= 86400) {
     tv = work / 86400;
-    snprintf(word2, sizeof word2, "%lu day%s, ", tv, (tv == 1) ? "" : "s");
+    snprintf(word2, sizeof word2, "%li day%s, ", tv, (tv == 1) ? "" : "s");
     work = work % 86400;
   }
   if (work >= 3600) {
     tv = work / 3600;
-    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%lu hour%s, ", tv, (tv == 1) ? "" : "s");
+    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%li hour%s, ", tv, (tv == 1) ? "" : "s");
     work = work % 3600;
   }
   if (work >= 60) {
     tv = work / 60;
-    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%lu minute%s, ", tv,
+    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%li minute%s, ", tv,
             (tv == 1) ? "" : "s");
   }
   if (!word2[0] && (work < 60)) {

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -184,7 +184,7 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
       !oix[2]) || (!oix[1] && (oix[-1] == 's' || oix[-1] == 'z' ||
       oix[-1] == 'x' || oix[-1] == 'S' || oix[-1] == 'Z' ||
       oix[-1] == 'X')))) {
-    strncpy(object, word1, oix - word1);
+    strlcpy(object, word1, sizeof object);
     object[oix - word1] = 0;
     wordshift(word1, text);
     if (!word1[0]) {
@@ -476,18 +476,18 @@ targetcont:
   }
   if (work >= 3600) {
     tv = work / 3600;
-    sprintf(word2 + strlen(word2), "%lu hour%s, ", tv, (tv == 1) ? "" : "s");
+    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%lu hour%s, ", tv, (tv == 1) ? "" : "s");
     work = work % 3600;
   }
   if (work >= 60) {
     tv = work / 60;
-    sprintf(word2 + strlen(word2), "%lu minute%s, ", tv,
+    snprintf(word2 + strlen(word2), (sizeof word2) - strlen(word2), "%lu minute%s, ", tv,
             (tv == 1) ? "" : "s");
   }
   if (!word2[0] && (work < 60)) {
     strlcpy(word2, "just moments ago!!", sizeof word2);
   } else {
-    strcpy(word2 + strlen(word2) - 2, " ago.");
+    strlcpy(word2 + strlen(word2) - 2, " ago.", (sizeof word2) - strlen(word2) + 2);
   }
   if (lastonplace[0] && (strchr(CHANMETA, lastonplace[0]) != NULL))
     snprintf(word1, sizeof word1, "on IRC channel %s", lastonplace);

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -367,7 +367,6 @@ targetcont:
         snprintf(word2, sizeof word2, "%s!%s", m->nick, m->userhost);
         urec = get_user_by_host(word2);
         if (urec && !strcasecmp(urec->handle, whotarget)) {
-          onchan = 1;
           strcat(whoredirect, whotarget);
           strcat(whoredirect, " is ");
           strcat(whoredirect, m->nick);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix dead assignment, more strlcpy() / snprintf() and fix format secifiers to make Codacy happy

Additional description (if needed):
No functional difference

Test cases demonstrating functionality (if applicable):
