### PR TITLE
Add tcl script to sort .bots

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1744,3 +1744,7 @@ if {[info exists net-type]} {
     }
   }
 }
+
+# This script enhances Eggdrop's built-in dcc '.bots' command to output a sorted
+# list.
+source scripts/sortedbots.tcl

--- a/scripts/sortedbots.tcl
+++ b/scripts/sortedbots.tcl
@@ -1,0 +1,8 @@
+unbind dcc - bots *dcc:bots
+bind dcc - bots sortedbots
+
+proc sortedbots {hand idx param} {
+  putidx $idx [join [lsort [split [*dcc:bots $hand $idx $param]]]]
+}
+
+putlog "TCL loaded: sortedbots"


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #743

One-line summary:
Add tcl script to sort .bots

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
