### PR TITLE
Fix false positive compiler warning under OpenBSD 6.8

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -712,7 +712,8 @@ static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
 #endif
   socklen_t namelen;
   struct sockaddr_storage ss;
-  Tcl_Obj *masterlist;
+  Tcl_Obj *masterlist = NULL; /* initialize to NULL to make old gcc versions
+                               * happy */
  
   if (src) {
     masterlist = Tcl_NewListObj(0, NULL);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix false positive compiler warning under OpenBSD 6.8

Additional description (if needed):
Its a problem with old gcc versions
But i wanted to have a current operating system in the PR title to show a problem of NOW not of the PAST.
OpenBSD 6.8 uses gcc 4.2.1 and is affected.
Fedora10 uses 4.3.2 and is affected.
Since it is a false positive, its fine to silence this warning by initializing to NULL.

Test cases demonstrating functionality (if applicable):
The following tests are under OpenBSD 6.8 with gcc 4.2.1
Before:
```
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tcldcc.c
tcldcc.c: In function 'dccsocklist':
tcldcc.c:715: warning: 'masterlist' may be used uninitialized in this function
```
After:
`gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tcldcc.c`