### PR TITLE
Fix misleading indentation / compiler warning

### DIFF
--- a/src/mod/notes.mod/notes.c
+++ b/src/mod/notes.mod/notes.c
@@ -412,7 +412,7 @@ static int tcl_erasenotes STDVAR
   while (!feof(f) && fgets(s, sizeof s, f) != NULL) {
     if (s[strlen(s) - 1] == '\n')
       s[strlen(s) - 1] = 0;
-      rmspace(s);
+    rmspace(s);
     if ((s[0]) && (s[0] != '#') && (s[0] != ';')) {   /* Not comment */
       s1 = s;
       to = newsplit(&s1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix misleading indentation

Additional description (if needed):
Found with gcc 11-20201004, which seems to enable -Wmisleading-indentation with -Wall.
Same with gcc-11-20201018.

Test cases demonstrating functionality (if applicable):
```
$ CC=/home/michael/opt/gcc-11-20201004/bin/gcc make
[...]
/home/michael/opt/gcc-11-20201004/bin/gcc   -shared -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../../../irc.so ../irc.o -L/usr/lib -ltcl8.6  -lz -lpthread -lm -lssl -lcrypto -ldl  -lresolv  && touch ../../../irc.so
make[2]: Leaving directory '/home/michael/projects/eggdrop/src/mod/irc.mod'
make[2]: Entering directory '/home/michael/projects/eggdrop/src/mod/notes.mod'
/home/michael/opt/gcc-11-20201004/bin/gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././notes.mod/notes.c && mv -f notes.o ../
.././notes.mod/notes.c: In function ‘tcl_erasenotes’:
.././notes.mod/notes.c:413:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  413 |     if (s[strlen(s) - 1] == '\n')
      |     ^~
In file included from .././notes.mod/notes.c:32:
../../../src/mod/module.h:306:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  306 | #define rmspace ((void (*)(char *))global[162])
      |                 ^
.././notes.mod/notes.c:415:7: note: in expansion of macro ‘rmspace’
  415 |       rmspace(s);
      |       ^~~~~~~
```