### PR TITLE
Fix time_t handling

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1504,7 +1504,7 @@ static void cmd_backup(struct userrec *u, int idx, char *par)
 static void cmd_trace(struct userrec *u, int idx, char *par)
 {
   int i;
-  char x[NOTENAMELEN + 11], y[12];
+  char x[NOTENAMELEN + 11], y[22];
 
   if (!par[0]) {
     dprintf(idx, "Usage: trace <botname>\n");
@@ -1521,7 +1521,7 @@ static void cmd_trace(struct userrec *u, int idx, char *par)
   }
   putlog(LOG_CMDS, "*", "#%s# trace %s", dcc[idx].nick, par);
   simple_sprintf(x, "%d:%s@%s", dcc[idx].sock, dcc[idx].nick, botnetnick);
-  simple_sprintf(y, ":%d", now);
+  snprintf(y, sizeof y, ":%" PRId64, (int64_t) now);
   botnet_send_trace(i, x, par, y);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix time_t handling

Additional description (if needed):
Fix buffer size, format specifier, type and maybe also hereby fix a "year 2038 problem". The reason for finding this issue so late is, that it was shadowed by the use of simple_sprintf(). Lets use snprintf() instead.

Test cases demonstrating functionality (if applicable):
```
.trace BotB
Trace result -> BotA:BotB (1 secs, 1 hop)
```
