### PR TITLE
Revert "Remove unnecessary openssl function checks"

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1658,6 +1658,10 @@ AC_DEFUN([EGG_TLS_DETECT],
     if test -z "$SSL_LIBS"; then
       AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-lssl])
       AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
+      AC_CHECK_FUNCS([EVP_md5 EVP_sha1 a2i_IPADDRESS], , [[
+        havessllib="no"
+        break
+      ]])
     fi
     AC_CHECK_FUNC(OPENSSL_buf2hexstr, ,
       AC_CHECK_FUNC(hex_to_string,


### PR DESCRIPTION
Reverts eggheads/eggdrop#1047

#1047 was based on 2 facts. 1. eggdrop depends on openssl 0.9.8+ 2. the function checks removed with #1047 are functions that are available since 0.9.8. But #1047 did a mistake, it didnt take into account, that the denial of old openssl verisons was based on this function check (instead of proper OPENSSLVERSION check).

From mortmann: when we stopped checking fgor functions EVP_md5 EVP_sha1 a2i_IPADDRESS havessllib="no" is not executed.  that was a heuristic to determine old openssl versions.