### PR TITLE
(Low Prio) Fix dead nested assignment

### DIFF
--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1509,8 +1509,7 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
         dprintf(idx, "Usage: chanset [%schannel] <settings>\n", CHANMETA);
         return;
       }
-      if (!chan &&
-          !(chan = findchan_by_dname(chname = dcc[idx].u.chat->con_chan))) {
+      if (!chan && !findchan_by_dname(chname = dcc[idx].u.chat->con_chan)) {
         dprintf(idx, "Invalid console channel.\n");
         return;
       }

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1509,7 +1509,7 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
         dprintf(idx, "Usage: chanset [%schannel] <settings>\n", CHANMETA);
         return;
       }
-      if (!chan && !findchan_by_dname(chname = dcc[idx].u.chat->con_chan)) {
+      if (!chan && !(chan = findchan_by_dname(dcc[idx].u.chat->con_chan))) {
         dprintf(idx, "Invalid console channel.\n");
         return;
       }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann, Cizzle
Fixes: 

One-line summary:
Fix dead nested assignment

Additional description (if needed):
Although the value stored to 'chname' is used in the enclosing expression, the value is never actually read from 'chname'

Test cases demonstrating functionality (if applicable):
No functional change