### PR TITLE
Change language log msg

### DIFF
--- a/src/language.c
+++ b/src/language.c
@@ -132,7 +132,7 @@ void add_lang(char *lang)
   if (langpriority)
     lp->next = langpriority;
   langpriority = lp;
-  debug1("LANG: Language loaded: %s", lang);
+  debug1("LANG: Language added to list: %s", lang);
 }
 
 /* Remove a language from the list of preferred languages.


### PR DESCRIPTION
Found by: mortman
Patch by: Geo
Fixes: #1020 

One-line summary:
Change language log msg

Additional info:
I don't think we want this to totally error, but agree the log is misleading. Updated to reflect the addition of the language to the language list, instead of 'loaded'