### PR TITLE
Parse/modify oident.conf file

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -171,14 +171,14 @@ static void ident_oidentd()
 putlog(LOG_MISC, "*", "family is %d\n", addr.addr.sa.sa_family);
     if (addr.addr.sa.sa_family == AF_INET) {
       fprintf(fd, "lport %i from %s { reply \"%s\" } "
-                "### eggdrop_%s !%ld\n", ntohs(addr.addr.s4.sin_port),
-                inet_ntop(AF_INET, &(addr.addr.s4.sin_addr), s, INET_ADDRSTRLEN),
-                botuser, pid_file, time(NULL));
+            "### eggdrop_%s !%ld\n", ntohs(addr.addr.s4.sin_port),
+            inet_ntop(AF_INET, &(addr.addr.s4.sin_addr), s, INET_ADDRSTRLEN),
+            botuser, pid_file, time(NULL));
     } else if (addr.addr.sa.sa_family == AF_INET6) {
       fprintf(fd, "lport %i from %s { reply \"%s\" } "
-                "### eggdrop_%s !%ld\n", ntohs(addr.addr.s6.sin6_port),
-                inet_ntop(AF_INET6, &(addr.addr.s6.sin6_addr), s, INET_ADDRSTRLEN),
-                botuser, pid_file, time(NULL));
+            "### eggdrop_%s !%ld\n", ntohs(addr.addr.s6.sin6_port),
+            inet_ntop(AF_INET6, &(addr.addr.s6.sin6_addr), s, INET6_ADDRSTRLEN),
+            botuser, pid_file, time(NULL));
     } else {
       putlog(LOG_DEBUG, "*", "IDENT: Error writing oident.conf line");
     }

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -168,10 +168,20 @@ static void ident_oidentd()
   fd = fopen(path, "w");
   if (fd != NULL) {
     fprintf(fd, "%s", data);
-    fprintf(fd, "lport %i from %s { reply \"%s\" } "
+putlog(LOG_MISC, "*", "family is %d\n", addr.addr.sa.sa_family);
+    if (addr.addr.sa.sa_family == AF_INET) {
+      fprintf(fd, "lport %i from %s { reply \"%s\" } "
                 "### eggdrop_%s !%ld\n", ntohs(addr.addr.s4.sin_port),
                 inet_ntop(AF_INET, &(addr.addr.s4.sin_addr), s, INET_ADDRSTRLEN),
                 botuser, pid_file, time(NULL));
+    } else if (addr.addr.sa.sa_family == AF_INET6) {
+      fprintf(fd, "lport %i from %s { reply \"%s\" } "
+                "### eggdrop_%s !%ld\n", ntohs(addr.addr.s6.sin6_port),
+                inet_ntop(AF_INET6, &(addr.addr.s6.sin6_addr), s, INET_ADDRSTRLEN),
+                botuser, pid_file, time(NULL));
+    } else {
+      putlog(LOG_DEBUG, "*", "IDENT: Error writing oident.conf line");
+    }
     fclose(fd);
   } else {
     putlog(LOG_MISC, "*", "IDENT: Error opening oident.conf for writing");

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -167,8 +167,8 @@ static void ident_oidentd()
     putlog(LOG_MISC, "*", "IDENT: Error opening oident.conf for reading");
   }
   servidx = findanyidx(serv);
-  unsigned int foo = sizeof ss;
-  int ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &foo);
+  unsigned int size = sizeof ss;
+  int ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &size);
   if (ret) {
     putlog(LOG_DEBUG, "*", "IDENT: Error getting socket info for writing");
   }

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -113,7 +113,8 @@ static void ident_oidentd()
 #else
   char s[INET_ADDRSTRLEN];
 #endif
-  int prevtime, servidx;
+  int ret, prevtime, servidx;
+  unsigned int size;
   struct sockaddr_storage ss;
 
   snprintf(identstr, sizeof identstr, "### eggdrop_%s", pid_file);
@@ -135,14 +136,14 @@ static void ident_oidentd()
       if (filesize == -1) {
         putlog(LOG_MISC, "*", "IDENT: Error reading oident.conf");
       }
