### PR TITLE
Change add/delserver to server add/remove

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -180,20 +180,16 @@ tagmsg <tags> <target>
 
   Module: server
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-addserver <ip/host> [[+]port [password]]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Description: adds a server to the list of servers Eggdrop will connect to. Prefix the port with '+' to indicate an SSL-protected port. A port value is required if password is to be specified. 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+server <command> <ip/host> [[+]port [password]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Description: adds or removes a server to the list of servers Eggdrop will connect to. Valid commands are "add" and "remove". Prefix the port with '+' to indicate an SSL-protected port. A port value is required if password is to be specified. The remove command Eggdrop will remove only the first server matching the ip or hostname provided. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000). The remove command will ignore a password if one is provided.
 
   Returns: nothing
 
   Module: server
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-delserver <ip/host> [[+]port]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Description: removes a server from the list of servers Eggdrop will connect to. If no port is specified, Eggdrop will remove the first server matching the ip or hostname provided. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
 
 User Record Manipulation Commands
 ---------------------------------

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -194,7 +194,7 @@ server add <ip/host> [[+]port [password]]
 server del <ip/host> [[+] port]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: Removes a server from the list of servers Eggdrop will connect to. If no port is provided, all servers matching the ip or hostname provided will be removed, otherwise only the ip/host with the corresponding port will be removed. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
+  Description: removes a server from the list of servers Eggdrop will connect to. If no port is provided, all servers matching the ip or hostname provided will be removed, otherwise only the ip/host with the corresponding port will be removed. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -194,7 +194,7 @@ server add <ip/host> [[+]port [password]]
 server del <ip/host> [[+] port]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: Removes a server from the list of servers Eggdrop will connect to. The remove command will remove only the first server matching the ip or hostname provided. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
+  Description: Removes a server from the list of servers Eggdrop will connect to. If no port is provided, all servers matching the ip or hostname provided will be removed, otherwise only the ip/host with the corresponding port will be removed. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -180,11 +180,21 @@ tagmsg <tags> <target>
 
   Module: server
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-server <command> <ip/host> [[+]port [password]]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+server add <ip/host> [[+]port [password]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: adds or removes a server to the list of servers Eggdrop will connect to. Valid commands are "add" and "remove". Prefix the port with '+' to indicate an SSL-protected port. A port value is required if password is to be specified. The remove command Eggdrop will remove only the first server matching the ip or hostname provided. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000). The remove command will ignore a password if one is provided.
+  Description: adds a server to the list of servers Eggdrop will connect to. Prefix the port with '+' to indicate an SSL-protected port. A port value is required if password is to be specified. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
+
+  Returns: nothing
+
+  Module: server
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+server del <ip/host> [[+] port]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Description: Removes a server from the list of servers Eggdrop will connect to. The remove command will remove only the first server matching the ip or hostname provided. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -191,7 +191,7 @@ server add <ip/host> [[+]port [password]]
   Module: server
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-server del <ip/host> [[+] port]
+server del <ip/host> [[+]port]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   Description: removes a server from the list of servers Eggdrop will connect to. If no port is provided, all servers matching the ip or hostname provided will be removed, otherwise only the ip/host with the corresponding port will be removed. The SSL status (+) of the provided port is matched against as well (ie, 7000 is not the same as +7000).

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -82,9 +82,9 @@ set network "I.didn't.edit.my.config.file.net"
 # servers to YOUR network's servers.
 #
 # The format is:
-#   addserver <server> [port [password]]
+#   server add <server> [port [password]]
 # Prefix the port with a plus sign to attempt a SSL connection:
-#   addserver <server> +port [password]
+#   server add <server> +port [password]
 #
 # Both the port and password fields are optional. If a port isn't specified,
 # the default-port setting will be used. If you want to set a password or use
@@ -93,10 +93,10 @@ set network "I.didn't.edit.my.config.file.net"
 # This format is new as of version 1.9.0. The previous method using
 # set servers {} will still work for now, but is deprecated and will be removed
 # in a future release.
-addserver you.need.to.change.this 6667
-addserver another.example.com 6669 password
-addserver 2001:db8:618:5c0:263:: 6669 password
-addserver ssl.example.net +7000
+server add you.need.to.change.this 6667
+server add another.example.com 6669 password
+server add 2001:db8:618:5c0:263:: 6669 password
+server add ssl.example.net +7000
 
 ###########################################################################
 ## Network settings overview

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1105,9 +1105,9 @@ set default-port 6667
 # servers to YOUR network's servers.
 #
 # The format is:
-#   addserver <server> [port [password]]
+#   server add <server> [port [password]]
 # Prefix the port with a plus sign to attempt a SSL connection:
-#   addserver <server> +port [password]
+#   server add <server> +port [password]
 #
 # Both the port and password fields are optional. If a port isn't specified,
 # the default-port setting will be used. If you want to set a password or use
@@ -1116,10 +1116,10 @@ set default-port 6667
 # This format is new as of version 1.9.0. The previous method using
 # set servers {} will still work for now, but is deprecated and will be removed
 # in a future release.
