### PR TITLE
1.9.0rc2: Fix socklist for ./configure --disable-tls

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -674,7 +674,7 @@ static void build_sock_list(Tcl_Interp *irp, Tcl_Obj *masterlist, char *idxstr,
   Tcl_Obj *thelist;
   char securestr[2], portstr[6];
 
-  egg_snprintf(securestr, sizeof securestr, "%d", secure);
+  snprintf(securestr, sizeof securestr, "%d", secure);
   egg_snprintf(portstr, sizeof portstr, "%d", port);
   thelist = Tcl_NewListObj(0, NULL);
   Tcl_ListObjAppendElement(irp, thelist, Tcl_NewStringObj(val[0], -1));
@@ -761,7 +761,7 @@ static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
 #ifdef TLS
             dcc[i].ssl,
 #else
-            '0',
+            0,
 #endif
             dcc[i].type ? dcc[i].type->name : "*UNKNOWN*", other,
             timestamp);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
If configured with `--disable-tls` `tcldcc.c:build_sock_list()` was feeded with secure = `'0'` instead of `0` leading to output of `secure 4` instead of `secure 0`.

Additional description (if needed):
The `4` is due to `'0'` -> ascii -> `48` -> truncation -> `4`.

Test cases demonstrating functionality (if applicable):
Before:
```
$ ./configure --disable-tls
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tcldcc.c
tcldcc.c: In function ‘dccsocklist’:
tcldcc.c:677:48: warning: ‘snprintf’ output truncated before the last format character [-Wformat-truncation=]
  677 |   egg_snprintf(securestr, sizeof securestr, "%d", secure);
      |                                                ^
In file included from compat/compat.h:28,
                 from main.h:102,
                 from tcldcc.c:24:
compat/snprintf.h:58:24: note: ‘snprintf’ output 3 bytes into a destination of size 2
   58 | #  define egg_snprintf snprintf
tcldcc.c:677:3: note: in expansion of macro ‘egg_snprintf’
  677 |   egg_snprintf(securestr, sizeof securestr, "%d", secure);
      |
[...]
$ ./eggdrop -t BotA.conf
.tcl socklist
Tcl: {idx 5 handle (dns) host 192.168.1.4 ip 0.0.0.0 port 0 secure 4 type DNS info {dns   (ready)} time 1613371516} {idx 7 handle (telnet) host * ip 0.0.0.0 port 3333 secure 4 type TELNET info {lstn  3333} time 1613371516} {idx 1 handle -HQ host llama@console ip 0.0.0.0 port 0 secure 4 type CHAT info {chat  flags: cptEp/0} time 1613371516}
```
After:
```
.tcl socklist
Tcl: {idx 5 handle (dns) host 192.168.1.4 ip 0.0.0.0 port 0 secure 0 type DNS info {dns   (ready)} time 1613371691} {idx 7 handle (telnet) host * ip 0.0.0.0 port 3333 secure 0 type TELNET info {lstn  3333} time 1613371691} {idx 1 handle -HQ host llama@console ip 0.0.0.0 port 0 secure 0 type CHAT info {chat  flags: cptEp/0} time 1613371692}
```