### PR TITLE
Remove useless sleep(3)

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1953,10 +1953,8 @@ static void server_postrehash()
 static void server_die()
 {
   cycle_time = 100;
-  if (server_online) {
+  if (server_online)
     dprintf(-serv, "QUIT :%s\n", quit_msg[0] ? quit_msg : "");
-    sleep(3);                   /* Give the server time to understand */
-  }
   nuke_server(NULL);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
`.die` did a useless sleep for 3 secs.

Additional description (if needed):
The `sleep(3)` was between `write(socket, QUIT)` and `close(socket)`, the socket is gracefully cleaned up by `nuke_server()` and `killsock()`:
https://github.com/eggheads/eggdrop/blob/155f7a3c352f80f93db12bd78db7a9960863ae08/src/mod/server.mod/server.c#L1956-L1960
https://github.com/eggheads/eggdrop/blob/155f7a3c352f80f93db12bd78db7a9960863ae08/src/mod/server.mod/servmsg.c#L437-L453
https://github.com/eggheads/eggdrop/blob/155f7a3c352f80f93db12bd78db7a9960863ae08/src/mod/server.mod/servmsg.c#L1058-L1072
https://github.com/eggheads/eggdrop/blob/155f7a3c352f80f93db12bd78db7a9960863ae08/src/net.c#L413

Test cases demonstrating functionality (if applicable):
```
$ ./eggdrop -t BotA.conf
.jump irc.undernet.org
[20:33:21] tcl: builtin dcc call: *dcc:jump -HQ 1 irc.undernet.org
[20:33:21] #-HQ# jump irc.undernet.org 6667 
Jumping servers......
[20:33:22] Trying server irc.undernet.org:6667
[20:33:22] DNS Resolver: Creating new record
[20:33:22] DNS Resolver: Sent domain lookup request for "irc.undernet.org".
[20:33:22] DNS Resolver: Received nameserver reply. (qd:1 an:13 ns:0 ar:0)
[20:33:22] DNS Resolver: answered domain query: "irc.undernet.org"
[20:33:22] DNS Resolver: TTL: 28s
[20:33:22] DNS Resolver: TYPE: A: host address
[20:33:22] DNS Resolver: Lookup successful: irc.undernet.org
[20:33:22] DNS resolved irc.undernet.org to 27.131.104.74
[20:33:22] net: open_telnet_raw(): idx 4 host irc.undernet.org ip 27.131.104.74 port 6667 ssl 0
[20:33:23] net: connect! sock 10
[20:33:23] Connected to irc.undernet.org
[20:33:23] -NOTICE- *** Looking up your hostname
[20:33:23] -NOTICE- *** Checking Ident
[20:33:23] -NOTICE- *** No ident response
[20:33:24] -NOTICE- *** Found your hostname
[20:33:26] triggering bind evnt:init_server
[20:33:26] triggered bind evnt:init_server, user 0.048ms sys 0.016ms
[20:33:26] -NOTICE- on 1 ca 1(4) ft 10(10)
[20:33:39] BotA joined #test6888.
[20:33:50] DNS Resolver: Cache record for "irc.undernet.org" (27.131.104.74) has expired. (state: 0) Marked for expire at: 1611776030.
.die sleeptest
[20:34:15] tcl: builtin dcc call: *dcc:die -HQ 1 sleeptest
[20:34:15] #-HQ# die sleeptest
*** BOT SHUTDOWN (-HQ: sleeptest)
[20:34:15] Writing user file...
[20:34:15] Writing channel file...
[20:34:15] * DIE BY -HQ!llama@console (sleeptest)
```

```
$ irc testuser irc.undernet.org
[...]
*** testuser (~michael@p5dcb2a87.dip0.t-ipconnect.de) has joined channel #test6888
*** #test6888 1611776019
#test6888  testuser  H   ~michael@p5dcb2a87.dip0.t-ipconnect.de (*Unknown*)
#test6888  BotA      H@  ~BotA@p5dcb2a87.dip0.t-ipconnect.de (/msg BotA hello)
*** Signoff: BotA (Quit: sleeptest)
```

As you can see the quit msg is displayed with `sleep(3)` removed.