### PR TITLE
Fix 3 for time_t printing

### DIFF
--- a/src/userent.c
+++ b/src/userent.c
@@ -390,7 +390,7 @@ static int laston_tcl_get(Tcl_Interp * irp, struct userrec *u,
     if (!cr)
       Tcl_AppendResult(irp, "0", NULL);
   } else {
-    snprintf(number, sizeof number, "%" PRId64 " ", li->laston);
+    snprintf(number, sizeof number, "%" PRId64 " ", (int64_t) li->laston);
     Tcl_AppendResult(irp, number, li->lastonplace, NULL);
   }
   return TCL_OK;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix 3 for time_t printing

Additional description (if needed):
This one is hitting hard on me. Its the 3rd time i submit a patch to get this simple time_t printing right.

Test cases demonstrating functionality (if applicable):
```
$ uname -a
Darwin macos.local 19.6.0 Darwin Kernel Version 19.6.0: Mon Aug 31 22:12:52 PDT 2020; root:xnu-6153.141.2~1/RELEASE_X86_64 x86_64
```
Before:
```
rks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c userent.c
userent.c:393:53: warning: format specifies type 'long long' but the argument has type 'time_t' (aka 'long') [-Wformat]
    snprintf(number, sizeof number, "%" PRId64 " ", li->laston);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro
      'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~
1 warning generated.
```
After:
`gcc -g -O2 -pipe -Wall -I.. -I.. -I/usr/local/opt/openssl/include -DHAVE_CONFIG_H -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers -DSTATIC  -c userent.c`