### PR TITLE
Fix setsockname()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -271,7 +271,7 @@ void getvhost(sockname_t *addr, int af)
     h = vhost6;
 #endif
   if (setsockname(addr, (h ? h : ""), 0, 1) != af)
-    setsockname(addr, (af == AF_INET ? "0" : "::"), 0, 0);
+    setsockname(addr, (af == AF_INET ? "0.0.0.0" : "::"), 0, 0);
   /* Remember this 'self-lookup failed' thingie?
      I have good news - you won't see it again ;) */
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1030

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.set prefer-ipv6 
Currently: 1
```
Before:
```
.jump 127.0.0.1
[23:04:27] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1
[23:04:27] #-HQ# jump 127.0.0.1 6667 
Jumping servers......
[23:04:28] Trying server 127.0.0.1:6667
[23:04:28] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[23:04:28] Failed connect to 127.0.0.1 (Address family not supported by protocol)
```
After:
```
.jump 127.0.0.1
[23:06:36] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1
[23:06:36] #-HQ# jump 127.0.0.1 6667 
Jumping servers......
[23:06:37] Trying server 127.0.0.1:6667
[23:06:37] net: open_telnet_raw(): idx 5 host 127.0.0.1 port 6667 ssl 0
[23:06:38] net: connect! sock 9
[23:06:38] Connected to 127.0.0.1
```
