### PR TITLE
Fix parallel ipv6 resolving

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -125,9 +125,14 @@ static void dns_dcchostbyip(sockname_t *ip, char *hostn, int ok, void *other)
         (ip->family == AF_INET6 &&
           IN6_ARE_ADDR_EQUAL(&dcc[idx].u.dns->ip->addr.s6.sin6_addr,
                              &ip->addr.s6.sin6_addr)) ||
+        (ip->family == AF_INET &&
 #endif
           (dcc[idx].u.dns->ip->addr.s4.sin_addr.s_addr ==
-                              ip->addr.s4.sin_addr.s_addr))) {
+                              ip->addr.s4.sin_addr.s_addr)))
+#ifdef IPV6
+       )
+#endif
+    {
       if (dcc[idx].u.dns->host)
         nfree(dcc[idx].u.dns->host);
       dcc[idx].u.dns->host = get_data_ptr(strlen(hostn) + 1);
@@ -403,9 +408,14 @@ void call_hostbyip(sockname_t *ip, char *hostn, int ok)
         (ip->family == AF_INET6 &&
           IN6_ARE_ADDR_EQUAL(&de->res_data.ip_addr->addr.s6.sin6_addr,
                              &ip->addr.s6.sin6_addr)) ||
+        (ip->family == AF_INET &&
 #endif
           (de->res_data.ip_addr->addr.s4.sin_addr.s_addr ==
-                              ip->addr.s4.sin_addr.s_addr))) {
+                              ip->addr.s4.sin_addr.s_addr)))
+#ifdef IPV6
+        )
+#endif
+    {
         /* A memcmp() could have perfectly done it .. */
       /* Remove the event from the list here, to avoid conflicts if one of
        * the event handlers re-adds another event. */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1017

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.loadmod dns
[23:19:13] tcl: builtin dcc call: *dcc:loadmod -HQ 1 dns
[23:19:13] Module loaded: dns             
[23:19:13] #-HQ# loadmod dns
Module loaded: dns             
.tcl dnslookup fd9f:de9c:36c5:eda1::1 foo1
.tcl dnslookup ::2 foo3
[23:19:18] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup fd9f:de9c:36c5:eda1::1 foo1
[23:19:18] tcl: evaluate (.tcl): dnslookup fd9f:de9c:36c5:eda1::1 foo1
[23:19:18] DNS Resolver: Creating new record
[23:19:18] DNS Resolver: Sent domain lookup request for "fd9f:de9c:36c5:eda1::1".
Tcl: 
[23:19:18] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup ::2 foo3
[23:19:18] tcl: evaluate (.tcl): dnslookup ::2 foo3
[23:19:18] DNS Resolver: Creating new record
[23:19:18] DNS Resolver: Sent domain lookup request for "::2".
Tcl: 
[23:19:18] DNS Resolver: Domain does not exist.
[23:19:18] DNS Resolver: Lookup failed.
[23:19:18] DNS resolve failed for fd9f:de9c:36c5:eda1::1
[23:19:18] Tcl error [foo1]: invalid command name "foo1"
[23:19:18] DNS Resolver: Domain does not exist.
[23:19:18] DNS Resolver: Lookup failed.
[23:19:18] DNS resolve failed for ::2
[23:19:18] Tcl error [foo3]: invalid command name "foo3"
invalid command name "foo1"
    while executing
"foo1 fd9f:de9c:36c5:eda1::1 fd9f:de9c:36c5:eda1::1 0"
invalid command name "foo3"
    while executing
"foo3 ::2 ::2 0"
```

Also tested with --disable-ipv6