### PR TITLE
Fix buffer size

### DIFF
--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -870,13 +870,13 @@ static void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
 
 static void check_tcl_invite(char *nick, char *from, char *chan, char *invitee)
 {
-  char args[512];
+  char args[1024];
 
   Tcl_SetVar(interp, "_invite1", nick, 0);
   Tcl_SetVar(interp, "_invite2", from, 0);
   Tcl_SetVar(interp, "_invite3", chan, 0);
   Tcl_SetVar(interp, "_invite4", invitee, 0);
-  simple_sprintf(args, "%s %s", chan, invitee);
+  snprintf(args, sizeof args, "%s %s", chan, invitee);
   check_tcl_bind(H_invt, args, 0, " $_invite1 $_invite2 $_invite3 $_invite4",
                     MATCH_MASK | BIND_STACKABLE);
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix buffer size

Additional description (if needed):
A bogus or malicious irc server could crash the bot or worse if it sends a very long INVITE message.
This bug was probably introduced with #890 commit 14dcd6da44fc619ba316b0d2fdeef97df678b27a Dec 30, 2019 and will therefore probably only affect eggdrop git and not 1.8.4.

Test cases demonstrating functionality (if applicable):
```
[03:37:21] [@] INVITE YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY[...]
=================================================================
==198169==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe88aacd00 at pc 0x558598810782 bp 0x7ffe88aac900 sp 0x7ffe88aac8f0
WRITE of size 1 at 0x7ffe88aacd00 thread T0
    #0 0x558598810781 in simple_sprintf /home/michael/projects/eggdrop/src/botmsg.c:185
    #1 0x7f8dcf48080b in check_tcl_invite .././irc.mod/irc.c:879
    #2 0x7f8dcf480cc7 in gotinvite .././irc.mod/chan.c:1566
    #3 0x7f8dcf6bc80b in server_raw .././server.mod/server.c:1297
    #4 0x5585988da894 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:323
    #5 0x7f8dd4b51c01 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x40c01)
    #6 0x7f8dd4b53ab9 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42ab9)
    #7 0x7f8dd4b542e2 in Tcl_EvalEx (/usr/lib/libtcl8.6.so+0x432e2)
    #8 0x7f8dd4b54306 in Tcl_Eval (/usr/lib/libtcl8.6.so+0x43306)
    #9 0x7f8dd4b548f0 in Tcl_VarEvalVA (/usr/lib/libtcl8.6.so+0x438f0)
    #10 0x7f8dd4b549c9 in Tcl_VarEval (/usr/lib/libtcl8.6.so+0x439c9)
    #11 0x5585988f44a3 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:748
    #12 0x5585988f8d61 in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:891
    #13 0x7f8dcf6b41cc in check_tcl_raw .././server.mod/servmsg.c:192
    #14 0x7f8dcf6dd423 in server_activity .././server.mod/servmsg.c:1196
    #15 0x5585988adfdc in mainloop main.c:875
    #16 0x5585988b0bec in main main.c:1299
    #17 0x7f8dd3aee171 in __libc_start_main (/usr/lib/libc.so.6+0x28171)
    #18 0x5585987ff2cd in _start (/home/michael/eggdrop/eggdrop-1.9.0+0x1fa2cd)
```