### PR TITLE
Change one more time_t to PRId64

### DIFF
--- a/src/userent.c
+++ b/src/userent.c
@@ -390,7 +390,7 @@ static int laston_tcl_get(Tcl_Interp * irp, struct userrec *u,
     if (!cr)
       Tcl_AppendResult(irp, "0", NULL);
   } else {
-    snprintf(number, sizeof number, "%lu ", li->laston);
+    snprintf(number, sizeof number, "%" PRId64 " ", li->laston);
     Tcl_AppendResult(irp, number, li->lastonplace, NULL);
   }
   return TCL_OK;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Change one more time_t to PRId64

Additional description (if needed):
This PR fixes the following compiler warning similar to #1059
```
$ uname -sp
Minix i386
```

```
$ make
[...]
clang -g -O2 -pipe -Wall -I.. -I.. -I/usr/pkg/include -DHAVE_CONFIG_H -I/usr/pkg/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c userent.c
userent.c:393:45: warning: format specifies type 'unsigned long' but the argument has type 'time_t' (aka 'long long')
      [-Wformat]
    snprintf(number, sizeof number, "%lu ", li->laston);
                                     ~~~    ^~~~~~~~~~
                                     %lld
1 warning generated.
```

Test cases demonstrating functionality (if applicable):
test of the modified function via `.tcl getuser testuser laston` successful:
```
.whois testuser
[20:10:16] #-HQ# whois testuser
HANDLE                           PASS NOTES FLAGS           LAST
testuser                         no       0 hjlmoptx        2020-11-06 (partyline)
  HOSTS: testuser!~michael@localhost, michael!~michael@localhost
  INFO: foo2
[20:55:17] triggered bind dcc:whois, user 0.094ms sys 0.094ms
.tcl getuser testuser laston
Tcl: 1604692517 partyline
```