### PR TITLE
Fix strcpy param overlap

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2383,7 +2383,7 @@ static int gotmsg(char *from, char *msg)
       *p = 0;
       ctcp = buf2;
       strlcpy(buf2, p1, sizeof buf2);
-      strcpy(p1 - 1, p + 1);
+      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
       detect_chan_flood(nick, uhost, from, chan, strncmp(ctcp, "ACTION ", 7) ?
                         FLOOD_CTCP : FLOOD_PRIVMSG, NULL);
 
@@ -2502,7 +2502,7 @@ static int gotnotice(char *from, char *msg)
       *p = 0;
       ctcp = buf2;
       strcpy(ctcp, p1);
-      strcpy(p1 - 1, p + 1);
+      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
       p = strchr(msg, 1);
       detect_chan_flood(nick, uhost, from, chan,
                         strncmp(ctcp, "ACTION ", 7) ?

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -699,7 +699,7 @@ static int gotnotice(char *from, char *msg)
     if (*p == 1) {
       *p = 0;
       ctcp = strcpy(ctcpbuf, p1);
-      strcpy(p1 - 1, p + 1);
+      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
       if (!ignoring)
         detect_flood(nick, uhost, from, FLOOD_CTCP);
       p = strchr(msg, 1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix strcpy param overlap

Additional description (if needed):
For strcpy(), the result is undefined if src and dst overlap. Solution is to use memmove() instead.

Test cases demonstrating functionality (if applicable):
```
[04:18:00] [@] :BotA NOTICE   BotA :[...]
=================================================================
==200239==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x6290000c9718,0x6290000c9746) and [0x6290000c9744, 0x6290000c9772) overlap
    #0 0x7ff97d512d37 in __interceptor_strcpy /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:436
    #1 0x7ff977ed5bfd in gotnotice .././server.mod/servmsg.c:702
    #2 0x7ff977ebc80b in server_raw .././server.mod/server.c:1297
    #3 0x5599188cc894 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:323
    #4 0x7ff97d33bc01 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x40c01)
    #5 0x7ff97d33dab9 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42ab9)
    #6 0x7ff97d33e2e2 in Tcl_EvalEx (/usr/lib/libtcl8.6.so+0x432e2)
    #7 0x7ff97d33e306 in Tcl_Eval (/usr/lib/libtcl8.6.so+0x43306)
    #8 0x7ff97d33e8f0 in Tcl_VarEvalVA (/usr/lib/libtcl8.6.so+0x438f0)
    #9 0x7ff97d33e9c9 in Tcl_VarEval (/usr/lib/libtcl8.6.so+0x439c9)
    #10 0x5599188e64a3 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:748
    #11 0x5599188ead61 in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:891
    #12 0x7ff977eb41cc in check_tcl_raw .././server.mod/servmsg.c:192
    #13 0x7ff977edd423 in server_activity .././server.mod/servmsg.c:1196
    #14 0x55991889ffdc in mainloop main.c:875
    #15 0x5599188a2bec in main main.c:1299
    #16 0x7ff97c2d8171 in __libc_start_main (/usr/lib/libc.so.6+0x28171)
    #17 0x5599187f12cd in _start (/home/michael/eggdrop/eggdrop-1.9.0+0x1fa2cd)
```