### PR TITLE
Fix dns freeze in dns.mod

### DIFF
--- a/src/mod/dns.mod/coredns.c
+++ b/src/mod/dns.mod/coredns.c
@@ -1231,7 +1231,7 @@ static int dns_hosts(char *hostn) {
   for (i = 0; i < hostn_len; i++) {
       /* while at it, reject hostnames with bogus chars, see rfc 952, 1123 and 2181 */
       if (!strchr("-.0123456789ABCDEFGHIJABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz", hostn[i])) {
-        ddebug0(RES_MSG "bogus char in hostname input");
+        ddebug2(RES_MSG "bogus char in hostname input: 0x%02x at %i", hostn[i], i + 1);
         return 1;
       }
       hostn_lower[i] = tolower((unsigned char) hostn[i]);
@@ -1333,7 +1333,7 @@ static void dns_forward(char *hostn)
     return;
   }
   if (dns_hosts(hostn))
-    return;
+    ddebug0(RES_MSG "Couldnt lookup /etc/hosts");
   ddebug0(RES_MSG "Creating new record");
   rp = allocresolve();
   rp->state = STATE_AREQ;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix dns freeze in dns.mod for failures during /etc/hosts lookup

Additional description (if needed):
We cant simply return from dns_forward(). This bug was introduced with commit d1b9c828187a41632210ce1d8f739c3a86b1465f and effects eggdrop version **1.9.0-RC1**.

Test cases demonstrating functionality (if applicable):
Before:
```
.jump 127.0.0.1:6667
[13:02:17] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1:6667
[13:02:17] #-HQ# jump 127.0.0.1:6667 6667 
Jumping servers......
[13:02:18] Trying server 127.0.0.1:6667:6667
[13:02:18] DNS Resolver: bogus char in hostname input
.jump 127.0.0.1     
[13:02:22] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1
[13:02:22] #-HQ# jump 127.0.0.1 6667 
Jumping servers......
.server
[13:02:27] tcl: builtin dcc call: *dcc:servers -HQ 1 
[13:02:27] #-HQ# servers
Server list:
  127.0.0.1:+6697
  127.0.0.1:6667:6667 <- I am here
End of server list.
```
After:
```
.jump 127.0.0.1:6667
[13:02:59] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1:6667
[13:02:59] #-HQ# jump 127.0.0.1:6667 6667 
Jumping servers......
[13:02:59] Trying server 127.0.0.1:6667:6667
[13:02:59] DNS Resolver: bogus char in hostname input: 0x3a at 10
[13:02:59] DNS Resolver: Couldnt lookup /etc/hosts
[13:02:59] DNS Resolver: Creating new record
[13:02:59] DNS Resolver: Sent domain lookup request for "127.0.0.1:6667".
[13:02:59] DNS Resolver: Domain does not exist.
[13:02:59] DNS Resolver: Lookup failed.
[13:02:59] DNS resolve failed for 127.0.0.1:6667
[13:02:59] Failed connect to 127.0.0.1:6667 (DNS lookup failed)
.jump 127.0.0.1     
[13:03:02] tcl: builtin dcc call: *dcc:jump -HQ 1 127.0.0.1
[13:03:02] #-HQ# jump 127.0.0.1 6667 
Jumping servers......
[13:03:02] Trying server 127.0.0.1:6667
[13:03:02] net: open_telnet_raw(): idx 5 host 127.0.0.1 ip 127.0.0.1 port 6667 ssl 0
[13:03:02] net: connect! sock 12
[13:03:02] Connected to 127.0.0.1
[13:03:02] triggering bind evnt:init_server
[13:03:02] triggered bind evnt:init_server, user 0.079ms sys 0.002ms
[13:03:02] -NOTICE- Server is currently in split-mode.
.servers
[13:03:05] tcl: builtin dcc call: *dcc:servers -HQ 1 
[13:03:05] #-HQ# servers
Server list:
  127.0.0.1:+6697
  127.0.0.1:6667:6667
  127.0.0.1:6667 (zen.localdomain) <- I am here
End of server list.
```