### PR TITLE
Fix OBOE

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -650,14 +650,14 @@ void wipe_timers(Tcl_Interp *irp, tcl_timer_t **stack)
  */
 void list_timers(Tcl_Interp *irp, tcl_timer_t *stack)
 {
-  char mins[10], count[10], id[26], *x;
+  char mins[11], count[11], id[26], *x;
   EGG_CONST char *argv[4];
   tcl_timer_t *mark;
 
   for (mark = stack; mark; mark = mark->next) {
-    egg_snprintf(mins, sizeof mins, "%u", mark->mins);
+    snprintf(mins, sizeof mins, "%u", mark->mins);
     snprintf(id, sizeof id, "timer%lu", mark->id);
-    egg_snprintf(count, sizeof count, "%u", mark->count);
+    snprintf(count, sizeof count, "%u", mark->count);
     argv[0] = mins;
     argv[1] = mark->cmd;
     argv[2] = id;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix OBOE

Additional description (if needed):
Unlikely to trigger, but better safe than sorry. The compiler would have catched it, if it wasnt shadowed by the use of egg_snprintf().

Test cases demonstrating functionality (if applicable):
