### PR TITLE
Fix declaration of host

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -464,7 +464,7 @@ void call_ipbyhost(char *hostn, sockname_t *ip, int ok)
  */
 void block_dns_hostbyip(sockname_t *addr)
 {
-  char host[UHOSTLEN];
+  char host[256] = "";
   volatile int i = 1;
 
   if (addr->family == AF_INET) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
in case of error, an undefined host would be returned, which looks problematic, better be safe than sorry here.

Additional description (if needed):
a hostname is max 256 chars, not UHOSTLEN. UHOSTLEN is greater than 256 currently, but also, better be safe than sorry.

Test cases demonstrating functionality (if applicable):
