### PR TITLE
Upsize fgets()-buffer from 1024 to 8 * 1024 and add fgets()-error-check

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1202,12 +1202,12 @@ static void dns_lookup(sockname_t *addr)
   sendrequest(rp, T_PTR);
 }
 
-/* Read /etc/hosts 	*/
+/* Read /etc/hosts */
 static int dns_hosts(char *hostn) {
   #define PATH "/etc/hosts"
   size_t hostn_len;
   int i;
-  char hostn_lower[256], hostn_upper[256], line[1024], *p1, *p2, *p3, *p4;
+  char hostn_lower[256], hostn_upper[256], line[8 * 1024], *p1, *p2, *p3, *p4;
   FILE *hostf;
   sockname_t name;
 #ifdef IPV6
@@ -1289,6 +1289,10 @@ static int dns_hosts(char *hostn) {
       }
       p2++;
     }
+  }
+  if (ferror(hostf)) {
+    ddebug0(RES_MSG "fgets(" PATH ")");
+    return 0;
   }
 #ifdef IPV6
   if (fallback_set) {


### PR DESCRIPTION
Found by: thommey
Patch by: michaelortmann
Fixes: 

One-line summary:
This is a small follow-up to #701

Additional description (if needed):
https://github.com/eggheads/eggdrop/pull/701#pullrequestreview-501616659
Some implementations using fgets() for /etc/hosts use larger buffers than 1k, like glibc, which used 8k here:
https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/resolv/compat-gethnamaddr.c#L83

Test cases demonstrating functionality (if applicable):
