### PR TITLE
Fix OBOE

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -430,8 +430,8 @@ static void out_dcc_bot(int idx, char *buf, void *x)
 
     if (len && buf[len - 1] == '\n') {
       /* Make a copy as buf could be const */
-      fnd = nmalloc(len);
-      strlcpy(fnd, buf, len);
+      fnd = nmalloc(len + 1);
+      strcpy(fnd, buf);
       p = fnd;
     }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix an OBOE, which is yet another possible stringop truncation

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
