### PR TITLE
Fix strcpy

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -368,8 +368,7 @@ void *n_malloc(int size, const char *file, int line)
   memtbl[i].line = line;
   memtbl[i].size = size;
   p = strrchr(file, '/');
-  strncpy(memtbl[i].file, p ? p + 1 : file, 19);
-  memtbl[i].file[19] = 0;
+  strlcpy(memtbl[i].file, p ? p + 1 : file, sizeof memtbl[i].file);
   memused += size;
   lastused++;
 #endif
@@ -405,8 +404,7 @@ void *n_realloc(void *ptr, int size, const char *file, int line)
   memtbl[i].line = line;
   memtbl[i].size = size;
   p = strrchr(file, '/');
-  strncpy(memtbl[i].file, p ? p + 1 : file, 19);
-  memtbl[i].file[19] = 0;
+  strlcpy(memtbl[i].file, p ? p + 1 : file, sizeof memtbl[i].file);
   memused += size;
 #endif
   return x;

--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -149,7 +149,7 @@ static void ident_oidentd()
           } else {
             /* If it is Eggdrop but not me, check for expiration and remove */
             if (!strstr(line, identstr)) {
-              strncpy(buf, line, sizeof buf);
+              strlcpy(buf, line, sizeof buf);
               strtok(buf, "!");
               prevtime = atoi(strtok(NULL, "!"));
               if ((now - prevtime) > 300) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
The strncpy() in ident.mod looked unsafe. Could be problem with missing null terminator. Additionally this PR does a strncpy -> strlcpy cleanup in mem.c.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