-addserver you.need.to.change.this 6667
-addserver another.example.com 6669 password
-addserver 2001:db8:618:5c0:263:: 6669 password
-addserver ssl.example.net +7000
+server add you.need.to.change.this 6667
+server add another.example.com 6669 password
+server add 2001:db8:618:5c0:263:: 6669 password
+server add ssl.example.net +7000
 
 #### CAP Features ####
 # This section controls IRCv3 capabilities supported natively by Eggdrop. You

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1064,6 +1064,7 @@ static int del_server(const char *name, const char *port)
 {
   struct server_list *z, *curr, *prev;
   char *ret;
+  int found = 0;
 
   if (!serverlist) {
     return 2;
@@ -1073,7 +1074,6 @@ static int del_server(const char *name, const char *port)
       return 1;
     }
   }
-  ret = 0;
 /* Check if server to be deleted is first node in list */
   if (!strcasecmp(name, serverlist->name)) {
     z = serverlist;
@@ -1091,15 +1091,14 @@ static int del_server(const char *name, const char *port)
       serverlist = serverlist->next;
       free_server(z);
     }
-      ret = 1;
-//    return 0;
+    found = 1;
   }
   curr = serverlist->next;
   prev = serverlist;
 /* Check the remaining nodes in list */
   while (curr != NULL && prev != NULL) {
     if (!strcasecmp(name, curr->name)) {
-      if (strlen(port)) {
+      if (port[0] != '\0') {
         if ((atoi(port) != curr->port)
 #ifdef TLS
             || ((port[0] != '+') && curr->ssl )) {
@@ -1113,15 +1112,15 @@ static int del_server(const char *name, const char *port)
       }
       z = curr;
       prev->next = curr->next;
+      curr = curr->next;
       free_server(z);
-        ret = 1;
-//      return 0;
+      found = 1;
+    } else {
+      prev = curr;
+      curr = curr->next;
     }
-    prev = curr;
-    curr = curr->next;
   }
-    ret ? return 0 : return 3;
-//  return 3;
+  return found ? 0 : 3; 
 }
 
 /* Free a single removed server from server link list */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1073,6 +1073,7 @@ static int del_server(const char *name, const char *port)
       return 1;
     }
   }
+  ret = 0;
 /* Check if server to be deleted is first node in list */
   if (!strcasecmp(name, serverlist->name)) {
     z = serverlist;
@@ -1090,7 +1091,8 @@ static int del_server(const char *name, const char *port)
       serverlist = serverlist->next;
       free_server(z);
     }
-    return 0;
+      ret = 1;
+//    return 0;
   }
   curr = serverlist->next;
   prev = serverlist;
@@ -1112,12 +1114,14 @@ static int del_server(const char *name, const char *port)
       z = curr;
       prev->next = curr->next;
       free_server(z);
-      return 0;
+        ret = 1;
+//      return 0;
     }
     prev = curr;
     curr = curr->next;
   }
