### PR TITLE
Reject invalid chars in +bot

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -806,7 +806,7 @@ int check_int_range(char *value, int min, int max) {
 
 static void cmd_pls_bot(struct userrec *u, int idx, char *par)
 {
-  char *handle, *addr, *port, *port2, *relay, *host;
+  char *handle, *addr, *port, *port2, *relay, *host, *p;
   struct userrec *u1;
   struct bot_addr *bi;
   int i, found = 0;
@@ -842,6 +842,13 @@ static void cmd_pls_bot(struct userrec *u, int idx, char *par)
     dprintf(idx, "You can't start a botnick with '%c'.\n", handle[0]);
     return;
   }
+
+/* Check for bad characters throughout the handle */
+  for (p = handle; *p; p++)
+    if ((unsigned char) *p <= 32 || *p == '@') {
+      dprintf(idx, "Invalid character '%c' in handle, try again\n", p[0]);
+      return;
+    }
 
   if (addr[0]) {
 #ifndef IPV6

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -311,8 +311,10 @@ static int tcl_addbot STDVAR
   strlcpy(addr, argv[2], sizeof addr);
 
   for (p = hand; *p; p++)
-    if ((unsigned char) *p <= 32 || *p == '@')
-      *p = '?';
+    if ((unsigned char) *p <= 32 || *p == '@') {
+      Tcl_AppendResult(irp, "Invalid character in handle", NULL);
+      return TCL_ERROR;
+    }
 
   if ((argv[1][0] == '*') || strchr(BADHANDCHARS, argv[1][0]) ||
       get_user_by_handle(userlist, hand))


### PR DESCRIPTION
Found by: MalaGaM
Patch by: Geo
Fixes: #1126 

Adds a check for invalid ascii characters to +bot; changes the discovery of invalid ascii character in tcl_addbot from silently converting to a '?' to instead returning a TCL_ERROR

Do we count this as an API change? I lean towards it being a bug more than an API change which is why I wrote it this way; please leave comments below if you agree or disagree and we can edit this as we see fit. But importantly, I think the +bot and addbot need to match