-      data = nmalloc(sizeof(char) * (filesize + 256)); /* Room for Eggdrop adds */
+      data = nmalloc(filesize + 256); /* Room for Eggdrop adds */
       data[0] = '\0';
 
       /* Read the file into buffer */
       if (fseek(fd, 0, SEEK_SET) != 0) {
         putlog(LOG_MISC, "*", "IDENT: Error setting oident.conf file pointer");
       } else {
-        while(fgets(line, 255, fd)) {
+        while (fgets(line, 255, fd)) {
           /* If it is not an Eggdrop entry, don't mess with it */
           if (!strstr(line, "### eggdrop_")) {
             strncat(data, line, ((filesize + 256) - strlen(data)));
@@ -167,8 +168,8 @@ static void ident_oidentd()
     putlog(LOG_MISC, "*", "IDENT: Error opening oident.conf for reading");
   }
   servidx = findanyidx(serv);
-  unsigned int size = sizeof ss;
-  int ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &size);
+  size = sizeof ss;
+  ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &size);
   if (ret) {
     putlog(LOG_DEBUG, "*", "IDENT: Error getting socket info for writing");
   }
@@ -190,7 +191,7 @@ static void ident_oidentd()
                 botuser, pid_file, time(NULL));
 #endif
     } else {
-      putlog(LOG_DEBUG, "*", "IDENT: Error writing oident.conf line");
+      putlog(LOG_MISC, "*", "IDENT: Error writing oident.conf line");
     }
     fclose(fd);
   } else {

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -509,6 +509,7 @@
 /* 308 - 311 */
 #define make_rand_str_from_chars ((void (*) (char *, int, char *))global[308])
 #define add_tcl_objcommands ((void (*) (tcl_cmds *))global[309])
+#define pid_file ((char *)(global[310]))
 
 /* hostmasking */
 #define maskhost(a,b) maskaddr((a),(b),3)

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -511,6 +511,7 @@
 #define add_tcl_objcommands ((void (*) (tcl_cmds *))global[309])
 #define pid_file ((char *)(global[310]))
 
+
 /* hostmasking */
 #define maskhost(a,b) maskaddr((a),(b),3)
 #define maskban(a,b) maskaddr((a),(b),3)

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2201,7 +2201,7 @@ static Function server_table[] = {
   (Function) & exclusive_binds, /* int                                  */
   /* 40 - 43 */
   (Function) & H_out,           /* p_tcl_bind_list                      */
-  (Function) & net_type_int,     /* int                                  */
+  (Function) & net_type_int,    /* int                                  */
   (Function) & H_account,       /* p_tcl_bind)list                      */
   (Function) & cap,             /* cap_list                             */
   /* 44 - 47 */
@@ -2210,7 +2210,7 @@ static Function server_table[] = {
   (Function) & H_isupport,      /* p_tcl_bind_list                      */
   (Function) & isupport_get,    /*                                      */
   /* 48 - 52 */
-  (Function) & isupport_parseint /*                                     */
+  (Function) & isupport_parseint/*                                      */
 };
 
 char *server_start(Function *global_funcs)

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1936,10 +1936,6 @@ static void server_resolve_success(int servidx)
   changeover_dcc(servidx, &SERVER_SOCKET, 0);
   dcc[servidx].sock = getsock(dcc[servidx].sockname.family, 0);
   setsnport(dcc[servidx].sockname, dcc[servidx].port);
-  /* Setup ident right before opening the socket to the IRC server to minimize
-   * race.
-   */
-  check_tcl_event("ident");
   serv = open_telnet_raw(dcc[servidx].sock, &dcc[servidx].sockname);
   if (serv < 0) {
     char *errstr = NULL;
@@ -1956,6 +1952,8 @@ static void server_resolve_success(int servidx)
     lostdcc(servidx);
     return;
   }
+  /* Setup ident with server values populated */
+  check_tcl_event("ident");
 #ifdef TLS
   if (dcc[servidx].ssl && ssl_handshake(serv, TLS_CONNECT, tls_vfyserver,
                                         LOG_SERV, dcc[servidx].host, NULL)) {

--- a/src/modules.c
+++ b/src/modules.c
@@ -75,7 +75,8 @@ extern struct userrec *userlist, *lastuser;
 extern struct chanset_t *chanset;
 
 extern char botnetnick[], botname[], origbotname[], botuser[], ver[], log_ts[],
-            admin[], userfile[], notify_new[], helpdir[], version[], quit_msg[];
+            admin[], userfile[], notify_new[], helpdir[], version[], quit_msg[],
+            pid_file[];
 
 extern int parties, noshare, dcc_total, egg_numver, userfile_perm, ignore_time,
            must_be_owner, raw_log, max_dcc, make_userfile, default_flags,
@@ -609,7 +610,8 @@ Function global_table[] = {
   (Function) check_validpass,
   /* 308 - 311 */
   (Function) make_rand_str_from_chars,
-  (Function) add_tcl_objcommands
+  (Function) add_tcl_objcommands,
+  (Function) pid_file             /* char                                */
 };
 
 void init_modules(void)


### PR DESCRIPTION
Found by:
Patch by:
Fixes: #942 

One-line summary:
Parse and modify oident.conf entries

Additional description (if needed):
Instead of just overwriteing oident.conf, this PR will write Eggdrop entries to oident.conf in a specific format that will allow us to parse the file. This should allow us to co-exist with other programs using oident.conf, as well as help mitigate race conditions when using multiple bots from the same account. This will also check and prune the oident.conf file for 'stale' entries no longer needed based on a timestamp. 

The one-liner oident.conf entry looks like:
```to irc.com lport 5555 from myhost fport 6667 { reply "myident" } ### eggdrop_pidfile !1602208657```
where pidfile is the pidfile of the eggdrop, and the !number string is unixtime.



Test cases demonstrating functionality (if applicable):
