### PR TITLE
eggdrop 1.9.0rc3 - Make the compiler use 64bit ari

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1017,7 +1017,7 @@ static void init_random(void) {
 #endif
       struct timeval tp;
       gettimeofday(&tp, NULL);
-      seed = (tp.tv_sec * tp.tv_usec) ^ getpid();
+      seed = (((int64_t) tp.tv_sec * tp.tv_usec)) ^ getpid();
 #ifdef HAVE_GETRANDOM
     }
   }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
Effects eggdrop on 32 bit systems only.

Test cases demonstrating functionality (if applicable):
```
$ uname -a
Linux debian 3.16.0-11-586 #1 Debian 3.16.84-1 (2020-06-09) i686 GNU/Linux
```
**this is a 32bit system**
`$ CFLAGS="-fsanitize=undefined" ./configure`
Before:
```
Test run of ./eggdrop -v:
./main.c:1020:25: runtime error: signed integer overflow: 1614822626 * 892262 cannot be represented in type 'long int'
```
After:
```
Test run of ./eggdrop -v:
Eggdrop v1.9.0 (C) 1997 Robey Pointer (C) 1999-2021 Eggheads
```