### PR TITLE
eggdrop 1.9.0rc3 - Fix /dcc chat <bot> for eggdrop compiled with --disable-ipv6

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -130,14 +130,13 @@ char *iptostr(struct sockaddr *sa)
  */
 int setsockname(sockname_t *addr, char *src, int port, int allowres)
 {
-  char *endptr;
+  char *endptr, *src2 = src;;
   long val;
   IP ip;
   struct hostent *hp;
   volatile int af = AF_UNSPEC;
 #ifdef IPV6
   char ip2[INET6_ADDRSTRLEN];
-  char *src2 = src;
   int pref;
 #else
   char ip2[INET_ADDRSTRLEN];
@@ -151,9 +150,7 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
     ip = htonl(val);
     if (inet_ntop(AF_INET, &ip, ip2, sizeof ip2)) {
       debug2("net: setsockname(): ip %s -> %s", src, ip2);
-#ifdef IPV6
       src2 = ip2;
-#endif
     }
   }
 #ifdef IPV6
@@ -218,7 +215,7 @@ int setsockname(sockname_t *addr, char *src, int port, int allowres)
  * have to resort to hackishly counting :s to see if its IPv6 or not.
  * Go internet.
  */
-  if (!inet_pton(AF_INET, src, &addr->addr.s4.sin_addr)) {
+  if (!inet_pton(AF_INET, src2, &addr->addr.s4.sin_addr)) {
     /* Boring way to count :s */
     count = 0;
     for (i = 0; src[i]; i++) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix `/dcc chat <bot>` for eggdrop compiled with `--disable-ipv6`

Additional description (if needed):
This bug fixed here is as follows:
If eggdrop is compiled with `./configure --disable-ipv6`, then `/dcc chat` is broken. This means: Usually the bot would answer to a valid /dcc chat request of a user. It would ask for password, and open a dcc chat session to the user.  The /dcc chat request tells the bot about the IP of the user and the bot will uses this ip to open a connection. For ipv4 the IP is coded as an integer and must be decoded by the bot. The decoding was "recently" broken and fixed. But the Fix was not complete, fixing it only for the case the bot was not compiled with `--disable-ipv6`. The decoding was already working, but the result of the decoding was not used when compiled with `--disable-ipv6`. So this is a small follow up fix, that uses the decoded IP also in the IPv4-only code path.

Test cases demonstrating functionality (if applicable):
**Before:**
Client:
```
/dcc chat BotA
*** Sent DCC CHAT [192.168.1.4:41821] request to BotA
```
Bot:
```
[19:45:55] net: setsockname(): ip 3232235780 -> 192.168.1.4
[19:45:55] net: open_telnet_raw(): idx 3 host ~michael@192.168.1.4 ip 0.0.0.0 port 41821 ssl 0
[19:45:55] net: attempted socket connection refused: 0.0.0.0:41821
[19:45:55] DCC connection failed: CHAT (alice!~michael@192.168.1.4)
[19:45:55]     (Operation now in progress)
[19:45:55] CTCP DCC: CHAT chat 3232235780 41821 from alice (~michael@192.168.1.4)
```
**After:**
Client:
```
/dcc chat BotA
*** DCC chat connection to BotA[192.168.1.3:55045] established
=BotA= Enter your password.
```
Bot:
```
[19:50:12] net: setsockname(): ip 3232235780 -> 192.168.1.4
[19:50:12] net: open_telnet_raw(): idx 3 host ~michael@192.168.1.4 ip 192.168.1.4 port 44029 ssl 0
[19:50:13] DCC connection: CHAT (alice!~michael@192.168.1.4)
[19:50:13] CTCP DCC: CHAT chat 3232235780 44029 from alice (~michael@192.168.1.4)
```