### PR TITLE
RFC: Do not send escape codes to ssl connections

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2344,7 +2344,8 @@ static void dcc_telnet_got_ident(int i, char *host)
   /* Note: we don't really care about telnet status here. We use the
    * STATUS option as a hopefully harmless way to detect if the other
    * side is a telnet client or not. */
-  dprintf(i, TLN_IAC_C TLN_WILL_C TLN_STATUS_C);
+  if (!dcc[i].ssl)
+    dprintf(i, TLN_IAC_C TLN_WILL_C TLN_STATUS_C);
 
   /* Copy acceptable-nick/host mask */
   dcc[i].status = STAT_TELNET | STAT_ECHO;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Do not send escape codes to ssl connections for openssl does not interpret but print them.

Additional description (if needed):
If one telnets to the bot, the bot will send some telnet codes. For example to suppress echoing the password. If one connects via ssl, one usually uses openssl and openssl does not interpret those telnet codes but prints them to the screen. This looks ugly. I think, openssl is not the only way to connect to eggdrop via ssl, but i also dont know of any telnet-client able to connect to eggdrop via ssl. So, i need more opinions, if the `if (!dcc[i].ssl)` is a good idea.

Test cases demonstrating functionality (if applicable):
Before:
```
$ openssl s_client -cert alice.crt -key alice.key -connect 127.0.0.1:3343
[...]
read R BLOCK
ÿû

Nickname.
^[[?1;2c
```
After:
```
$ openssl s_client -cert alice.crt -key alice.key -connect 127.0.0.1:3343
[...]
read R BLOCK


Nickname.
```