### PR TITLE
Fix format truncation

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -805,12 +805,12 @@ static void subst_addcol(char *s, char *newcol)
 void help_subst(char *s, char *nick, struct flag_record *flags,
                 int isdcc, char *topic)
 {
-  char xx[HELP_BUF_LEN + 1], sub[514], *current, *q, chr, *writeidx,
-       *readidx, *towrite;
   struct chanset_t *chan;
   int i, j, center = 0;
   static int help_flags;
   struct utsname uname_info;
+  char xx[HELP_BUF_LEN + 1], *current, *q, chr, *writeidx, *readidx, *towrite,
+       sub[(sizeof uname_info.sysname) + (sizeof uname_info.release)];
 
   if (s == NULL) {
     /* Used to reset substitutions */

--- a/src/misc.c
+++ b/src/misc.c
@@ -805,7 +805,7 @@ static void subst_addcol(char *s, char *newcol)
 void help_subst(char *s, char *nick, struct flag_record *flags,
                 int isdcc, char *topic)
 {
-  char xx[HELP_BUF_LEN + 1], sub[512], *current, *q, chr, *writeidx,
+  char xx[HELP_BUF_LEN + 1], sub[514], *current, *q, chr, *writeidx,
        *readidx, *towrite;
   struct chanset_t *chan;
   int i, j, center = 0;
@@ -901,8 +901,8 @@ void help_subst(char *s, char *nick, struct flag_record *flags,
       break;
     case 'U':
       if (uname(&uname_info) >= 0) {
-        egg_snprintf(sub, sizeof sub, "%s %s", uname_info.sysname,
-                     uname_info.release);
+        snprintf(sub, sizeof sub, "%s %s", uname_info.sysname,
+                 uname_info.release);
         towrite = sub;
       } else
         towrite = "*UNKNOWN*";


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Follow up to #1044 

Additional description (if needed):
OpenIndiana has struct utsname fields with 257 chars each. Linux 65 each. This Patch fixes undersizing (OpenIndiana), oversizing (Linux) and gets the size right for any system out there by making size correctly calculated by the C preprocessor using sizeof on the underlying struct.

Test cases demonstrating functionality (if applicable):
Before:
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c misc.c
misc.c: In function 'help_subst':
misc.c:904:43: warning: '%s' directive output may be truncated writing up to 256 bytes into a region of size between 255 and 511 [-Wformat-truncation=]
  904 |         egg_snprintf(sub, sizeof sub, "%s %s", uname_info.sysname,
      |                                           ^~
  905 |                      uname_info.release);
      |                      ~~~~~~~~~~~~~~~~~~    
In file included from compat/compat.h:28,
                 from main.h:102,
                 from misc.c:29:
compat/snprintf.h:58:24: note: 'snprintf' output between 2 and 514 bytes into a destination of size 512
   58 | #  define egg_snprintf snprintf
misc.c:904:9: note: in expansion of macro 'egg_snprintf'
  904 |         egg_snprintf(sub, sizeof sub, "%s %s", uname_info.sysname,
      |
```
After:
`gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c misc.c`