### PR TITLE
Ignore config comments in listen cmd

### DIFF
--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -429,3 +429,4 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0xe32,Afviste telnet forbindelse fra %s (forsøg på at bruge mit botnetnick)
 0xe33,Mistede telnet forbindelse fra %s mens der blev tjekket for dubletter
 0xe34,TIMEOUT ident forbindelse
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -429,4 +429,4 @@ Telnet to the bot and enter 'NEW' as your handle.
 0xe32,Refused telnet connection from %s (tried using my botnetnick)
 0xe33,Lost telnet connection from %s while checking for duplicate
 0xe34,TIMEOUT ident connection
-0xe36,Please remove the #comment from your listen setting and try again
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -429,4 +429,4 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0xe32,Refused telnet connection from %s (tried using my botnetnick)
 0xe33,Lost telnet connection from %s while checking for duplicate
 0xe34,TIMEOUT ident connection
-0xe35,Please remove the #comment from your listen setting and try again
+0xe36,Please remove the #comment from your listen setting and try again

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -429,3 +429,4 @@ Telnet to the bot and enter 'NEW' as your nickname.
 0xe32,Refused telnet connection from %s (tried using my botnetnick)
 0xe33,Lost telnet connection from %s while checking for duplicate
 0xe34,TIMEOUT ident connection
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -429,3 +429,4 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0xe32,Evätään telnet yhteys %s (yritä käyttää minun botnetnickkiäni)
 0xe33,Telnet yhteys hukattu %s silläaikaa kun tarkistettiin tuplausta
 0xe34,Kadotettu ident yhteys
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -430,3 +430,4 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe32,Refus de la connexion telnet de %s (essai avec mon surnom botnet)
 0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
 0xe34,Timeout ident connection
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -438,4 +438,4 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe32,Telnet-Verbindung von %s zurueckgewiesen (versuchte, meinen botnetnick zu benutzen)
 0xe33,Telnet-Verbindung von %s waerend Kontrolle auf Duplikat verloren
 0xe34,Zeitueberschreitung bei der Ident-Verbindung
-0xe35,Please remove the #comment from your listen setting and try again
+0xe35,Bitte entferne den #Kommentar im listen-Befehl und versuche es erneut

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -438,3 +438,4 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe32,Telnet-Verbindung von %s zurueckgewiesen (versuchte, meinen botnetnick zu benutzen)
 0xe33,Telnet-Verbindung von %s waerend Kontrolle auf Duplikat verloren
 0xe34,Zeitueberschreitung bei der Ident-Verbindung
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -429,3 +429,4 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe32,Recusada ligação telnet de %s (tentou usar o meu nick de botnet)
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
 0xe34,Timeout em ligação de identificação
+0xe35,Please remove the #comment from your listen setting and try again

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -429,4 +429,4 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe32,Recusada ligação telnet de %s (tentou usar o meu nick de botnet)
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
 0xe34,Timeout em ligação de identificação
