### PR TITLE
Fix type compiler warning in eggdrop 1.9-rc1 ident mod under 32-bit Cygwin

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -113,7 +113,7 @@ static void ident_oidentd()
   char s[INET_ADDRSTRLEN];
 #endif
   int ret, prevtime, servidx;
-  unsigned int size;
+  socklen_t namelen;
   struct sockaddr_storage ss;
 
   snprintf(identstr, sizeof identstr, "### eggdrop_%s", pid_file);
@@ -169,8 +169,8 @@ static void ident_oidentd()
             "for reading");
   }
   servidx = findanyidx(serv);
-  size = sizeof ss;
-  ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &size);
+  namelen = sizeof ss;
+  ret = getsockname(dcc[servidx].sock, (struct sockaddr *) &ss, &namelen);
   if (ret) {
     putlog(LOG_DEBUG, "*", "IDENT: Error getting socket info for writing");
   }

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -710,7 +710,7 @@ static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
 #else
   char s[INET_ADDRSTRLEN];
 #endif
-  unsigned int size;
+  socklen_t namelen;
   struct sockaddr_storage ss;
   Tcl_Obj *masterlist;
  
@@ -744,8 +744,8 @@ static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
       /* If this came from socklist... */
       } else {
         /* Update dcc table socket information, needed for getting local IP */
-        size = sizeof ss;
-        getsockname(dcc[i].sock, (struct sockaddr *) &ss, &size);
+        namelen = sizeof ss;
+        getsockname(dcc[i].sock, (struct sockaddr *) &ss, &namelen);
         if (ss.ss_family == AF_INET) {
           struct sockaddr_in *saddr = (struct sockaddr_in *)&ss;
           inet_ntop(AF_INET, &(saddr->sin_addr), s, INET_ADDRSTRLEN);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix type

Additional description (if needed):
This fixes a type of a variable and thereby an ugly compiler warning under 32-bit Cygwin 2.11.1 Windows 7 gcc 7.3.0.

Test cases demonstrating functionality (if applicable):
