### PR TITLE
Fix format specifier

### DIFF
--- a/src/botmsg.c
+++ b/src/botmsg.c
@@ -916,7 +916,7 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
     return NOTE_OK; /* Error msg from a tandembot: don't store. */
 
   /* Call 'storenote' Tcl command. */
-  simple_sprintf(ss, "%d", (idx >= 0) ? dcc[idx].sock : -1);
+  snprintf(ss, sizeof ss, "%ld", (idx >= 0) ? dcc[idx].sock : -1);
   Tcl_SetVar(interp, "_from", from, 0);
   Tcl_SetVar(interp, "_to",   to,   0);
   Tcl_SetVar(interp, "_data", msg,  0);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix wrong format specifier covered by simple_sprintf()

Additional description (if needed):
sock is long, see: https://github.com/eggheads/eggdrop/blob/f59fb68811437536ee86dedb1ca23a31b48a5cca/src/eggdrop.h#L376

Test cases demonstrating functionality (if applicable):
