### PR TITLE
Fix openssl/version/function detection/collide

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1658,6 +1658,10 @@ AC_DEFUN([EGG_TLS_DETECT],
     if test -z "$SSL_LIBS"; then
       AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-lssl])
       AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
+      AC_CHECK_FUNCS([a2i_IPADDRESS], , [[
+        havessllib="no"
+        break
+      ]])
     fi
     AC_CHECK_FUNC(OPENSSL_buf2hexstr, ,
       AC_CHECK_FUNC(hex_to_string,

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -69,6 +69,7 @@ static void refresh_who_chan(char *);
 
 void reset_chan_info(struct chanset_t *, int, int);
 static void recheck_channel(struct chanset_t *, int);
+#undef set_key /* because it could collide with openssl */
 static void set_key(struct chanset_t *, char *);
 static void maybe_revenge(struct chanset_t *, char *, char *, int);
 static int detect_chan_flood(char *, char *, char *, struct chanset_t *, int,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix openssl/version/function detection/collide

Additional description (if needed):
**1. Since 5012919e7437903d2dc489b7b5824d664bc1d0f3 configure could pick up an old openssl version:**
```
$ ./configure
[...]
SSL/TLS Support: yes (OpenSSL 0.9.7e-p1 25 Oct 2004)
```
In this case eggdrops `set_key()` could collide with openssl.

This PR fixes such collide.

The old openssl version is picked up because this commit did `misc/runautotools`

**2. #1047 changed `aclocal.m4`**

#1047 was based on 2 facts. 1. eggdrop depends on openssl 0.9.8+ 2. the function checks removed with #1047 are functions that are available since 0.9.8. But #1047 did a mistake, it didnt take into account, that thhe denial of old openssl verisons was based on this function check (instead of proper OPENSSLVERSION check).

This PR fixes this, by unmerging the important function check that was removed with #1047.

Test cases demonstrating functionality (if applicable):
Before:
```
./configure
[...]
SSL/TLS Support: yes (OpenSSL 0.9.7e-p1 25 Oct 2004)
[...]
gcc -std=gnu99 -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.4 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././irc.mod/irc.c && mv -f irc.o ../
In file included from .././irc.mod/irc.c:28:
.././irc.mod/irc.h:72: error: syntax error before '(' token
In file included from .././irc.mod/irc.c:67:
.././irc.mod/chan.c: In function `got324':
.././irc.mod/chan.c:1000: warning: passing arg 1 of `DES_set_key' from incompatible pointer type
.././irc.mod/chan.c:1000: warning: passing arg 2 of `DES_set_key' from incompatible pointer type
.././irc.mod/chan.c:1003: warning: passing arg 1 of `DES_set_key' from incompatible pointer type
.././irc.mod/chan.c:1003: warning: passing arg 2 of `DES_set_key' from incompatible pointer type
In file included from .././irc.mod/irc.c:68:
.././irc.mod/mode.c: In function `gotmode':
.././irc.mod/mode.c:1210: warning: passing arg 1 of `DES_set_key' from incompatible pointer type
.././irc.mod/mode.c:1210: warning: passing arg 2 of `DES_set_key' from incompatible pointer type
.././irc.mod/mode.c:1221: error: invalid lvalue in unary `&'
.././irc.mod/mode.c:1221: warning: passing arg 1 of `DES_set_key' from incompatible pointer type
.././irc.mod/irc.c: At top level:
.././irc.mod/irc.c:252: error: syntax error before '(' token
.././irc.mod/irc.c:34: warning: 'H_part' defined but not used
.././irc.mod/irc.c:34: warning: 'H_pub' defined but not used
.././irc.mod/irc.c:34: warning: 'H_pubm' defined but not used
.././irc.mod/irc.c:35: warning: 'H_mode' defined but not used
.././irc.mod/irc.c:35: warning: 'H_kick' defined but not used
.././irc.mod/irc.c:35: warning: 'H_need' defined but not used
.././irc.mod/irc.c:35: warning: 'H_invt' defined but not used
.././irc.mod/irc.c:35: warning: 'H_ircaway' defined but not used
.././irc.mod/irc.c:40: warning: 'wait_split' defined but not used
.././irc.mod/irc.c:60: warning: 'twitch' defined but not used
.././irc.mod/irc.c:62: warning: 'rfc_compliant' defined but not used
.././irc.mod/chan.c:638: warning: 'check_this_ban' defined but not used
.././irc.mod/chan.c:2679: warning: 'irc_raw' defined but not used
.././irc.mod/chan.c:2713: warning: 'irc_isupport_binds' defined but not used
.././irc.mod/chan.c:2718: warning: 'irc_rawt' defined but not used
.././irc.mod/mode.c:201: warning: 'real_add_mode' defined but not used
.././irc.mod/cmdsirc.c:1174: warning: 'irc_dcc' defined but not used
.././irc.mod/msgcmds.c:1118: warning: 'C_msg' defined but not used
.././irc.mod/tclirc.c:1159: warning: 'tclchan_cmds' defined but not used
*** Error code 1

Stop in /usr/home/michael/usr/src/eggdrop/src/mod/irc.mod.
*** Error code 1

Stop in /usr/home/michael/usr/src/eggdrop/src/mod.
*** Error code 1

Stop in /usr/home/michael/usr/src/eggdrop.
```
After:
```
./configure
[...]
SSL/TLS Support: no
[...]
```