-  return 3;
+    ret ? return 0 : return 3;
+//  return 3;
 }
 
 /* Free a single removed server from server link list */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1010,6 +1010,7 @@ static void old_add_server(const char *ss) {
 }
 
 /* Add a new server to the server_list.
+ * Don't return '3' from here, that is used by del_server() for tcl_server()
  */
 static int add_server(const char *name, const char *port, const char *pass)
 {

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -447,13 +447,13 @@ static int tcl_queuesize STDVAR
 static int tcl_server STDVAR {
   int ret;
 
-  BADARGS(2, 5, " command, host, port, ?password?");
+  BADARGS(2, 5, " subcommand, host port ?password?");
   if (!strcmp(argv[1], "add")) {
     ret = add_server(argv[2], argv[3] ? argv[3] : "", argv[4] ? argv[4] : "");
   } else if (!strcmp(argv[1], "remove")) {
     ret = del_server(argv[2], argv[3] ? argv[3] : "");
   } else {
-    Tcl_AppendResult(irp, "Invalid command: ", argv[1],
+    Tcl_AppendResult(irp, "Invalid subcommand: ", argv[1],
         ". Should be \"add\" or \"remove\"", NULL);
     return TCL_ERROR;
   }

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -444,55 +444,31 @@ static int tcl_queuesize STDVAR
   return TCL_ERROR;
 }
 
-static int tcl_addserver STDVAR {
-  char name[256] = "";
-  char port[7] = "";
-  char pass[121] = "";
-  char ret = 0;
+static int tcl_server STDVAR {
+  int ret;
 
-  BADARGS(2, 4, " server ?port? ?pass?");
-  strlcpy(name, argv[1], sizeof name);
-  if (argc >= 3) {
-      strlcpy(port, argv[2], sizeof port);
+  BADARGS(2, 5, " command, host, port, ?password?");
+  if (!strcmp(argv[1], "add")) {
+    ret = add_server(argv[2], argv[3] ? argv[3] : "", argv[4] ? argv[4] : "");
+  } else if (!strcmp(argv[1], "remove")) {
+    ret = del_server(argv[2], argv[3] ? argv[3] : "");
+  } else {
+    Tcl_AppendResult(irp, "Invalid command: ", argv[1],
+        ". Should be \"add\" or \"remove\"", NULL);
+    return TCL_ERROR;
   }
-  if (argc == 4) {
-    strlcpy(pass, argv[3], sizeof pass);
-  }
-  ret = add_server(name, port, pass);
   if (ret == 0) {
     return TCL_OK;
-  } else if (ret == 1) {
-    Tcl_AppendResult(irp, "A ':' was detected in the non-IPv6 address ", name,
-                " Make sure the port is separated by a space, not a ':'. "
-                "Skipping...", NULL);
+  }
+  if (ret == 1) {
+    Tcl_AppendResult(irp, "A ':' was detected in the non-IPv6 address ", argv[2],
+            " Make sure the port is separated by a space, not a ':'. ", NULL);
   } else if (ret == 2) {
     Tcl_AppendResult(irp, "Attempted to add SSL-enabled server, but Eggdrop "
-                "was not compiled with SSL libraries. Skipping...", NULL);
-  }
-  return TCL_ERROR;
-}
-
-static int tcl_delserver STDVAR {
-  char name[256] = "";
-  char port[7] = "";
-  char ret = 0;
-
-  BADARGS(2, 3, " server, ?port?");
-  strlcpy(name, argv[1], sizeof name);
-  if (argc == 3) {
-    strlcpy(port, argv[2], sizeof port);
-  }
-  ret = del_server(name, port);
-  if (!ret) {
-    return TCL_OK;
-  } else if (ret == 1) {
-    Tcl_AppendResult(irp, "A ':' was detected in the non-IPv6 address ", name,
-                " Make sure the port is separated by a space, not a ':'. "
-                "Skipping...", NULL);
-  } else if (ret == 2) {
-    Tcl_AppendResult(irp, "Server list is empty", NULL);
-  } else if (ret == 3) {
-    Tcl_AppendResult(irp, "Server ", name, strlen(port) ? ":" : "", strlen(port) ? port : ""," not found.", NULL);
+            "was not compiled with SSL libraries.", NULL);
+  } else if (ret == 3) {    /* del_server only */
+    Tcl_AppendResult(irp, "Server ", argv[2], argv[3] ? ":" : "",
+            argv[3] ? argv[3] : ""," not found.", NULL);
   }
   return TCL_ERROR;
 }
@@ -508,10 +484,8 @@ static tcl_cmds my_tcl_cmds[] = {
   {"putquick",      tcl_putquick},
   {"putnow",        tcl_putnow},
   {"tagmsg",        tcl_tagmsg},
-  {"addserver",     tcl_addserver},
-  {"delserver",     tcl_delserver},
+  {"server",        tcl_server},
   {"getaccount",    tcl_getaccount},
   {"isidentified",  tcl_isidentified},
   {NULL,         NULL}
 };
-

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -447,7 +447,7 @@ static int tcl_queuesize STDVAR
 static int tcl_server STDVAR {
   int ret;
 
-  BADARGS(2, 5, " subcommand, host port ?password?");
+  BADARGS(2, 5, " subcommand host ?port ?password??");
   if (!strcmp(argv[1], "add")) {
     ret = add_server(argv[2], argv[3] ? argv[3] : "", argv[4] ? argv[4] : "");
   } else if (!strcmp(argv[1], "remove")) {


### PR DESCRIPTION
Found by: Malagam
Patch by: Geo
Fixes: 

One-line summary:
Change add/delserver to server add/remove

Additional description (if needed):
As identified in #1110 , it probably makes more sense (and is extendable!) to swap from addserver/delserver to 'server add/remove' (this mirrors the channel add remove syntax as well). Many thanks to @MalaGaM for the tip


Test cases demonstrating functionality (if applicable):
```
.tcl server add foo.com
Tcl: 
.tcl server add foo.com 5555
Tcl: 
.tcl server add foo.com 6666 asdf
Tcl: 
.servers
Server list:
  chat.freenode.net:6667 (orwell.freenode.net) <- I am here
  foo.com:6667
  foo.com:5555
  foo.com:6666 (password
End of server list.
.tcl server remove foo.com
Tcl: 
.servers
Server list:
  chat.freenode.net:6667 (orwell.freenode.net) <- I am here
  foo.com:5555
  foo.com:6666 (password
End of server list.

.tcl server remove foo.com 6666
Tcl: 
.servers
Server list:
  chat.freenode.net:6667 (orwell.freenode.net) <- I am here
  foo.com:5555
End of server list.

.tcl server remove foo.com 5555
Tcl: 
.servers
Server list:
  chat.freenode.net:6667 (orwell.freenode.net) <- I am here
End of server list.

.tcl server add foo.com:5555
Tcl error: A ':' was detected in the non-IPv6 address foo.com:5555 Make sure the port is separated by a space, not a ':'. 

.tcl server remove notaserver.com
Tcl error: Server notaserver.com not found.