### PR TITLE
Fix format overflow (!) and format truncation

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -604,7 +604,7 @@ int remove_timer(tcl_timer_t ** stack, unsigned long id)
 void do_check_timers(tcl_timer_t ** stack)
 {
   tcl_timer_t *mark = *stack, *old = NULL;
-  char x[16];
+  char x[26];
 
   /* New timers could be added by a Tcl script inside a current timer
    * so i'll just clear out the timer list completely, and add any
@@ -617,7 +617,7 @@ void do_check_timers(tcl_timer_t ** stack)
     old = mark;
     mark = mark->next;
     if (!old->mins) {
-      egg_snprintf(x, sizeof x, "timer%lu", old->id);
+      snprintf(x, sizeof x, "timer%lu", old->id);
       do_tcl(x, old->cmd);
       if (old->count == 1) {
         nfree(old->cmd);
@@ -653,13 +653,13 @@ void wipe_timers(Tcl_Interp *irp, tcl_timer_t **stack)
  */
 void list_timers(Tcl_Interp *irp, tcl_timer_t *stack)
 {
-  char mins[10], count[10], id[16], *x;
+  char mins[10], count[10], id[26], *x;
   EGG_CONST char *argv[4];
   tcl_timer_t *mark;
 
   for (mark = stack; mark; mark = mark->next) {
     egg_snprintf(mins, sizeof mins, "%u", mark->mins);
-    egg_snprintf(id, sizeof id, "timer%lu", mark->id);
+    snprintf(id, sizeof id, "timer%lu", mark->id);
     egg_snprintf(count, sizeof count, "%u", mark->count);
     argv[0] = mins;
     argv[1] = mark->cmd;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -249,7 +249,7 @@ static int tcl_binds STDVAR
 static int tcl_timer STDVAR
 {
   unsigned long x;
-  char s[16];
+  char s[26];
 
   BADARGS(3, 4, " minutes command ?count?");
 
@@ -264,7 +264,7 @@ static int tcl_timer STDVAR
   if (argv[2][0] != '#') {
     x = add_timer(&timer, atoi(argv[1]), (argc == 4 ? atoi(argv[3]) : 1),
                   argv[2], 0L);
-    egg_snprintf(s, sizeof s, "timer%lu", x);
+    snprintf(s, sizeof s, "timer%lu", x);
     Tcl_AppendResult(irp, s, NULL);
   }
   return TCL_OK;
@@ -273,7 +273,7 @@ static int tcl_timer STDVAR
 static int tcl_utimer STDVAR
 {
   unsigned long x;
-  char s[16];
+  char s[26];
 
   BADARGS(3, 4, " seconds command ?count?");
 
@@ -288,7 +288,7 @@ static int tcl_utimer STDVAR
   if (argv[2][0] != '#') {
     x = add_timer(&utimer, atoi(argv[1]), (argc == 4 ? atoi(argv[3]) : 1),
                   argv[2], 0L);
-    egg_snprintf(s, sizeof s, "timer%lu", x);
+    snprintf(s, sizeof s, "timer%lu", x);
     Tcl_AppendResult(irp, s, NULL);
   }
   return TCL_OK;

--- a/src/userent.c
+++ b/src/userent.c
@@ -375,8 +375,7 @@ static int laston_tcl_get(Tcl_Interp * irp, struct userrec *u,
                           struct user_entry *e, int argc, char **argv)
 {
   struct laston_info *li = (struct laston_info *) e->u.extra;
-  char number[20];
-  long tv;
+  char number[22];
   struct chanuserrec *cr;
 
   BADARGS(3, 4, " handle LASTON ?channel?");
@@ -391,8 +390,7 @@ static int laston_tcl_get(Tcl_Interp * irp, struct userrec *u,
     if (!cr)
       Tcl_AppendResult(irp, "0", NULL);
   } else {
-    tv = li->laston;
-    sprintf(number, "%lu ", tv);
+    snprintf(number, sizeof number, "%lu ", li->laston);
     Tcl_AppendResult(irp, number, li->lastonplace, NULL);
   }
   return TCL_OK;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format overflow (!) and format truncation

Additional description (if needed):
In userent.c there was a format overflow possibility due to an array being too small and sprintf() instead of snprintf() used on that array.
This PR also fixes similar format truncation possibilities, where snprintf() is used and the array is also too small. This cannot lead to overflow but truncation:
Under 64 bit systems `snprintf(x, sizeof x, "timer%lu", ...);` could write up to 26 chars. max unsigned long is 2^64-1. the char array was declared with size 16. this could lead to truncation.

Test cases demonstrating functionality (if applicable):
