### PR TITLE
Add Large File Support for 32 bit systems

### DIFF
--- a/src/misc_file.c
+++ b/src/misc_file.c
@@ -90,7 +90,7 @@ int copyfilef(char *oldpath, FILE *newfile)
   int fi, x;
   char buf[512];
   struct stat st;
-  long oripos;
+  off_t oripos;
 
 #ifndef CYGWIN_HACKS
   fi = open(oldpath, O_RDONLY, 0);
@@ -105,7 +105,7 @@ int copyfilef(char *oldpath, FILE *newfile)
     return 3;
   }
 
-  oripos = ftell(newfile);
+  oripos = ftello(newfile);
   rewind(newfile);
 
   for (x = 1; x > 0;) {
@@ -113,7 +113,7 @@ int copyfilef(char *oldpath, FILE *newfile)
     if (x > 0) {
       if (fwrite(buf, 1, x, newfile) < x) {      /* Couldn't write */
         close(fi);
-        fseek(newfile, oripos, SEEK_SET);
+        fseeko(newfile, oripos, SEEK_SET);
         return 4;
       }
     }
@@ -122,7 +122,7 @@ int copyfilef(char *oldpath, FILE *newfile)
   fsync(fileno(newfile));
   close(fi);
 
-  fseek(newfile, oripos, SEEK_SET);
+  fseeko(newfile, oripos, SEEK_SET);
 
   return 0;
 }
@@ -142,7 +142,7 @@ int fcopyfile(FILE *oldfile, char *newpath)
   size_t x;
   char buf[512];
   struct stat st;
-  long oripos;
+  off_t oripos;
 
   if (fstat(fileno(oldfile), &st) || !(st.st_mode & S_IFREG)) {
     return 3;
@@ -152,7 +152,7 @@ int fcopyfile(FILE *oldfile, char *newpath)
     return 2;
   }
 
-  oripos = ftell(oldfile);
+  oripos = ftello(oldfile);
   rewind(oldfile);
 
   for (x = 1; x > 0;) {
@@ -161,7 +161,7 @@ int fcopyfile(FILE *oldfile, char *newpath)
       if (write(fo, buf, x) < x) {      /* Couldn't write */
         close(fo);
         unlink(newpath);
-        fseek(oldfile, oripos, SEEK_SET);
+        fseeko(oldfile, oripos, SEEK_SET);
         return 4;
       }
     }
@@ -170,7 +170,7 @@ int fcopyfile(FILE *oldfile, char *newpath)
   fsync(fo);
   close(fo);
 
-  fseek(oldfile, oripos, SEEK_SET);
+  fseeko(oldfile, oripos, SEEK_SET);
 
   return 0;
 }

--- a/src/mod/filesys.mod/dbcompat.c
+++ b/src/mod/filesys.mod/dbcompat.c
@@ -128,7 +128,7 @@ static int convert_old_files(char *path, char *newfiledb)
     filedb_addfile(fdb, fdbe);
     free_fdbe(&fdbe);
   }
-  fseek(fdb, 0L, SEEK_END);
+  fseeko(fdb, 0, SEEK_END);
   unlockfile(f);
   unlockfile(fdb);
   fclose(fdb);

--- a/src/mod/filesys.mod/filedb3.c
+++ b/src/mod/filesys.mod/filedb3.c
@@ -249,8 +249,8 @@ static filedb_entry *filedb_findempty(FILE *fdb, int tot)
 
   /* No existing entries, so create new entry at end of DB instead. */
   fdbe = malloc_fdbe();
-  fseek(fdb, 0L, SEEK_END);
-  fdbe->pos = ftell(fdb);
+  fseeko(fdb, 0, SEEK_END);
+  fdbe->pos = ftello(fdb);
   return fdbe;
 }
 
@@ -840,7 +840,7 @@ static FILE *filedb_open(char *path, int sort)
 static void filedb_close(FILE *fdb)
 {
   filedb_timestamp(fdb);
-  fseek(fdb, 0L, SEEK_END);
+  fseeko(fdb, 0, SEEK_END);
   count--;
   unlockfile(fdb);
   fclose(fdb);

--- a/src/mod/filesys.mod/filedb3.h
+++ b/src/mod/filesys.mod/filedb3.h
@@ -60,7 +60,7 @@ typedef struct {
    *       movements often invalidate them too, so make sure you know
    *       what you're doing before using/relying on them.
    */
-  long pos;                     /* Last position in the filedb  */
+  unsigned long pos;            /* Last position in the filedb  */
   unsigned short int dyn_len;   /* Length of dynamic data in DB */
   unsigned short int buf_len;   /* Length of additional buffer  */
 

--- a/src/mod/transfer.mod/transfer.c
+++ b/src/mod/transfer.mod/transfer.c
@@ -953,15 +953,15 @@ static int raw_dcc_resend_send(char *filename, char *nick, char *from,
 {
   int zz, port, i;
   char *nfn, *buf = NULL;
-  long dccfilesize;
+  off_t dccfilesize;
   FILE *f;
 
   zz = -1;
   f = fopen(filename, "r");
   if (!f)
     return DCCSEND_BADFN;
-  fseek(f, 0, SEEK_END);
-  dccfilesize = ftell(f);
+  fseeko(f, 0, SEEK_END);
+  dccfilesize = ftello(f);
   fclose(f);
 
   if (dccfilesize == 0)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add Large File Support for 32 bit systems

Additional description (if needed):
fseek() and ftell() do not support Large File Support for 32 bit systems
solution is to use fseeko() and ftello()
see: https://stackoverflow.com/questions/16696297/ftell-at-a-position-past-2gb/16696552#16696552
furthermore the following two sources also recommend fseeko() and ftello() over fseek() and ftell():
https://www.gnu.org/software/libc/manual/html_node/File-Positioning.html
See also: https://wiki.sei.cmu.edu/confluence/display/c/FIO19-C.+Do+not+use+fseek%28%29+and+ftell%28%29+to+compute+the+size+of+a+regular+file
The fseeko() and ftello() functions conform to IEEE Std 1003.1-2001 ("POSIX.1").

Test cases demonstrating functionality (if applicable):
