### PR TITLE
Fix stringop truncation

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1172,7 +1172,7 @@ struct dcc_table DCC_CHAT = {
 };
 
 static int lasttelnets;
-static char lasttelnethost[81];
+static char lasttelnethost[UHOSTLEN + 15];
 static time_t lasttelnettime;
 
 /* A modified detect_flood for incoming telnet flood protection.
@@ -1277,7 +1277,7 @@ static void dcc_telnet_hostresolved(int i)
 {
   int idx;
   int j = 0, sock;
-  char s[UHOSTLEN + 20], *userhost;
+  char s[sizeof lasttelnethost], *userhost;
 
   strlcpy(dcc[i].host, dcc[i].u.dns->host, UHOSTLEN);
 
@@ -1302,7 +1302,7 @@ static void dcc_telnet_hostresolved(int i)
       return;
     }
   }
-  sprintf(s, "-telnet!telnet@%s", dcc[i].host);
+  snprintf(s, sizeof s, "-telnet!telnet@%s", dcc[i].host);
   userhost = s + strlen("-telnet!");
   if (match_ignore(s) || detect_telnet_flood(s)) {
     killsock(dcc[i].sock);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix stringop truncation

Additional description (if needed):
telnet flood detection could truncate host. this is the fix.

Test cases demonstrating functionality (if applicable):
