### PR TITLE
Fix .servers

### DIFF
--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -68,13 +68,13 @@ static void cmd_servers(struct userrec *u, int idx, char *par)
         strlcpy(setpass, "", sizeof setpass);
       }
       if ((i == curserv) && realservername) {
-        len += snprintf(s+len, sizeof s - len, "%d%s (%s) <- I am here",
-                        x->port ? x->port : default_port, setpass,
-                        realservername);
+        snprintf(s+len, sizeof s - len, "%d%s (%s) <- I am here",
+                 x->port ? x->port : default_port, setpass,
+                 realservername);
       } else {
         snprintf(s+len, sizeof s - len, "%d%s%s",
-                        x->port ? x->port : default_port, setpass,
-                        (i == curserv) ? " <- I am here" : "");
+                 x->port ? x->port : default_port, setpass,
+                 (i == curserv) ? " <- I am here" : "");
       }
       dprintf(idx, "%s\n", s);
       i++;

--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -72,7 +72,7 @@ static void cmd_servers(struct userrec *u, int idx, char *par)
                         x->port ? x->port : default_port, setpass,
                         realservername);
       } else {
-        len += snprintf(s+len, sizeof s - len, "%d%s%s",
+        snprintf(s+len, sizeof s - len, "%d%s%s",
                         x->port ? x->port : default_port, setpass,
                         (i == curserv) ? " <- I am here" : "");
       }

--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -60,20 +60,21 @@ static void cmd_servers(struct userrec *u, int idx, char *par)
         t = time(NULL);
         currtm = localtime(&t); /* ******* */
         if ((currtm->tm_mon == 3) && (currtm->tm_mday == 1)) {
-          strlcpy(setpass, "(hunter2)", sizeof setpass);
+          strlcpy(setpass, " (hunter2)", sizeof setpass);
         } else {
-          strlcpy(setpass, "(password)", sizeof setpass);
+          strlcpy(setpass, " (password)", sizeof setpass);
         }
       } else {
         strlcpy(setpass, "", sizeof setpass);
       }
       if ((i == curserv) && realservername) {
-        len += egg_snprintf(s+len, sizeof s - len, "%d (%s) <- I am here",
-                x->port ? x->port : default_port, setpass, realservername);
-      }  else {
-        len += egg_snprintf(s+len, sizeof s - len, "%d %s",
-                x->port ? x->port : default_port, setpass,
-                (i == curserv) ? "<- I am here" : "");
+        len += snprintf(s+len, sizeof s - len, "%d%s (%s) <- I am here",
+                        x->port ? x->port : default_port, setpass,
+                        realservername);
+      } else {
+        len += snprintf(s+len, sizeof s - len, "%d%s%s",
+                        x->port ? x->port : default_port, setpass,
+                        (i == curserv) ? " <- I am here" : "");
       }
       dprintf(idx, "%s\n", s);
       i++;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix .servers (realservername), broken since https://github.com/eggheads/eggdrop/commit/7d94a5b8e7cdbffab11e66e391b8444a1767cac5

Additional description (if needed):
Found with #1028, but can/should be merged independently before #1028.

Test cases demonstrating functionality (if applicable):
Before:
```
.servers
Server list:
  127.0.0.1:6667 
  localhost:6667 () <- I am here
End of server list.
```
After:
```
.servers
Server list:
  127.0.0.1:6667
  localhost:6667 (zen.localdomain) <- I am here
End of server list.
```