### PR TITLE
Fix function / snprintf cast

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1231,14 +1231,14 @@ static void next_server(int *ptr, char *serv, unsigned int *port, char *pass)
 
 static int server_6char STDVAR
 {
-  Function F = (Function) cd;
+  IntFunc F = (IntFunc) cd;
   char x[20];
 
   BADARGS(7, 7, " nick user@host handle dest/chan keyword text");
 
   CHECKVALIDITY(server_6char);
-  egg_snprintf(x, sizeof x, "%d",
-               F(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]));
+  snprintf(x, sizeof x, "%d",
+           F(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]));
   Tcl_AppendResult(irp, x, NULL);
   return TCL_OK;
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix function / snprintf cast in preparation of #1028

Additional description (if needed):
Found with #1028, but can/should be merged independently before #1028.

Test cases demonstrating functionality (if applicable):
No functional / visual change, just fixing what would cause the following compiler warning after #1028:
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
.././server.mod/server.c: In function ‘server_6char’:
.././server.mod/server.c:1240:27: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘intptr_t’ {aka ‘long int’} [-Wformat=]
 1240 |   snprintf(x, sizeof x, "%d",
      |                          ~^
      |                           |
      |                           int
      |                          %ld
 1241 |                F(argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]));
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                |
      |                intptr_t {aka long int}

```