-0xe35,Please remove the #comment from your listen setting and try again
+0xe35,Por favor, remova o #comentário na configuração de listen e tente novamente

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1518,7 +1518,7 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
   buf[HANDLEN] = 0;
   /* Toss out bad nicknames */
   if (dcc[idx].nick[0] != '@' && !wild_match(dcc[idx].nick, buf)) {
-    dprintf(idx, "Sorry, that nickname format is invalid.\n");
+    dprintf(idx, "Sorry, that nickname is not allowed.\n");
     putlog(LOG_BOTS, "*", DCC_BADNICK, dcc[idx].host);
     killsock(dcc[idx].sock);
     lostdcc(idx);

--- a/src/lang.h
+++ b/src/lang.h
@@ -489,5 +489,6 @@
 #define DCC_MYBOTNETNICK        get_language(0xe32)
 #define DCC_LOSTDUP             get_language(0xe33)
 #define DCC_TIMEOUTIDENT        get_language(0xe34)
+#define DCC_BADLISTEN           get_language(0xe35)
 
 #endif /* _EGG_LANG_H */

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1045,7 +1045,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
   memset(&hint, '\0', sizeof hint);
   hint.ai_family = PF_UNSPEC;
   hint.ai_flags = AI_NUMERICHOST;
-  if (!strlen(ip)) {
+  if (!ip[0]) {
 #ifdef IPV6
     if (pref_af) {
       strlcpy(newip, "::", sizeof newip);
@@ -1218,7 +1218,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     strcpy(dcc[idx].nick, "(users)");
   else if (!strcmp(type, "all"))
     strcpy(dcc[idx].nick, "(telnet)");
-  if (strlen(maskproc))
+  if (maskproc[0])
     strlcpy(dcc[idx].host, maskproc, UHOSTMAX);
   else
     strcpy(dcc[idx].host, "*");
@@ -1251,7 +1251,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
  */
 static int tcl_listen STDVAR
 {
-  char ip[121], port[7], type[7], maskproc[UHOSTMAX] = "", flag[4], *endptr;
+  char ip[121] = "", maskproc[UHOSTMAX] = "";
+  char port[7], type[7], flag[4], *endptr;
   unsigned char buf[sizeof(struct in6_addr)];
   int i = 1;
 
@@ -1284,8 +1285,6 @@ static int tcl_listen STDVAR
       Tcl_AppendResult(irp, "invalid ip address", NULL);
       return TCL_ERROR;
     }
-  } else {
-    strcpy(ip, "");
   }
 /* Check for port */
   if ((atoi(argv[i]) > 65535) || (atoi(argv[i]) < 1)) {
@@ -1308,22 +1307,22 @@ static int tcl_listen STDVAR
   }
   strlcpy(type, argv[i], sizeof(type));
 /* Check if mask or proc exists */
-  if ((((argc>3) && !strlen(ip)) || ((argc >4) && strlen(ip))) &&
+  if ((((argc>3) && !ip[0]) || ((argc >4) && ip[0])) &&
         (argv[i+1][0] != '#')) { /* Ignore config comments! */
     i++;
     strlcpy(maskproc, argv[i], sizeof(maskproc));
   }
 /* If script, check for proc and flag */
   if (!strcmp(type, "script")) {
-    if (!strlen(maskproc)) {
+    if (!maskproc[0]) {
       Tcl_AppendResult(irp, "a proc name must be specified for a script listen", NULL);
       return TCL_ERROR;
     }
-    if ((!strlen(ip) && (argc==4)) || (strlen(ip) && argc==5)) {
+    if ((!ip[0] && (argc==4)) || (ip[0] && argc==5)) {
       Tcl_AppendResult(irp, "missing flag. allowed flags: pub", NULL);
       return TCL_ERROR;
     }
-    if ((!strlen(ip) && (argc==5)) || (argc == 6)) {
+    if ((!ip[0] && (argc==5)) || (argc == 6)) {
       i++;
       if (strcmp(argv[i], "pub")) {
         Tcl_AppendResult(irp, "unknown flag: ", flag, ". allowed flags: pub",

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1255,7 +1255,20 @@ static int tcl_listen STDVAR
   unsigned char buf[sizeof(struct in6_addr)];
   int i = 1;
 
-  BADARGS(3, 6, " ip port type ?mask?/?proc flag?");
+/* People like to add comments to this commnd for some reason, and it can cause
+ * errors that are difficult to figure out. Let's instead throw a more helpful
+ * error for this case to get around BADARGS, and handle other cases further
+ * down in the code
+ *
+ * Check if extra args are config comments 
+ */
+  if (argc > 6) {
+    if (argv[6][0] == '#') {
+      fatal(DCC_BADLISTEN, 0);
+    }
+  }
+
+  BADARGS(3, 6, " ?ip? port type ?mask?/?proc flag?");
 
 /* Check if IP exists, set to NULL if not */
   strtol(argv[1], &endptr, 10);
@@ -1295,7 +1308,8 @@ static int tcl_listen STDVAR
   }
   strlcpy(type, argv[i], sizeof(type));
 /* Check if mask or proc exists */
-  if (((argc>3) && !strlen(ip)) || ((argc >4) && strlen(ip))) {
+  if ((((argc>3) && !strlen(ip)) || ((argc >4) && strlen(ip))) &&
+        (argv[i+1][0] != '#')) { /* Ignore config comments! */
     i++;
     strlcpy(maskproc, argv[i], sizeof(maskproc));
   }


### PR DESCRIPTION
Found by: Lord255
Patch by: Geo

Because a "comment" can go over BADRGS limit and makes for a confusing error,
we check for >ARGS at run. We can handle a comment in <ARGS later in the code.

Tested:
listen port all #comment
listen ip port all #comment
listen port script foo pub #comment
listen ip port script foo pub #comment  <- fatals