### PR TITLE
Cleanup if/else, avoid statement not reached

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -968,8 +968,9 @@ int fork_before_tcl()
 {
 #ifndef REPLACE_NOTIFIER
   return tcl_threaded();
-#endif
+#else
   return 0;
+#endif
 }
 
 time_t get_expire_time(Tcl_Interp * irp, const char *s) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup if/else, avoid statement not reached

Additional description (if needed):
Found with `Sun C 5.12 SunOS_sparc 2011/11/16`

Test cases demonstrating functionality (if applicable):
```
/opt/solarisstudio12.3/bin/cc -D_STDC_C99= -g -I.. -I..  -DHAVE_CONFIG_H -DSTATIC  -c tcl.c
[...]
"tcl.c", line 972: warning: statement not reached
```