### PR TITLE
Fix typo

### DIFF
--- a/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
@@ -141,7 +141,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
 #. WSPR (WHISPER)
 
-  bind wspr <flags> <commmand> <proc>
+  bind wspr <flags> <command> <proc>
 
   procname <nick> <userhost> <handle> <msg>
 

--- a/doc/sphinx_source/mainDocs/twitch.rst
+++ b/doc/sphinx_source/mainDocs/twitch.rst
@@ -41,7 +41,7 @@ Make sure you leave the 'oauth:' there, including the ':'.
 Twitch web UI functions
 *************************
 
-Twitch is normally accessed via a web UI, and uses commands prefixed with a . or a / to interact with the channel. The Twitch module adds the partyline command ``twcmd`` to replicate those Twitch-specific commands. For example, to grant VIP status to a user via Tcl, you would use the command ``.twcmd vip username``. or to restrict chat to subscibers, you would use ``.twcmd subscribers`` (Note: no . or / is needed as a prefix to the Twitch command). In other words, ``.twcmd`` in Tcl is the interface to the standard Twitch set of commands available through the web UI (Also available as a Tcl command).
+Twitch is normally accessed via a web UI, and uses commands prefixed with a . or a / to interact with the channel. The Twitch module adds the partyline command ``twcmd`` to replicate those Twitch-specific commands. For example, to grant VIP status to a user via Tcl, you would use the command ``.twcmd vip username``. or to restrict chat to subscribers, you would use ``.twcmd subscribers`` (Note: no . or / is needed as a prefix to the Twitch command). In other words, ``.twcmd`` in Tcl is the interface to the standard Twitch set of commands available through the web UI (Also available as a Tcl command).
 
 **********************
 Twitch IRC limitations

--- a/misc/runautotools
+++ b/misc/runautotools
@@ -40,7 +40,7 @@ if test "x${1}" = "x-h" || test "x${1}" = "x--help"; then
 fi
 
 echo "Running autotools in root directory..."
-# Necessary to regenerate misc/getcommit revsion info
+# Necessary to regenerate misc/getcommit revision info
 touch -c configure.ac
 autoconf
 autoheader

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1256,7 +1256,7 @@ static int tcl_listen STDVAR
   unsigned char buf[sizeof(struct in6_addr)];
   int i = 1;
 
-/* People like to add comments to this commnd for some reason, and it can cause
+/* People like to add comments to this command for some reason, and it can cause
  * errors that are difficult to figure out. Let's instead throw a more helpful
  * error for this case to get around BADARGS, and handle other cases further
  * down in the code


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix typo

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
