### PR TITLE
Update userinfo.tcl

### DIFF
--- a/scripts/userinfo.tcl
+++ b/scripts/userinfo.tcl
@@ -1,4 +1,4 @@
-# userinfo.tcl v1.06 for Eggdrop 1.4.3 and higher
+# userinfo.tcl v1.08 for Eggdrop 1.4.3 and higher
 #           Scott G. Taylor -- ButchBub!staylor@mrynet.com
 #
 # v1.00      ButchBub     14 July      1997 -Original release.  Based on
@@ -20,10 +20,12 @@
 # v1.07      TaKeDa       20 August    2001 -now script works also on bots,
 #                                            which didn't have server module loaded
 #                                           -added new fields PHONE & ICQ
+# v1.08      mortmann     16 July      2020 -removed field ICQ
+#                                           -added new fields YOUTUBE and TWITCH
 #
 # TO USE:  o    Set the desired userinfo field keywords to the
 #               `userinfo-fields' line below where indicated.
-#          o    Load this script on a 1.1.6 or later Eggdrop bot.
+#          o    Load this script on a 1.4.3 or later Eggdrop bot.
 #          o    Begin having users save the desired information.  If you
 #               choose to add the default "IRL" field, they just use
 #               the IRC command: /MSG <botnick> irl Joe Blow.
@@ -61,18 +63,19 @@
 #   DOB     Birthday (Date Of Birth)
 #   EMAIL   Email address
 #   PHONE   Phone number
-#   ICQ     ICQ number
+#   YOUTUBE YouTube channel
+#   TWITCH  Twitch channel
 
 
 ################################
 # Set your desired fields here #
 ################################
 
-set userinfo-fields "URL BF GF IRL EMAIL DOB PHONE ICQ"
+set userinfo-fields "URL BF GF IRL EMAIL DOB PHONE YOUTUBE TWITCH"
 
 # This script's identification
 
-set userinfover "Userinfo TCL v1.07"
+set userinfover "Userinfo TCL v1.08"
 
 # This script is NOT for pre-1.4.3 versions.
 

--- a/scripts/userinfo.tcl
+++ b/scripts/userinfo.tcl
@@ -19,9 +19,8 @@
 #                                            lastbind is fixed in eggdrop1.4.3
 # v1.07      TaKeDa       20 August    2001 -now script works also on bots,
 #                                            which didn't have server module loaded
-#                                           -added new fields PHONE & ICQ
-# v1.08      mortmann     16 July      2020 -removed field ICQ
-#                                           -added new fields YOUTUBE and TWITCH
+#                                           -added new fields PHONE and ICQ
+# v1.08      mortmann     16 July      2020 -added new fields YOUTUBE and TWITCH
 #
 # TO USE:  o    Set the desired userinfo field keywords to the
 #               `userinfo-fields' line below where indicated.
@@ -63,6 +62,7 @@
 #   DOB     Birthday (Date Of Birth)
 #   EMAIL   Email address
 #   PHONE   Phone number
+#   ICQ     ICQ number
 #   YOUTUBE YouTube channel
 #   TWITCH  Twitch channel
 
@@ -71,7 +71,7 @@
 # Set your desired fields here #
 ################################
 
-set userinfo-fields "URL BF GF IRL EMAIL DOB PHONE YOUTUBE TWITCH"
+set userinfo-fields "URL BF GF IRL EMAIL DOB PHONE ICQ YOUTUBE TWITCH"
 
 # This script's identification
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Added new fields YOUTUBE and TWITCH

Additional description (if needed):
First i removed ICQ, because ICQ is dead since 2018/2019 when its OSCAR protocol was disabled. But after vanosg stated it is not dead yet, i readded ICQ, to let that zombie live on.

Test cases demonstrating functionality (if applicable):
