### PR TITLE
RFC: Add bind-timeout option to let eggdrop wait for useable listen port

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -277,6 +277,9 @@ set userfile-perm 0600
 # and set it to the nick you would like to use.
 #set botnet-nick "LlamaBot"
 
+# Bind timeout in seconds. Must be set before listen command. Default is 0.
+# set bind-timeout 300
+
 # This opens a telnet port by which you and other bots can interact with the
 # Eggdrop by telneting in. There are more options for the listen command in
 # doc/tcl-commands.doc. Note that if you are running more than one bot on the

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -58,7 +58,7 @@ extern int flood_telnet_thr, flood_telnet_time, shtime, share_greet,
            max_logsize, dcc_total, raw_log, identtimeout, dcc_sanitycheck,
            dupwait_timeout, egg_numver, share_unlinks, protect_telnet,
            resolve_timeout, default_uflags, userfile_perm, cidr_support,
-           remove_pass, show_uname;
+           remove_pass, show_uname, bind_timeout;
 
 #ifdef IPV6
 extern char vhost6[];
@@ -497,6 +497,7 @@ static tcl_ints def_tcl_ints[] = {
   {"prefer-ipv6",           &pref_af,              0},
 #endif
   {"show-uname",            &show_uname,           0},
+  {"bind-timeout",          &bind_timeout,         0},
   {NULL,                    NULL,                  0}
 };
 


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: 

One-line summary:
Workaround and/or solution to #1142

Additional description (if needed):
We removed trying port+1 port+2 port+3 if port is unavailable with #843. This PR adds a configureable timeout for eggdrop attempting to bind to an (still) unavailable port.

Test cases demonstrating functionality (if applicable):
For the following test i blocked the listen port for 2 seconds:
```
$ grep bind-timeout BotA.conf 
set bind-timeout 5
```

```
$ ./eggdrop -n BotA.conf
[...]
[22:04:48] The specified address is already in use. Attempting to bind for 5 seconds.
[22:04:50] Listening for telnet connections on 0.0.0.0 port 3333 (all).
```
