### PR TITLE
Fix format specifier for intptr_t with c99 PRIdPTR

### DIFF
--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1425,7 +1425,7 @@ static void cmd_chaninfo(struct userrec *u, int idx, char *par)
           dprintf(idx, "User defined channel settings:\n");
           tmp = 1;
         }
-        egg_snprintf(work + work_len, sizeof(work) - work_len, "%s: %d   ",
+        egg_snprintf(work + work_len, sizeof(work) - work_len, "%s: %" PRIdPTR "   ",
                      ul->name, getudef(ul->values, chan->dname));
         ii++;
         if (ii > 4) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format specifier for `intptr_t` with c99 `PRIdPTR`

Additional description (if needed):
https://github.com/eggheads/eggdrop/blob/f92829c88c5092260cc1ed148557397a955895bb/src/mod/channels.mod/cmdschan.c#L1428 prints an `intptr_t` with %d. The compiler would throw a warning, but it's shadowed, due to eggdrop using `egg_snprintf()` instead of `snprintf()`. I found this with #1028. To test this, i printed an `intptr_t` with `%d` and the result was different from `%ld` with my 64 bit test system:
```
%d      : 415729632
%ld     : 139724291803104
PRIdPTR : 139724291803104
```
The solution is to use a c99 format specifier macro for `intptr_t`. Yeah, c99 comes to the rescue again. So i changed `%d `into `PRIdPTR`.

Test cases demonstrating functionality (if applicable):
```
.tcl setudef int 23
.chanset 23 <number>
.chaninfo
```
is the same before and after this PR, because **eggdrop doesn't validate the input and seems to use int32 internally, So there is another issue, we could fix, if need be:**
```
.tcl setudef int 23
.chanset 23 6666666666
.chaninfo
[...]
User defined channel settings:
23: -1923267926
[...]
```
The following compiler warning after #1028 is fixed by this PR:
```
.././channels.mod/cmdschan.c: In function ‘cmd_chaninfo’:
.././channels.mod/cmdschan.c:1428:66: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘intptr_t’ {aka ‘long int’} [-Wformat=]
 1428 |         snprintf(work + work_len, sizeof(work) - work_len, "%s: %d   ",
      |                                                                 ~^
      |                                                                  |
      |                                                                  int
      |                                                                 %ld
 1429 |                      ul->name, getudef(ul->values, chan->dname));
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
      |                                |
      |                                intptr_t {aka long int}
```
**`.save` doesn't save user defined channel settings. I don't know if this is by design or if this is another bug.**