### PR TITLE
Fix SNI

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -866,13 +866,16 @@ int ssl_handshake(int sock, int flags, int verify, int loglevel, char *host,
     /* Introduce 1ms lag so an unpatched hub has time to setup the ssl handshake */
     nanosleep(&req, NULL);
 #ifdef SSL_set_tlsext_host_name
-    if (!SSL_set_tlsext_host_name(td->socklist[i].ssl, data->host))
-       debug1("TLS: setting the server name indication (SNI) to %s failed", data->host);
+    if (*data->host)
+      if (!SSL_set_tlsext_host_name(td->socklist[i].ssl, data->host))
+        debug1("TLS: setting the server name indication (SNI) to %s failed", data->host);
+      else
+        debug1("TLS: setting the server name indication (SNI) to %s successful", data->host);
     else
-       debug1("TLS: setting the server name indication (SNI) to %s successful", data->host);
+      debug0("TLS: not setting the server name indication (SNI) because host is an empty string");
 #else
-    debug1("TLS: setting the server name indication (SNI) not supported by ssl "
-           "lib, probably < openssl 0.9.8f", data->host);
+    debug0("TLS: setting the server name indication (SNI) not supported by ssl "
+           "lib, probably < openssl 0.9.8f");
 #endif
     ret = SSL_connect(td->socklist[i].ssl);
     if (!ret)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes:  #1057

One-line summary:
Do not set SNI to an empty hostname

Additional description (if needed):
Do not set SNI to an empty hostname to fix userfile sharing under Minix 3.3.0 OpenSSL 1.0.1g, a bug that was introduced by commit 45ce50296a0aaad3de1604275831debb8a8374e0.

Test cases demonstrating functionality (if applicable):
Test under Minix 3.3.0 OpenSSL 1.0.1g
Before:
.link BotA
[...]
[12:49:14] Linked to BotA.
[12:49:14] Downloading user file from BotA
[12:49:14] net: setsock(): setsockopt() s 12 level SOL_SOCKET optname SO_LINGER error Function not implemented
[12:49:14] net: setsock(): setsockopt() s 12 level IPPROTO_TCP optname TCP_NODELAY error Function not implemented
[12:49:15] TLS: attempting SSL negotiation...
[12:49:15] TLS: setting the server name indication (SNI) to  successful
[12:49:15] TLS: state change: before/connect initialization
[12:49:15] TLS: state change: before/connect initialization
[12:49:15] TLS: state change: SSLv2/v3 write client hello A
[12:49:15] TLS: awaiting more reads
[12:49:15] TLS: handshake in progress
[12:49:15] Disconnected from: BotA. No reason (lost 1 bot and 1 user).
[12:49:15] (Userlist download aborted.)
After:
.link BotA
[12:51:02] Linked to BotA.
[12:51:02] Downloading user file from BotA
[12:51:02] net: setsock(): setsockopt() s 12 level SOL_SOCKET optname SO_LINGER error Function not implemented
[12:51:02] net: setsock(): setsockopt() s 12 level IPPROTO_TCP optname TCP_NODELAY error Function not implemented
[12:51:03] TLS: attempting SSL negotiation...
[12:51:03] TLS: not setting the server name indication (SNI) because host is an empty string
[12:51:03] TLS: state change: before/connect initialization
[12:51:03] TLS: state change: before/connect initialization
[12:51:03] TLS: state change: SSLv2/v3 write client hello A
[12:51:03] TLS: awaiting more reads
[12:51:03] TLS: handshake in progress
[12:51:03] TLS: state change: SSLv3 read server hello A
[12:51:03] TLS: peer certificate warning: self signed certificate
[12:51:03] TLS: peer certificate warning: self signed certificate
[12:51:03] TLS: state change: SSLv3 read server certificate A
[12:51:03] TLS: state change: SSLv3 read server certificate request A
[12:51:03] TLS: state change: SSLv3 read server done A
[12:51:03] TLS: state change: SSLv3 write client certificate A
[12:51:03] TLS: state change: SSLv3 write client key exchange A
[12:51:03] TLS: state change: SSLv3 write certificate verify A
[12:51:03] TLS: state change: SSLv3 write change cipher spec A
[12:51:03] TLS: state change: SSLv3 write finished A
[12:51:03] TLS: state change: SSLv3 flush data
[12:51:03] TLS: awaiting more reads
[12:51:03] TLS: awaiting more reads
[12:51:03] sockread EAGAIN: 12 35 (Resource temporarily unavailable)
[12:51:03] TLS: state change: SSLv3 read server session ticket A
[12:51:03] TLS: state change: SSLv3 read finished A
[12:51:03] TLS: handshake successful. Secure connection established.
[12:51:03] TLS: certificate subject: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[12:51:03] TLS: certificate issuer: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[12:51:03] TLS: certificate SHA1 Fingerprint: CF:E9:F0:7F:91:25:EE:CD:2A:9A:F7:17:20:45:D4:08:D0:EB:89:3A
[12:51:03] TLS: certificate SHA-256 Fingerprint: 98:97:A0:5D:54:2A:AE:81:45:BD:EA:B6:A4:0C:76:A8:0A:87:C1:BB:31:D9:0A:79:0F:0B:F0:A9:A8:1E:A6:4D
[12:51:03] TLS: certificate valid from Nov  3 10:54:50 2020 GMT to Dec  3 10:54:50 2020 GMT
[12:51:03] TLS: cipher used: AES256-GCM-SHA384 TLSv1.2; 256 bits (256 secret)
[12:51:03] TLS: cipher details: AES256-GCM-SHA384       TLSv1.2 Kx=RSA      Au=RSA  Enc=AESGCM(256) Mac=AEAD

[12:51:04] Received close notify warning during read
[12:51:04] net: eof!(read) socket 12
[12:51:04] Userfile loaded, unpacking...
[12:51:04] Userlist transfer complete; switched over.