### PR TITLE
Ident.mod: Fix writing of time_t under 32 bit systems

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <time.h>
 #include "src/mod/module.h"
 #include "server.mod/server.h"
 

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -153,7 +153,7 @@ static void ident_oidentd()
               strncpy(buf, line, sizeof buf);
               strtok(buf, "!");
               prevtime = atoi(strtok(NULL, "!"));
-              if ((time(NULL) - prevtime) > 300) {
+              if ((now - prevtime) > 300) {
                 putlog(LOG_DEBUG, "*", "IDENT: Removing expired oident.conf entry: \"%s\"", buf);
               } else {
                 strncat(data, line, ((filesize + 256) - strlen(data)));
@@ -179,16 +179,16 @@ static void ident_oidentd()
     if (ss.ss_family == AF_INET) {
       struct sockaddr_in *saddr = (struct sockaddr_in *)&ss;
       fprintf(fd, "lport %i from %s { reply \"%s\" } "
-                "### eggdrop_%s !%ld\n", ntohs(saddr->sin_port),
+                "### eggdrop_%s !%" PRId64 "\n", ntohs(saddr->sin_port),
                 inet_ntop(AF_INET, &(saddr->sin_addr), s, INET_ADDRSTRLEN),
-                botuser, pid_file, time(NULL));
+                botuser, pid_file, (int64_t) now);
 #ifdef IPV6
     } else if (ss.ss_family == AF_INET6) {
       struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)&ss;
       fprintf(fd, "lport %i from %s { reply \"%s\" } "
-                "### eggdrop_%s !%ld\n", ntohs(saddr->sin6_port),
+                "### eggdrop_%s !%" PRId64 "\n", ntohs(saddr->sin6_port),
                 inet_ntop(AF_INET6, &(saddr->sin6_addr), s, INET6_ADDRSTRLEN),
-                botuser, pid_file, time(NULL));
+                botuser, pid_file, (int64_t) now);
 #endif
     } else {
       putlog(LOG_MISC, "*", "IDENT: Error writing oident.conf line");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Ident.mod: Fix writing of time_t

Additional description (if needed):
type of time_t is kinda undefined. There can be argued about how to handle this correcty as long as one wants. To cut it short, clang 3.4 under Minix 3.3.0 **32bit** throws a compiler warning. And to cast time_t to int64_t is kinda sane. This PR will fix that warning and while at it, also replace `time(NULL)` with `now`, which is the secondly tick within eggdrops core, that is also exported to modules.

Test cases demonstrating functionality (if applicable):
Test under clang 3.4 under Minix 3.3.0 **32bit**
Before:
```
clang -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod -I/usr/pkg/include -DHAVE_CONFIG_H -I/usr/pkg/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././ident.mod/ident.c && mv -f ident.o ../
.././ident.mod/ident.c:184:36: warning: format specifies type 'long' but the argument has type 'time_t'
      (aka 'long long') [-Wformat]
                botuser, pid_file, time(NULL));
                                   ^~~~~~~~~~
1 warning generated.
```

After:
`clang -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod -I/usr/pkg/include -DHAVE_CONFIG_H -I/usr/pkg/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././ident.mod/ident.c && mv -f ident.o ../`

Functional test:
```
$ ./eggdrop -t BotA.conf
[...]
[13:44:38] main: entering loop
[13:44:38] Trying server 127.0.0.1:6667
[13:44:38] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[13:44:38] net: connect! sock 9
[13:44:38] Connected to 127.0.0.1
[13:44:38] triggering bind evnt:init_server
[13:44:38] triggered bind evnt:init_server, user 0.070ms sys 0.024ms
[...]

$ cat ../.oidentd.conf 
lport 56973 from 127.0.0.1 { reply "BotA" } ### eggdrop_pid.BotA !1604407478
```