### PR TITLE
Fix eggdrop 1.9.0-rc2 make error under SunOS

### DIFF
--- a/src/compat/explicit_bzero.c
+++ b/src/compat/explicit_bzero.c
@@ -44,6 +44,7 @@
 */
 
 #include <stddef.h>
+#define __STDC_WANT_LIB_EXT1__ 1 /* SunOS */
 #include <string.h>
 #include "main.h"
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix eggdrop 1.9-rc2 make error under SunOS

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
$ uname -a                                                                                                                                                                                                                       
SunOS fire 5.11 11.4.0.15.0 i86pc i386 i86pc
$ /opt/developerstudio12.6/bin/cc -V                                                                                                                                                                                             
cc: Studio 12.6 Sun C 5.15 SunOS_i386 2017/05/30
```
Before:
```
/opt/developerstudio12.6/bin/cc -g -I../.. -I../.. -I../../src  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c explicit_bzero.c
"explicit_bzero.c", line 71: warning: implicit function declaration: memset_s
"explicit_bzero.c", line 71: undefined symbol: rsize_t
"explicit_bzero.c", line 71: syntax error before or at: len
cc: acomp failed for explicit_bzero.c
gmake[2]: *** [Makefile:41: explicit_bzero.o] Error 2
gmake[2]: Leaving directory '/export/home/michael/usr/src/eggdrop/src/compat'
gmake[1]: *** [Makefile:71: compatibility] Error 2
gmake[1]: Leaving directory '/export/home/michael/usr/src/eggdrop/src'
gmake: *** [Makefile:251: debug] Error 2
```
After:
`/opt/developerstudio12.6/bin/cc -g -I../.. -I../.. -I../../src  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c explicit_bzero.c`