### PR TITLE
Fix another OBOE in twitch mod

### DIFF
--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -153,7 +153,7 @@ static void cmd_userstate(struct userrec *u, int idx, char *par) {
  */
 char *get_value(char *dict, char *key) {
   char *ptr, *ptr2, s[TOTALTAGMAX];
-  strncpy(s, dict, sizeof s);
+  strlcpy(s, dict, sizeof s);
   ptr = strstr(s, key);                  /* Get ptr to key */
   if (!ptr) {
     return NULL;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix another OBOE in twitch mod

Additional description (if needed):
Pls use strlcpy(), for its very common do get strncpy() wrong.

Test cases demonstrating functionality (if applicable):
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././twitch.mod/twitch.c && mv -f twitch.o ../
.././twitch.mod/twitch.c: In function ‘get_value’:
.././twitch.mod/twitch.c:156:3: warning: ‘strncpy’ specified bound 8191 equals destination size [-Wstringop-truncation]
  156 |   strncpy(s, dict, sizeof s);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~