### PR TITLE
Fix OBOE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -456,7 +456,7 @@ static void got_ill(int z)
  */
 void eggContext(const char *file, int line, const char *module)
 {
-  eggContextNote(file, line, module, 0);
+  eggContextNote(file, line, module, NULL);
 }
 
 /* Called from the ContextNote macro.

--- a/src/main.c
+++ b/src/main.c
@@ -172,7 +172,7 @@ unsigned long itraffic_unknown_today = 0;
 
 #ifdef DEBUG_CONTEXT
 /* Context storage for fatal crashes */
-char cx_file[16][30];
+char cx_file[16][32];
 char cx_note[16][256];
 int cx_line[16];
 int cx_ptr = 0;
@@ -456,15 +456,14 @@ static void got_ill(int z)
  */
 void eggContext(const char *file, int line, const char *module)
 {
-  char x[31], *p;
+  char *p;
 
   p = strrchr(file, '/');
-  if (!module) {
-    strlcpy(x, p ? p + 1 : file, sizeof x);
-  } else
-    egg_snprintf(x, 31, "%s:%s", module, p ? p + 1 : file);
   cx_ptr = ((cx_ptr + 1) & 15);
-  strcpy(cx_file[cx_ptr], x);
+  if (!module) {
+    strlcpy(cx_file[cx_ptr], p ? p + 1 : file, sizeof cx_file[cx_ptr]);
+  } else
+    snprintf(cx_file[cx_ptr], sizeof cx_file[cx_ptr], "%s:%s", module, p ? p + 1 : file);
   cx_line[cx_ptr] = line;
   cx_note[cx_ptr][0] = 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -456,16 +456,7 @@ static void got_ill(int z)
  */
 void eggContext(const char *file, int line, const char *module)
 {
-  char *p;
-
-  p = strrchr(file, '/');
-  cx_ptr = ((cx_ptr + 1) & 15);
-  if (!module) {
-    strlcpy(cx_file[cx_ptr], p ? p + 1 : file, sizeof cx_file[cx_ptr]);
-  } else
-    snprintf(cx_file[cx_ptr], sizeof cx_file[cx_ptr], "%s:%s", module, p ? p + 1 : file);
-  cx_line[cx_ptr] = line;
-  cx_note[cx_ptr][0] = 0;
+  eggContextNote(file, line, module, 0);
 }
 
 /* Called from the ContextNote macro.
@@ -473,17 +464,19 @@ void eggContext(const char *file, int line, const char *module)
 void eggContextNote(const char *file, int line, const char *module,
                     const char *note)
 {
-  char x[31], *p;
+  char *p;
 
   p = strrchr(file, '/');
-  if (!module)
-    strlcpy(x, p ? p + 1 : file, sizeof x);
-  else
-    egg_snprintf(x, 31, "%s:%s", module, p ? p + 1 : file);
   cx_ptr = ((cx_ptr + 1) & 15);
-  strcpy(cx_file[cx_ptr], x);
+  if (!module)
+    strlcpy(cx_file[cx_ptr], p ? p + 1 : file, sizeof cx_file[cx_ptr]);
+  else
+    snprintf(cx_file[cx_ptr], sizeof cx_file[cx_ptr], "%s:%s", module, p ? p + 1 : file);
   cx_line[cx_ptr] = line;
-  strlcpy(cx_note[cx_ptr], note, sizeof cx_note[cx_ptr]);
+  if (!note)
+    cx_note[cx_ptr][0] = 0;
+  else
+    strlcpy(cx_note[cx_ptr], note, sizeof cx_note[cx_ptr]);
 }
 #endif /* DEBUG_CONTEXT */
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix OBOE

Additional description (if needed):
This OBOE is a buffer overflow.

The buffer overflow occurs, when an the filename of an eggdrop source file exceeds a certain value. I triggered that bug with a 3rd party module.

eggdrop Context https://github.com/eggheads/eggdrop/blob/e8f94348cc543b55ce7fdb6f35bebbc52f9b11d6/src/main.c#L175 defines strings of len 30 but https://github.com/eggheads/eggdrop/blob/e8f94348cc543b55ce7fdb6f35bebbc52f9b11d6/src/main.c#L467
 copies up to 31 bytes including null terminator.

We mostly changed all strcpy() to strlcpy() already and eggdrops source was probably audited more than once regarding any remaining strcpy(). Again this is a warning to never use strcpy(). Even us careful eggheads cant use it safely.

This PR changes the len to 32, changes hardcoded len values to sizeof, changes strcpy() to strlcpy() and simplifies the source.

```
=================================================================
==84318==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55fc0980ac60 at pc 0x7f8ea86a9e16 bp 0x7ffebb07a830 sp 0x7ffebb079fd8
WRITE of size 31 at 0x55fc0980ac60 thread T0
    #0 0x7f8ea86a9e15 in __interceptor_strcpy /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:438
    #1 0x55fc094dbecf in eggContext main.c:467
    #2 0x7f8ea263c608 in template_add_cmd_chan_user core/templates_stats_commands.c:339
    #3 0x7f8ea2637e41 in templates_commands_addtocontent core/templates_commands.c:79
    #4 0x7f8ea2638712 in templates_content_parse core/templates_content.c:189
    #5 0x7f8ea2681d5a in templates_content_load core/templates_content.c:78
    #6 0x7f8ea2682a33 in loadskin core/templates.c:124
    #7 0x7f8ea26835a3 in tcl_loadstatsskin /home/michael/projects/eggdrop/src/mod/stats.mod/tclstats.c:155
    #8 0x55fc095089d6 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:324
    #9 0x55fc09508b27 in tcl_call_stringproc /home/michael/projects/eggdrop/src/tcl.c:333
    #10 0x7f8ea84d0c61 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x40c61)
    #11 0x7f8ea84d2b39 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42b39)
    #12 0x7f8ea858d369 in Tcl_FSEvalFileEx (/usr/lib/libtcl8.6.so+0xfd369)
    #13 0x7f8ea858d509 in Tcl_EvalFile (/usr/lib/libtcl8.6.so+0xfd509)
    #14 0x55fc0950bf7c in readtclprog /home/michael/projects/eggdrop/src/tcl.c:814
    #15 0x55fc094698ac in chanprog /home/michael/projects/eggdrop/src/chanprog.c:461
    #16 0x55fc094debc2 in main main.c:1162
    #17 0x7f8ea7477171 in __libc_start_main (/usr/lib/libc.so.6+0x28171)
    #18 0x55fc0942f30d in _start (/home/michael/eggdrop/eggdrop-1.9.0+0x20730d)

0x55fc0980ac60 is located 32 bytes to the left of global variable 'itraffic_unknown_today' defined in './main.c:171:15' (0x55fc0980ac80) of size 8
0x55fc0980ac60 is located 0 bytes to the right of global variable 'cx_file' defined in './main.c:175:6' (0x55fc0980aa80) of size 480
SUMMARY: AddressSanitizer: global-buffer-overflow /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:438 in __interceptor_strcpy
Shadow bytes around the buggy address:
  0x0ac0012f9530: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac0012f9540: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0ac0012f9550: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac0012f9560: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac0012f9570: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0ac0012f9580: 00 00 00 00 00 00 00 00 00 00 00 00[f9]f9 f9 f9
  0x0ac0012f9590: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac0012f95a0: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac0012f95b0: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac0012f95c0: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac0012f95d0: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==84318==ABORTING
```

Test cases demonstrating functionality (if applicable):
