### PR TITLE
Fix handling of null-argument in server.mod

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1757,18 +1757,17 @@ static int ctcp_DCC_CHAT(char *nick, char *from, char *handle,
   param = newsplit(&msg);
   ip = newsplit(&msg);
   prt = newsplit(&msg);
-#ifdef TLS
-  if (strcasecmp(action, "CHAT") || strcasecmp(object, botname) || !u)
+  if (strcasecmp(action, "CHAT"))
   {
+#ifdef TLS
     if (!strcasecmp(action, "SCHAT"))
       ssl = 1;
     else
+#endif
       return 0;
   }
-#else
-  if (strcasecmp(action, "CHAT") || strcasecmp(object, botname) || !u)
+  if (strcasecmp(object, botname) || !u)
     return 0;
-#endif
   get_user_flagrec(u, &fr, 0);
   if (dcc_total == max_dcc && increase_socks_max()) {
     if (!quiet_reject)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix handling of null-argument in server.mod

Additional description (if needed):
The code in server.c:ctcp_DCC_CHAT() with TLS enabled wasnt rejecting u == NULL. This is not a major problem, because with u == NULL, the flags in fr become 0 and the function will reject before a NULL access would happen in line https://github.com/eggheads/eggdrop/blob/fcb9068dc8aa4fff1af8c1660d4b9b3e9bea5e14/src/mod/server.mod/server.c#L1808. Anyway, this PR improves code maintenance / quality, makes sure, this functtion will stay secure and will make code analyzers happy.

Test cases demonstrating functionality (if applicable):
No functional change, but i tested eggdrop with kvirc:
**1. dcc schat from unknown user:**
kvirc:
```
[16:22:35] Attempting a passive DCC SCHAT connection
[16:22:36] Listening on interface 127.0.0.1 port 60183
[16:22:36] The local IP address is private, determining from IRC server: ::1
[16:22:36] Sent DCC SCHAT request to BotA, waiting for the remote client to connect...
```
eggdrop:
```
[16:22:36] Refused DCC SCHAT: mallory!~kvirc@localhost
[16:22:36] CTCP SCHAT: chat ::1 60183 from mallory (~kvirc@localhost)
```
**2. dcc chat from known user:**
kvirc:
```
[16:27:19] Attempting a passive DCC CHAT connection
[16:27:20] Listening on interface 127.0.0.1 port 60283
[16:27:20] Sent DCC CHAT request to BotA, waiting for the remote client to connect...
[16:27:20] Connected to 127.0.0.1:40581
[16:27:20] Local end is 127.0.0.1:60283
[16:27:21] <BotA> Enter your password.
```
eggdrop:
```
[16:27:20] net: setsockname(): ip 2130706433 -> 127.0.0.1
[16:27:20] DNS Resolver: Creating new record
[16:27:20] DNS Resolver: Sent domain lookup request for "127.0.0.1".
[16:27:20] CTCP DCC: CHAT chat 2130706433 60283 from testuser (~michael@localhost)
[16:27:20] DNS Resolver: Domain does not exist.
[16:27:20] DNS Resolver: Lookup failed.
[16:27:20] DNS resolve failed for 127.0.0.1
[16:27:20] net: open_telnet_raw(): idx 5 host ~michael@localhost ip 127.0.0.1 port 60283 ssl 0
[16:27:21] DCC connection: CHAT (testuser!~michael@localhost)
```