### PR TITLE
(Low Prio) Do not discard const qualifier

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -315,10 +315,9 @@ char *newsplit(char **rest)
 void maskaddr(const char *s, char *nw, int type)
 {
   int d = type % 5, num = 1;
-  char *p, *u = 0, *h = 0, *ss;
+  const char *p, *u = 0, *h = 0;
 
   /* Look for user and host.. */
-  ss = (char *)s;
   u = strchr(s, '!');
   if (u)
     h = strchr(u, '@');
@@ -337,7 +336,7 @@ void maskaddr(const char *s, char *nw, int type)
   *nw++ = '!';
 
   /* Write user if required and available */
-  u = (u ? u + 1 : ss);
+  u = (u ? u + 1 : s);
   if (!h || (d == 2) || (d == 4))
     *nw++ = '*';
   else {
@@ -357,7 +356,7 @@ void maskaddr(const char *s, char *nw, int type)
   }
 
   /* The rest is for the host */
-  h = (h ? h + 1 : ss);
+  h = (h ? h + 1 : s);
   for (p = h; *p; p++) /* hostname? */
     if ((*p > '9' || *p < '0') && *p != '.') {
       num = 0;

--- a/src/rfc1459.c
+++ b/src/rfc1459.c
@@ -27,23 +27,19 @@
 
 int _rfc_casecmp(const char *s1, const char *s2)
 {
-  unsigned char *str1 = (unsigned char *) s1;
-  unsigned char *str2 = (unsigned char *) s2;
   int res;
 
-  while (!(res = rfc_toupper(*str1) - rfc_toupper(*str2))) {
-    if (*str1 == '\0')
+  while (!(res = rfc_toupper(*s1) - rfc_toupper(*s2))) {
+    if (*s1 == '\0')
       return 0;
-    str1++;
-    str2++;
+    s1++;
+    s2++;
   }
   return res;
 }
 
-int _rfc_ncasecmp(const char *str1, const char *str2, int n)
+int _rfc_ncasecmp(const char *s1, const char *s2, int n)
 {
-  unsigned char *s1 = (unsigned char *) str1;
-  unsigned char *s2 = (unsigned char *) str2;
   int res;
 
   while (!(res = rfc_toupper(*s1) - rfc_toupper(*s2))) {

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -140,7 +140,9 @@ static char *tcl_eggcouplet(ClientData cdata, Tcl_Interp *irp,
                             EGG_CONST char *name1,
                             EGG_CONST char *name2, int flags)
 {
-  char *s, s1[41];
+  char s1[41];
+  const char *s;
+
   coupletinfo *cp = (coupletinfo *) cdata;
 
   if (flags & (TCL_TRACE_READS | TCL_TRACE_UNSETS)) {
@@ -151,15 +153,11 @@ static char *tcl_eggcouplet(ClientData cdata, Tcl_Interp *irp,
                    TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                    tcl_eggcouplet, cdata);
   } else {                        /* writes */
-    s = (char *) Tcl_GetVar2(interp, name1, name2, 0);
+    s = Tcl_GetVar2(interp, name1, name2, 0);
     if (s != NULL) {
       int nr1, nr2;
 
       nr1 = nr2 = 0;
-
-      if (strlen(s) > 40)
-        s[40] = 0;
-
       sscanf(s, "%d%*c%d", &nr1, &nr2);
       *(cp->left) = nr1;
       *(cp->right) = nr2;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Do not discard const qualifier

Additional description (if needed):
Cleanup misc.c:maskaddr(), rfc1459.c and tcl.c:tcl_eggcouplet()
Remove the unnecessary string truncation at s[40] in tcl.c:tcl_eggcouplet()

Test cases demonstrating functionality (if applicable):
