### PR TITLE
Fix OBE in twitch mod

### DIFF
--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -347,11 +347,11 @@ static int gotwhisper(char *from, char *msg, char *tags) {
 }
 
 static int gotclearmsg(char *from, char *msg, char *tags) {
-  char nick[NICKMAX], *chan, *msgid;
+  char nick[NICKLEN], *chan, *msgid;
   
   chan = newsplit(&msg);
   fixcolon(msg);
-  strncpy(nick, get_value(tags, "login"), sizeof nick);
+  strlcpy(nick, get_value(tags, "login"), sizeof nick);
   msgid = get_value(tags, "target-msg-id");
   check_tcl_clearmsg(nick, chan, msgid, msg);
   putlog(LOG_SERV, "*", "* TWITCH: Cleared message %s from %s", msgid, nick);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix off by one error (stringop-truncation)

Additional description (if needed):
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././twitch.mod/twitch.c && mv -f twitch.o ../
.././twitch.mod/twitch.c:749:12: warning: ‘strncpy’ specified bound 32 equals destination size [-Wstringop-truncation]
  354 |   strncpy(nick, get_value(tags, "login"), sizeof nick);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Test cases demonstrating functionality (if applicable):
