### PR TITLE
Fix error msg for .restart when running foreground

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1329,7 +1329,7 @@ static void cmd_restart(struct userrec *u, int idx, char *par)
 {
   putlog(LOG_CMDS, "*", "#%s# restart", dcc[idx].nick);
   if (!backgrd) {
-    dprintf(idx, "You cannot .restart a bot when running -n (due to Tcl).\n");
+    dprintf(idx, "You cannot .restart a bot when running -n/-t (due to Tcl).\n");
     return;
   }
   dprintf(idx, "Restarting.\n");


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: 

One-line summary:
Since `-t` is a standalone option since eggdrop 1.9.0, the error msg for running a bot with `-t` was wrong and named only `-n`.

Additional description (if needed):
`-t` now has implicit `-n`

Test cases demonstrating functionality (if applicable):
```
./eggdrop -t BotA.conf
.restart
```
Before:
`You cannot .restart a bot when running -n (due to Tcl).`
After:
`You cannot .restart a bot when running -n/-t (due to Tcl).`
