### PR TITLE
Fix misaligned address followup

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -40,7 +40,7 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 #undef answer /* before resolv.h because it could collide with src/mod/module.h
-		 (dietlibc) */
+                 (dietlibc) */
 #include <resolv.h>
 #include <errno.h>
 

--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -978,7 +978,8 @@ static void parserespacket(uint8_t *response, int len)
               classtypes[qclass] : classtypes[CLASSTYPES_COUNT]);
       return;
     }
-    if ((c + datalength) > (response + len)) {
+    c += datalength;
+    if (c > response + len) {
       ddebug0(RES_ERR "Specified rdata length exceeds packet size.");
       return;
     }


### PR DESCRIPTION
Found by: Geo and others
Patch by: michaelortmann
Fixes: #759

One-line summary:
This fixes a bug introduced with #759

Additional description (if needed):
#759 broke the parser for indexing resolve records within the array of records we receive from the dns server.

Test cases demonstrating functionality (if applicable):
Before:
```
.tcl dnslookup irc.rizon.net foo
[10:20:30] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup irc.rizon.net foo
[10:20:30] tcl: evaluate (.tcl): dnslookup irc.rizon.net foo
[10:20:30] DNS Resolver: Creating new record
[10:20:30] DNS Resolver: Sent domain lookup request for "irc.rizon.net".
Tcl: 
[10:20:30] DNS Resolver: Received nameserver reply. (qd:1 an:5 ns:0 ar:0)
[10:20:30] DNS Resolver: answered domain query: "irc.rizon.net"
[10:20:30] DNS Resolver: TTL: 28s
[10:20:30] DNS Resolver: TYPE: CNAME: name alias
[10:20:30] DNS Resolver: answered domain is CNAME for: irc.map.rizon.net
[10:20:30] DNS Resolver: answered domain query: "irc.map.rizon.net"
[10:20:30] DNS Resolver error: Answered class (unknown class) does not match queried class (IN: the Internet).
[10:20:30] DNS Resolver: Received nameserver reply. (qd:1 an:5 ns:0 ar:0)
[10:20:30] DNS Resolver: answered domain query: "irc.rizon.net"
[10:20:30] DNS Resolver: TTL: 28s
[10:20:30] DNS Resolver: TYPE: CNAME: name alias
[10:20:30] DNS Resolver: answered domain is CNAME for: irc.map.rizon.net
[10:20:30] DNS Resolver: answered domain query: "irc.map.rizon.net"
[10:20:30] DNS Resolver error: Answered class (unknown class) does not match queried class (IN: the Internet).
```
After:
```
.tcl dnslookup irc.rizon.net foo
[10:18:58] tcl: builtin dcc call: *dcc:tcl -HQ 1 dnslookup irc.rizon.net foo
[10:18:58] tcl: evaluate (.tcl): dnslookup irc.rizon.net foo
[10:18:58] DNS Resolver: Creating new record
[10:18:58] DNS Resolver: Sent domain lookup request for "irc.rizon.net".
Tcl: 
[10:18:58] DNS Resolver: Received nameserver reply. (qd:1 an:5 ns:0 ar:0)
[10:18:58] DNS Resolver: answered domain query: "irc.rizon.net"
[10:18:58] DNS Resolver: TTL: 2m
[10:18:58] DNS Resolver: TYPE: CNAME: name alias
[10:18:58] DNS Resolver: answered domain is CNAME for: irc.map.rizon.net
[10:18:58] DNS Resolver: answered domain query: "irc.map.rizon.net"
[10:18:58] DNS Resolver: TTL: 25m41s
[10:18:58] DNS Resolver: TYPE: CNAME: name alias
[10:18:58] DNS Resolver: answered domain is CNAME for: sfykrmx3gi2lvjzbq33dweqm5qyiky2u7fzqtmjtzq.map.rizon.net
[10:18:58] DNS Resolver: answered domain query: "sfykrmx3gi2lvjzbq33dweqm5qyiky2u7fzqtmjtzq.map.rizon.net"
[10:18:58] DNS Resolver: TTL: 25m41s
[10:18:58] DNS Resolver: TYPE: CNAME: name alias
[10:18:58] DNS Resolver: answered domain is CNAME for: d2iuomqoq4ayc3jgmmojxp6dgr356zwq7d6ahq5ute.map.rizon.net
[10:18:58] DNS Resolver: answered domain query: "d2iuomqoq4ayc3jgmmojxp6dgr356zwq7d6ahq5ute.map.rizon.net"
[10:18:58] DNS Resolver: TTL: 2m
[10:18:58] DNS Resolver: TYPE: A: host address
[10:18:58] DNS Resolver: Lookup successful: irc.rizon.net
[10:18:58] DNS resolved irc.rizon.net to 192.122.0.1
[10:18:58] Tcl error [foo]: invalid command name "foo"
invalid command name "foo"
    while executing
"foo 192.122.0.1 irc.rizon.net 1"
```