### PR TITLE
Cleanup getrusage() (eggdrop requires posix 2001)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ EGG_CHECK_OS
 EGG_HEADER_STDC
 AC_HEADER_DIRENT
 AC_HEADER_TIME
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h locale.h netdb.h netinet/in.h stdio.h stdarg.h stddef.h sys/file.h sys/param.h sys/rusage.h sys/select.h sys/socket.h sys/time.h unistd.h wchar.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h locale.h netdb.h netinet/in.h stdio.h stdarg.h stddef.h sys/file.h sys/param.h sys/select.h sys/socket.h sys/time.h unistd.h wchar.h])
 
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -113,7 +113,7 @@ AX_TYPE_SOCKLEN_T
 AX_CREATE_STDINT_H([eggint.h])
 
 # Checks for functions and their arguments.
-AC_CHECK_FUNCS([dprintf explicit_bzero explicit_memset getrandom getrusage inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
+AC_CHECK_FUNCS([dprintf explicit_bzero explicit_memset getrandom inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_B64_NTOP
 AC_FUNC_MMAP

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -28,13 +28,7 @@
 
 #include "main.h"
 
-#ifdef HAVE_GETRUSAGE
-#  include <sys/resource.h>
-#  ifdef HAVE_SYS_RUSAGE_H
-#    include <sys/rusage.h>
-#  endif
-#endif
-
+#include <sys/resource.h>
 #include <sys/utsname.h>
 
 #include "modules.h"
@@ -228,7 +222,6 @@ int expmem_chanprog()
 
 float getcputime()
 {
-#ifdef HAVE_GETRUSAGE
   float stime, utime;
   struct rusage ru;
 
@@ -236,9 +229,6 @@ float getcputime()
   utime = ru.ru_utime.tv_sec + (ru.ru_utime.tv_usec / 1000000.00);
   stime = ru.ru_stime.tv_sec + (ru.ru_stime.tv_usec / 1000000.00);
   return (utime + stime);
-#else
-  return (clock() / (CLOCKS_PER_SEC * 1.00));
-#endif
 }
 
 /* Dump uptime info out to dcc (guppy 9Jan99)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup getrusage() (eggdrop requires posix 2001)

Additional description (if needed):
Please run **misc/runautotools** after merge

Test cases demonstrating functionality (if applicable):
