### PR TITLE
Speed up startup of eggdrop by up to 1 sec

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1269,7 +1269,13 @@ int main(int arg_c, char **arg_v)
     dcc_chatter(term_z);
   }
 
-  then = now;
+  /* -1 to make mainloop() call
+   * call_hook(HOOK_SECONDLY)->server_secondly()->connect_server() before first
+   * sockgets()->sockread()->select() to avoid an unnecessary select timeout of
+   * up to 1 sec while starting up
+   */
+  then = now - 1;
+
   online_since = now;
   autolink_cycle(NULL);         /* Hurry and connect to tandem bots */
   add_help_reference("cmds1.help");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Speed up startup of eggdrop by up to 1 sec

Additional description (if needed):
eggdrops mainloop calls `select()` with a 1 sec timeout. so far so good. but eggdrop starts connecting to an irc server only after the first `select()` because hook secondly is called only after the first `select()`. that could (and in my test did) slow down eggdrops startup by 1 sec. This bug ennoyed me for an eternity but somehow i never found the time to report or fix it. Finally that time has come. Let eggdrop 1.9 shine!

Test cases demonstrating functionality (if applicable):
`strace -tt ./eggdrop -t BotA.conf 2>2.txt`
Before:
```
02:27:43.961103 execve("./eggdrop", ["./eggdrop", "-t", "BotA.conf"], 0x7ffc088a91d8 /* 31 vars */) = 0
[...]
02:27:44.995345 write(1, "[02:27:44] Connected to 127.0.0."..., 34) = 34
[...]
```
After:
```
02:31:28.303428 execve("./eggdrop", ["./eggdrop", "-t", "BotA.conf"], 0x7fffc0ef5308 /* 31 vars */) = 0
[...]
02:31:28.338382 write(1, "[02:31:28] Connected to 127.0.0."..., 34) = 34
[...]
```