### PR TITLE
Fix splitnicks()

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -421,7 +421,7 @@ static char *splitnicks(char **rest)
   char *o, *r;
 
   if (!rest)
-    return *rest = "";
+    return "";
   o = *rest;
   while (*o == ' ')
     o++;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann and thommey
Fixes: #1119

One-line summary:
Fix splitnicks() analogue to misc.c:newsplit()

Additional description (if needed):
See also: https://github.com/eggheads/eggdrop/commit/5d815ee87d2b6fb13f69f11c5afd2b3062b120d8#diff-9df9e2c313e694cf242534e90c1187fe119fac8de7c304ae438de0736209953bR279

Test cases demonstrating functionality (if applicable):
with `gcc-11-20210214 -fanalyzer`
Before:
```
/home/michael/opt/gcc-11-20210214/bin/gcc -fanalyzer -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
.././server.mod/server.c: In function ‘splitnicks’:
.././server.mod/server.c:424:18: warning: dereference of NULL ‘0’ [CWE-476] [-Wanalyzer-null-dereference]
  424 |     return *rest = "";
      |            ~~~~~~^~~~
  ‘splitnicks’: events 1-3
    |
    |  423 |   if (!rest)
    |      |      ^
    |      |      |
    |      |      (1) following ‘true’ branch (when ‘rest’ is NULL)...
    |  424 |     return *rest = "";
    |      |     ~~~~~~ ~~~~~~~~~~
    |      |     |            |
    |      |     |            (3) dereference of NULL ‘0’
    |      |     (2) ...to here
    |
```
After:
`/home/michael/opt/gcc-11-20210214/bin/gcc -fanalyzer -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../`