### PR TITLE
Remove unnecessary openssl function checks

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1657,10 +1657,6 @@ AC_DEFUN([EGG_TLS_DETECT],
     if test -z "$SSL_LIBS"; then
       AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-lssl])
       AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
-      AC_CHECK_FUNCS([EVP_md5 EVP_sha1 a2i_IPADDRESS], , [[
-        havessllib="no"
-        break
-      ]])
     fi
     AC_CHECK_FUNC(OPENSSL_buf2hexstr, ,
       AC_CHECK_FUNC(hex_to_string,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1046

One-line summary:
Remove unnecessary openssl function checks

Additional description (if needed):
Those checks were only done, if `--with-ssl*` was nor used with `./configure`
The first 2 functions `EVP_md5` and `EVP_sha1` are not used by eggdrop
All 3 functions are available with any openssl since at least openssl version 0.9.8.
Please run **misc/runautotools** after merge

Test cases demonstrating functionality (if applicable):
