### PR TITLE
Fix make error with older gcc (like from 2016) that default to -std=gnu89

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -184,6 +184,25 @@ EOF
 ])
 
 
+dnl EGG_CHECK_CC_C99()
+dnl
+dnl Check for a working C99 C compiler.
+dnl
+AC_DEFUN([EGG_CHECK_CC_C99],
+[
+  if test "$ac_cv_prog_cc_c99" = no; then
+    cat << 'EOF' >&2
+configure: error:
+
+  This C compiler does not appear to have a working C99 mode.
+  A working C99 C compiler is required to compile Eggdrop.
+
+EOF
+    exit 1
+  fi
+])
+
+
 dnl EGG_HEADER_STDC()
 dnl
 AC_DEFUN([EGG_HEADER_STDC],
@@ -224,20 +243,6 @@ AC_DEFUN([EGG_CHECK_ICC],[
     ICC="yes"
   else
     ICC="no"
-  fi
-])
-
-
-dnl EGG_CHECK_CCPIPE()
-dnl
-dnl This macro checks whether or not the compiler supports the `-pipe' flag,
-dnl which speeds up the compilation.
-dnl
-AC_DEFUN([EGG_CHECK_GCCC99],
-[
-  if test "$GCC" = yes; then
-    AC_MSG_NOTICE([GCC found, -std=c99 added])
-    CC="$CC -std=c99"
   fi
 ])
 
@@ -756,9 +761,6 @@ AC_DEFUN([EGG_CHECK_OS],
     ;;
     Linux)
       LINUX="yes"
-      if test "$GCC" = yes; then
-        CFLAGS="-D_DEFAULT_SOURCE -D_BSD_SOURCE $CFLAGS"
-      fi
       MOD_LD="$CC"
       SHLIB_CC="$CC -fPIC"
       SHLIB_LD="$CC -shared -nostartfiles"

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -233,6 +233,20 @@ dnl
 dnl This macro checks whether or not the compiler supports the `-pipe' flag,
 dnl which speeds up the compilation.
 dnl
+AC_DEFUN([EGG_CHECK_GCCC99],
+[
+  if test "$GCC" = yes; then
+    AC_MSG_NOTICE([GCC found, -std=c99 added])
+    CC="$CC -std=c99"
+  fi
+])
+
+
+dnl EGG_CHECK_CCPIPE()
+dnl
+dnl This macro checks whether or not the compiler supports the `-pipe' flag,
+dnl which speeds up the compilation.
+dnl
 AC_DEFUN([EGG_CHECK_CCPIPE],
 [
   if test "$GCC" = yes && test "$ICC" = no; then
@@ -743,7 +757,7 @@ AC_DEFUN([EGG_CHECK_OS],
     Linux)
       LINUX="yes"
       if test "$GCC" = yes; then
-        CFLAGS="-std=c99 -D_DEFAULT_SOURCE -D_BSD_SOURCE $CFLAGS"
+        CFLAGS="-D_DEFAULT_SOURCE -D_BSD_SOURCE $CFLAGS"
       fi
       MOD_LD="$CC"
       SHLIB_CC="$CC -fPIC"

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -742,6 +742,9 @@ AC_DEFUN([EGG_CHECK_OS],
     ;;
     Linux)
       LINUX="yes"
+      if test "$GCC" = yes; then
+        CFLAGS="-std=c99 -D_DEFAULT_SOURCE -D_BSD_SOURCE $CFLAGS"
+      fi
       MOD_LD="$CC"
       SHLIB_CC="$CC -fPIC"
       SHLIB_LD="$CC -shared -nostartfiles"

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ EGG_SAVE_PARAMETERS
 # Check for a working C compiler
 AC_PROG_CC([gcc cc clang])
 EGG_CHECK_CC
+AC_PROG_CC_C99
+EGG_CHECK_CC_C99
 
 # These 3 need to be done before any AC_COMPILE_IFELSE()'s.
 AC_AIX
@@ -51,7 +53,6 @@ AC_MINIX
 
 # Check C compiler characteristics.
 EGG_CHECK_ICC
-EGG_CHECK_GCCC99
 EGG_CHECK_CCPIPE
 EGG_CHECK_CCWALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_MINIX
 
 # Check C compiler characteristics.
 EGG_CHECK_ICC
+EGG_CHECK_GCCC99
 EGG_CHECK_CCPIPE
 EGG_CHECK_CCWALL
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix make error with older gcc with default -std=gnu89

Additional description (if needed):
**Please run misc/runautotools with this PR.**

Problem with current eggdrop version f92829c88c5092260cc1ed148557397a955895bb (20200908) since isupport.c was merged

Older but not ancient gcc, like version 4.9.4 (released August 3, 2016) default to -std=gnu89 https://gcc.gnu.org/onlinedocs/gcc-4.9.4/gcc/C-Dialect-Options.html#C-Dialect-Options, but eggdrop uses more and more c99 features without setting gcc into c99 mode, meanwhile leading to make errors and warning.

gccs -std=gnu89 allows parts of c99. This was shadowing the problem until now.

Meanwhile gcc 4.8.5 under netbsd, also not ancient, version 7.1.2 (released March 15, 2018) suffers from hard make error:
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/pkg/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
In file included from .././server.mod/server.c:143:0:
.././server.mod/isupport.c: In function 'find_record':
.././server.mod/isupport.c:178:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (isupport_t *data = isupport_list; data; data = data->next) {
   ^
.././server.mod/isupport.c:178:3: note: use option -std=c99 or -std=gnu99 to compile your code
.././server.mod/isupport.c: In function 'isupport_clear_values':
.././server.mod/isupport.c:391:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (struct isupport *data = isupport_list; (next = data ? data->next : NULL, data); data = next) {
   ^
.././server.mod/isupport.c: In function 'isupport_expmem':
.././server.mod/isupport.c:450:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (struct isupport *data = isupport_list; data; data = data->next) {
   ^
.././server.mod/isupport.c: In function 'isupport_report':
.././server.mod/isupport.c:494:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (struct isupport *data = isupport_list; data; data = data->next) {
   ^
.././server.mod/isupport.c:502:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (struct isupport *data = isupport_list; data; data = data->next) {
     ^
In file included from .././server.mod/server.c:144:0:
.././server.mod/tclisupport.c: In function 'tcl_isupport_get':
.././server.mod/tclisupport.c:78:4: error: 'for' loop initial declarations are only allowed in C99 mode
    for (struct isupport *data = isupport_list; data; data = data->next) {
    ^
.././server.mod/tclisupport.c: In function 'traced_isupport':
.././server.mod/tclisupport.c:162:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (struct isupport *data = isupport_list; data; data = data->next) {
     ^
*** Error code 1

Stop.
make[2]: stopped in /home/michael/usr/src/eggdrop/src/mod/server.mod
*** Error code 1

Stop.
make[1]: stopped in /home/michael/usr/src/eggdrop/src/mod
*** Error code 1

Stop.
make: stopped in /home/michael/usr/src/eggdrop
```

while gcc 4.3 under fedora 10 suffers "only" from compiler warnings

Test cases demonstrating functionality (if applicable):
gcc 4.8.5 under netbsd 7.1.2:
```
$ ./configure
[...]
checking for gcc option to accept ISO C99... -std=gnu99
[...]
$ make
[...]
gcc -std=gnu99 -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/pkg/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
[...]
```