### PR TITLE
(Cleanup) Cygwin: Eggdrop does not need FreeConsole() anymore

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,6 @@
  */
 #include <config.h>
 #ifdef CYGWIN_HACKS
-#  include <windows.h>
 #  undef X509_NAME
 #  undef X509_EXTENSIONS
 #  undef X509_CERT_PAIR
@@ -1240,9 +1239,6 @@ int main(int arg_c, char **arg_v)
     if (freopen("/dev/null", "w", stderr) == NULL) {
       putlog(LOG_MISC, "*", "Error renaming stderr file handle: %s", strerror(errno));
     }
-#ifdef CYGWIN_HACKS
-    FreeConsole();
-#endif
   }
 
   /* Terminal emulating dcc chat */


### PR DESCRIPTION
Found by: Travis Howell
Patch by: Travis Howell
Fixes: part of #176

One-line summary:
Eggdrop does not need FreeConsole() anymore

Additional description (if needed):
Windrop used that patch. I think they used it, because some time ago, the `FreeConsole()` behaviour in Cygwin was broken. Now it compiles and runs fine, but as i tested below, it works the same with and without `FreeConsole()`. So why not clean that old legacy code up.
Original patch here:
http://lists.eggheads.org/pipermail/patches/2001-March/000897.html
http://windrop.sourceforge.net/patches/eggdrop1.8.0.patch

Test cases demonstrating functionality (if applicable):
I tested with and without FreeConsole() executed under eggdrops background mode under Cygwin 2.11.1 under Windows 7 with gcc 7.3.0. No difference. OK.