### PR TITLE
Add more compile help for macOS

### DIFF
--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -210,10 +210,18 @@ Last revised: June 9, 2020
       If you notice a module that requires these changes, it would probably be
       a good idea to let the module's developer know, so it can be fixed.
 
-
       Note that on Mac OS X, the DYLD_LIBRARY_PATH environment variable should
       be used instead of LD_LIBRARY_PATH.
 
+      Install OpenSSL using homebrew:
+
+        Install homebrew from https://brew.sh/
+        brew update
+        brew install openssl
+
+      Tell configure where to find tcl and openssl:
+
+        ./configure --with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh --with-sslinc=/usr/local/opt/openssl/include --with-ssllib=/usr/local/opt/openssl/lib
 
     E. AIX
       Follow the standard compile process in Section A. To compile dynamically


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add more compile help for macOS

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Test on macOS Catalina 10.15.7 Darwin 19.6.0 clang 12.0.0:
```
michael@macos eggdrop % ./configure --with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh --with-sslinc=/usr/local/opt/openssl/include --with-ssllib=/usr/local/opt/openssl/lib

This is Eggdrop's GNU configure script.
It's going to run a bunch of tests to hopefully make your compile
work without much twiddling.
[...]
Operating System: Darwin 19.6.0
IPv6 Support: yes
Tcl version: 8.5.9 (threaded)
SSL/TLS Support: yes (OpenSSL 1.1.1g  21 Apr 2020)
[...]
Type 'make config' to configure the modules, or type 'make iconfig'
to interactively choose which modules to compile.

michael@macos eggdrop % make config
[...]
michael@macos eggdrop % make

Making module objects for static linking...

gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././assoc.mod/assoc.c && mv -f assoc.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././blowfish.mod/blowfish.c && mv -f blowfish.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././channels.mod/channels.c && mv -f channels.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././compress.mod/compress.c && mv -f compress.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././console.mod/console.c && mv -f console.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././ctcp.mod/ctcp.c && mv -f ctcp.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC   -DMAKING_MODS -c .././dns.mod/dns.c && mv -f dns.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././filesys.mod/filesys.c && mv -f filesys.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././ident.mod/ident.c && mv -f ident.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././irc.mod/irc.c && mv -f irc.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././notes.mod/notes.c && mv -f notes.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././seen.mod/seen.c && mv -f seen.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././share.mod/share.c && mv -f share.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././transfer.mod/transfer.c && mv -f transfer.o ../
gcc -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -DMAKING_MODS -c .././uptime.mod/uptime.c && mv -f uptime.o ../
Building static.h...
................ done.

Making core eggdrop for static linking...

gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c bg.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c botcmd.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c botmsg.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c botnet.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c chanprog.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c cmds.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c dcc.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c dccutil.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c dns.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c flags.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c language.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c match.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  \
	'-DCCFLAGS="gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC "' \
	'-DLDFLAGS="gcc -L/usr/local/opt/openssl/lib"' \
	'-DSTRIPFLAGS="touch"' -c ./main.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c mem.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c misc.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c misc_file.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c modules.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c net.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c rfc1459.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tcl.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tcldcc.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tclhash.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tclmisc.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tcluser.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c tls.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c userent.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c userrec.c
gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c users.c
gcc -g -O2 -pipe -Wall -I. -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c md5c.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c base64.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c explicit_bzero.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c gethostbyname2.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c in6.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c inet_aton.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c snprintf.c
gcc -g -O2 -pipe -Wall -I../.. -I../.. -I../../src -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c strlcpy.c
/Library/Developer/CommandLineTools/usr/bin/make linkstart && /Library/Developer/CommandLineTools/usr/bin/make link && /Library/Developer/CommandLineTools/usr/bin/make linkfinish

This may take a while. Go get some runts.

---------- Yeah! That's the compiling, now the linking! ----------

Linking eggdrop (static version).

gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC -L/usr/local/opt/openssl/lib -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o mod/*.o -L/usr/local/opt/openssl/lib -F/System/Library/Frameworks -framework Tcl -lpthread -framework CoreFoundation -lssl -lcrypto  -lresolv md5/md5c.o compat/*.o `cat mod/mod.xlibs`

Successful compile: eggdrop


Test run of ./eggdrop -v:
Eggdrop v1.9.0+etchost (C) 1997 Robey Pointer (C) 2010-2020 Eggheads
Configure flags: '--with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh' '--with-sslinc=/usr/local/opt/openssl/include' '--with-ssllib=/usr/local/opt/openssl/lib'
Compiled with: IPv6, TLS, handlen=32


Eggdrop successfully compiled:
-rwxr-xr-x  1 michael  staff  1242976 Oct  8 22:53 eggdrop


Now run "make install" to install your bot.

michael@macos eggdrop % make install

Eggdrop v1.9.0+etchost (C) 1997 Robey Pointer (C) 2010-2020 Eggheads
Configure flags: '--with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh' '--with-sslinc=/usr/local/opt/openssl/include' '--with-ssllib=/usr/local/opt/openssl/lib'
Compiled with: IPv6, TLS, handlen=32

Installing in directory: '/Users/michael/eggdrop'.

Removing symlink to archival eggdrop binary.
Copying new 'eggdrop' executable and creating symlink.
Copying help files.
Copying module help files.
Copying language files.
Copying module language files.
Copying docs.

Installation completed.

If you intend to use this bot as a botnet hub for other Eggdrops using SSL,
please run "make sslcert" now. If you installed eggdrop to a custom path
during the make install process, use the same DEST= option here.

You MUST ensure that you edit/verify your configuration file.
An example configuration file, eggdrop.conf, is distributed with Eggdrop.

Remember to change directory to /Users/michael/eggdrop before you proceed.
```