### PR TITLE
Fix error reporting for socket connections

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -584,6 +584,7 @@ int open_telnet_raw(int sock, sockname_t *addr)
       if (res == ECONNREFUSED) { /* Connection refused */
         debug2("net: attempted socket connection refused: %s:%i",
                iptostr(&addr->addr.sa), get_port_from_addr(addr));
+        errno = res;
         return -4;
       }
       if (res != 0) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix errno propagation

Additional description (if needed):
May be related to  #86

Test cases demonstrating functionality (if applicable):
Before:
```
[03:49:36] net: open_telnet_raw(): idx 2 host 127.0.0.1 ip 127.0.0.1 port 6667 ssl 0
[03:49:36] net: attempted socket connection refused: 127.0.0.1:6667
[03:49:36] Failed connect to 127.0.0.1 (Operation now in progress)
```
After:
```
[03:49:50] net: open_telnet_raw(): idx 2 host 127.0.0.1 ip 127.0.0.1 port 6667 ssl 0
[03:49:50] net: attempted socket connection refused: 127.0.0.1:6667
[03:49:50] Failed connect to 127.0.0.1 (Connection refused)
```