### PR TITLE
Break the silence of rejected botattrs

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2136,8 +2136,14 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
       mns.chan = 0;
     }
     if (!glob_owner(user)) {
-      pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
-      mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
+      if (pls.bot & (BOT_SHARE | BOT_GLOBAL)) {
+        pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
+        dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
+      }
+      if (mns.bot & (BOT_SHARE | BOT_GLOBAL)) {
+        mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
+        dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
+      }
     }
     user.match = FR_BOT | (chan ? FR_CHAN : 0);
     get_user_flagrec(u2, &user, par);

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2135,12 +2135,10 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
       pls.chan = 0;
       mns.chan = 0;
     }
-    if (!glob_owner(user)) {
-      if ((pls.bot | mns.bot) & (BOT_SHARE | BOT_GLOBAL)) {
-        pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
-        mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
-        dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
-      }
+    if (!glob_owner(user) && ((pls.bot | mns.bot) & (BOT_SHARE | BOT_GLOBAL))) {
+      pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
+      mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
+      dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
     }
     user.match = FR_BOT | (chan ? FR_CHAN : 0);
     get_user_flagrec(u2, &user, par);

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2136,11 +2136,8 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
       mns.chan = 0;
     }
     if (!glob_owner(user)) {
-      if (pls.bot & (BOT_SHARE | BOT_GLOBAL)) {
+      if ((pls.bot & (BOT_SHARE | BOT_GLOBAL)) | (mns.bot & (BOT_SHARE | BOT_GLOBAL))) {
         pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
-        dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
-      }
-      if (mns.bot & (BOT_SHARE | BOT_GLOBAL)) {
         mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
         dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");
       }

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2136,7 +2136,7 @@ static void cmd_botattr(struct userrec *u, int idx, char *par)
       mns.chan = 0;
     }
     if (!glob_owner(user)) {
-      if ((pls.bot & (BOT_SHARE | BOT_GLOBAL)) | (mns.bot & (BOT_SHARE | BOT_GLOBAL))) {
+      if ((pls.bot | mns.bot) & (BOT_SHARE | BOT_GLOBAL)) {
         pls.bot &= ~(BOT_SHARE | BOT_GLOBAL);
         mns.bot &= ~(BOT_SHARE | BOT_GLOBAL);
         dprintf(idx, "You do not have Global Owner privileges, so you cant change share attributes\n");


### PR DESCRIPTION
Found by: Geo?
Patch by: michaelortmann
Fixes: 

One-line summary:
Break the silence of rejected botattrs

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.botattr testbot +p
[20:04:51] #-HQ# botattr testbot +p
Bot flags for testbot are now +p.
.botattr testbot -p
[20:04:55] #-HQ# botattr testbot -p
There are no bot flags for testbot.
.whois testuser2
[20:04:57] #-HQ# whois testuser2
HANDLE                           PASS NOTES FLAGS           LAST
testuser2                        yes      0 hjlmoptx        19:54 (partyline)
.su testuser2
[...]
*** testuser2 joined the party line.
.botattr testbot +p
[20:05:04] tcl: builtin dcc call: *dcc:botattr testuser2 1 testbot +p
You do not have Global Owner privileges, so you cant change share attributes
[20:05:04] #testuser2# botattr testbot +p
There are no bot flags for testbot.
```