### PR TITLE
Fix crash - Add an AlertNotifier callback function

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -588,6 +588,13 @@ ClientData tickle_InitNotifier()
   return NULL;
 }
 
+void tickle_AlertNotifier(ClientData cd)
+{
+  if (cd)
+    putlog(LOG_MISC, "*", "stub tickle_AlertNotifier");
+  return;
+}
+
 int tclthreadmainloop(int zero)
 {
   int i;
@@ -654,6 +661,7 @@ void init_tcl(int argc, char **argv)
   notifierprocs.setTimerProc = tickle_SetTimer;
   notifierprocs.waitForEventProc = tickle_WaitForEvent;
   notifierprocs.finalizeNotifierProc = tickle_FinalizeNotifier;
+  notifierprocs.alertNotifierProc = tickle_AlertNotifier;
 
   Tcl_SetNotifier(&notifierprocs);
 #endif /* REPLACE_NOTIFIER */

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -592,7 +592,6 @@ void tickle_AlertNotifier(ClientData cd)
 {
   if (cd)
     putlog(LOG_MISC, "*", "stub tickle_AlertNotifier");
-  return;
 }
 
 int tclthreadmainloop(int zero)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #515 and #1031

One-line summary:
Add an AlertNotifier callback function.

Additional description (if needed):
The line `putlog(LOG_MISC, "*", "stub tickle_AlertNotifier");` shouldn't be triggered. Test case is `cd == NULL`. The `putlog` is to show, if we have more work to do, if we have to replace that putlog stub. We could then borrow from https://github.com/tcltk/tcl/blob/645d300beada575f29f390a13f578f469a61b4fa/unix/tclUnixNotfy.c#L102. It's not that complicated. A simple `tsdPtr->eventReady = 1;` and some boilerplate would probably do. Having said that, the fix works for #515 and #1031 and if no problem / side effect is found, i propose we merge it in.

Test cases demonstrating functionality (if applicable):
**1. Test for #515:**
Before:
```
.tcl package require Thread
[20:07:46] tcl: builtin dcc call: *dcc:tcl -HQ 1 package require Thread
[20:07:46] tcl: evaluate (.tcl): package require Thread
Tcl: 2.8.6
.tcl thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:07:52] tcl: builtin dcc call: *dcc:tcl -HQ 1 thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:07:52] tcl: evaluate (.tcl): thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:07:52] * Last context: tclhash.c/734 [Tcl proc: *dcc:tcl, param:  $_dcc1 $_dcc2 $_dcc3]
[20:07:52] * Please REPORT this BUG!
[20:07:52] * Check doc/BUG-REPORT on how to do so.
[20:07:52] * Wrote DEBUG
[20:07:52] * SEGMENT VIOLATION -- CRASHING!
Segmentation fault (core dumped)
```
After:
```
.tcl package require Thread
[20:05:37] tcl: builtin dcc call: *dcc:tcl -HQ 1 package require Thread
[20:05:37] tcl: evaluate (.tcl): package require Thread
Tcl: 2.8.6
.tcl thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:05:46] tcl: builtin dcc call: *dcc:tcl -HQ 1 thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:05:46] tcl: evaluate (.tcl): thread::send -async [set tid [thread::create]] { after 10000; puts test }
Tcl: 
[20:05:50] BotA joined #test6888.
test
.tcl thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:06:14] tcl: builtin dcc call: *dcc:tcl -HQ 1 thread::send -async [set tid [thread::create]] { after 10000; puts test }
[20:06:14] tcl: evaluate (.tcl): thread::send -async [set tid [thread::create]] { after 10000; puts test }
Tcl: 
test
```
**2. Test for  #1031:**
```
.status
[...]
I am BotA, running eggdrop v1.9.0: 11 users (mem: 270k).
[...]
Tcl version: 8.6.11 (header version 8.6.11)
Tcl is threaded.
[...]
.tcl package require Thread
Tcl: 2.8.6
.tcl package require Ttrace
Tcl: 2.8.6
.tcl set t1 [thread::create {package require Ttrace; thread::wait}]
Tcl: tid0x7f7337998640
.tcl ttrace::eval {proc test args {return test-[thread::id]}}
Tcl: 
.tcl thread::send $t1 test
Tcl: test-tid0x7f7337998640
.tcl set t2 [thread::create {package require Ttrace; thread::wait}]
Tcl: tid0x7f7337181640
.tcl thread::send $t2 test
Tcl: test-tid0x7f7337181640
```