### PR TITLE
Fix format truncation

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -805,7 +805,7 @@ static void subst_addcol(char *s, char *newcol)
 void help_subst(char *s, char *nick, struct flag_record *flags,
                 int isdcc, char *topic)
 {
-  char xx[HELP_BUF_LEN + 1], sub[161], *current, *q, chr, *writeidx,
+  char xx[HELP_BUF_LEN + 1], sub[512], *current, *q, chr, *writeidx,
        *readidx, *towrite;
   struct chanset_t *chan;
   int i, j, center = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix array len for snprintf()

Additional description (if needed):
Dont truncate (unlikely but possible) in https://github.com/eggheads/eggdrop/blob/74e04fbaa55d0a0fe2f4655a11b31cf129bb7212/src/misc.c#L904
Fix compiler warning under NetBSD 9.1 with gcc 7.5.0 and and NetBSD 9.0 with gcc 7.4.0.

Test cases demonstrating functionality (if applicable):