### PR TITLE
Fix server connect for --disable-ipv6

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -55,7 +55,7 @@ extern unsigned long otraffic_irc_today, otraffic_bn_today, otraffic_dcc_today,
                      otraffic_unknown_today;
 
 char natip[121] = "";         /* Public IPv4 to report for systems behind NAT */
-char listen_ip[121] = ""; /* IP (or hostname) for listening sockets    */
+char listen_ip[121] = "";     /* IP (or hostname) for listening sockets       */
 char vhost[121] = "";         /* IPv4 vhost for outgoing connections          */
 #ifdef IPV6
 char vhost6[121] = "";        /* IPv6 vhost for outgoing connections          */
@@ -270,7 +270,7 @@ void getvhost(sockname_t *addr, int af)
   else
     h = vhost6;
 #endif
-  if (setsockname(addr, (h ? h : ""), 0, 1) != af)
+  if (!vhost[0] || setsockname(addr, (h ? h : ""), 0, 1) != af)
     setsockname(addr, (af == AF_INET ? "0.0.0.0" : "::"), 0, 0);
   /* Remember this 'self-lookup failed' thingie?
      I have good news - you won't see it again ;) */
@@ -520,7 +520,7 @@ static int get_port_from_addr(const sockname_t *addr)
 #ifdef IPV6
   return ntohs((addr->family == AF_INET) ? addr->addr.s4.sin_port : addr->addr.s6.sin6_port);
 #else
-  return addr->addr.s4.sin_port;
+  return ntohs(addr->addr.s4.sin_port);
 #endif
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1072

One-line summary:
Fix server connect for `--disable-ipv6`

Additional description (if needed):
There were 2 bugs in eggdrop git version 48e6ff154a93da4083db447d3f4b408a2ede662b triggered by `./configure --disable-ipv6`. One bug was breaking server connect. The other one broke the logging of a port number. If server connection was refused the port was logged like:
`[23:44:06] net: attempted socket connection refused: 127.0.0.1:6667`
But the port was not converted to the correct byte order, so for example, instead of 6667 port 2842 was logged.
This PR fixes both bugs.

Test cases demonstrating functionality (if applicable):
./configure --disable-ipv6
```
Before:
[23:42:16] Trying server 127.0.0.1:6667
[23:42:16] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[23:42:16] Failed connect to 127.0.0.1 (Vhost set in config is not available on this machine)
```
After:
```
[23:44:29] Trying server 127.0.0.1:6667
[23:44:29] net: open_telnet_raw(): idx 4 host 127.0.0.1 port 6667 ssl 0
[23:44:29] net: connect! sock 9
[23:44:29] Connected to 127.0.0.1
```