### PR TITLE
Fix format overflow

### DIFF
--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -172,7 +172,7 @@ static void set_mode_protect(struct chanset_t *chan, char *set)
 
 static void get_mode_protect(struct chanset_t *chan, char *s)
 {
-  char *p = s, s1[121];
+  char *p = s, s1[122];
   int i, tst;
 
   s1[0] = 0;
@@ -183,11 +183,11 @@ static void get_mode_protect(struct chanset_t *chan, char *s)
         *p++ = '+';
       if (chan->limit_prot != 0) {
         *p++ = 'l';
-        sprintf(&s1[strlen(s1)], "%d ", chan->limit_prot);
+        snprintf(s1 + strlen(s1), (sizeof s1) - strlen(s1), "%d ", chan->limit_prot);
       }
       if (chan->key_prot[0]) {
         *p++ = 'k';
-        sprintf(&s1[strlen(s1)], "%s ", chan->key_prot);
+        snprintf(s1 + strlen(s1), (sizeof s1) - strlen(s1), "%s ", chan->key_prot);
       }
     } else {
       tst = chan->mode_mns_prot;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format overflow

Additional description (if needed):
Unlikely triggered by real word scenario, but better safe than sorry, i take every possible format overflow very serious. This PR changes sprintf() to snprintf() to avoid overflow and changes buffer size from 121 to 122 to avoid truncation. It thereby fixes also the possible compiler warning with upcomming gcc 11:

```
/home/michael/opt/gcc-11-20210117/bin/gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././channels.mod/channels.c && mv -f channels.o ../
.././channels.mod/channels.c: In function ‘get_mode_protect’:
.././channels.mod/channels.c:190:38: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
  190 |         sprintf(&s1[strlen(s1)], "%s ", chan->key_prot);
      |                                      ^
.././channels.mod/channels.c:190:9: note: ‘sprintf’ output between 2 and 122 bytes into a destination of size 121
  190 |         sprintf(&s1[strlen(s1)], "%s ", chan->key_prot);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Test cases demonstrating functionality (if applicable):
```
.chanset #test6888 chanmode +lk 42 hunter
.die
[17:19:49] Writing channel file...
```

```
$ cat BotA.chan
#Dynamic Channel File for  (eggdrop v1.9.0+etchost) -- written Tue Jan 19 17:20:00 2021

channel add #test6888 { chanmode {+lk 42 hunter} idle-kick 0 stopnethack-mode 0 revenge-mode 0 need-op {} need-invite {} need-key {} need-unban {} need-limit {} flood-chan 15:60 flood-ctcp 3:60 flood-join 5:60 flood-kick 3:10 flood-deop 3:10 flood-nick 5:60 aop-delay 5:30 ban-type 3 ban-time 120 exempt-time 60 invite-time 60 +enforcebans -dynamicbans +userbans -autoop -autohalfop -bitch +greet +protectops -protecthalfops -protectfriends +dontkickops -statuslog -revenge -revengebot -autovoice -secret +shared +cycle -seen -inactive +dynamicexempts +userexempts +dynamicinvites +userinvites -nodesynch -static }
```