### PR TITLE
Make compat explicit_bzero() available for modules

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -509,6 +509,9 @@
 /* 308 - 311 */
 #define make_rand_str_from_chars ((void (*) (char *, int, char *))global[308])
 #define add_tcl_objcommands ((void (*) (tcl_cmds *))global[309])
+#ifndef HAVE_EXPLICIT_BZERO
+# define explicit_bzero ((void (*) (void *const, const size_t))global[310])
+#endif
 
 /* hostmasking */
 #define maskhost(a,b) maskaddr((a),(b),3)

--- a/src/modules.c
+++ b/src/modules.c
@@ -609,7 +609,12 @@ Function global_table[] = {
   (Function) check_validpass,
   /* 308 - 311 */
   (Function) make_rand_str_from_chars,
-  (Function) add_tcl_objcommands
+  (Function) add_tcl_objcommands,
+#ifndef HAVE_EXPLICIT_BZERO
+  (Function) explicit_bzero
+#else
+  (Function) 0
+#endif
 };
 
 void init_modules(void)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Make compat explicit_bzero() available for modules

Additional description (if needed):
Tested with Minix 3.3.0

Test cases demonstrating functionality (if applicable):
Before:
```
$ ./eggdrop -t eggdrop.conf 

Eggdrop v1.9.0+etchost (C) 1997 Robey Pointer (C) 2010-2020 Eggheads
--- Loading eggdrop v1.9.0+etchost (Sat Oct 10 2020)
Listening for telnet connections on 192.168.1.21 port 2513 (all).
Module loaded: blowfish        
Module loaded: dns             
Module loaded: channels        
Module loaded: server          
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
Module loaded: ctcp            
Module loaded: irc             
Can't load modules share: /home/michael/eggdrop/modules/share.so: Undefined symbol "explicit_bzero" (symnum = 6)
Can't load modules compress: This module requires share module 2.3 or later.
Module loaded: transfer         (with lang support)
Module loaded: filesys          (with lang support)
Module loaded: notes            (with lang support)
```
After:
```
$ ./eggdrop -t eggdrop.conf 

Eggdrop v1.9.0+etchost (C) 1997 Robey Pointer (C) 2010-2020 Eggheads
--- Loading eggdrop v1.9.0+etchost (Sat Oct 10 2020)
Listening for telnet connections on 192.168.1.21 port 2513 (all).
Module loaded: blowfish        
Module loaded: dns             
Module loaded: channels        
Module loaded: server          
WARNING: Using an integer for net-type is deprecated and will be
         removed in a future release. Please reference an updated
         configuration file for the new allowed string values
Module loaded: ctcp            
Module loaded: irc             
Module loaded: transfer         (with lang support)
Module loaded: share           
Module loaded: compress        
Module loaded: filesys          (with lang support)
Module loaded: notes            (with lang support)
```