### PR TITLE
Enhance and fix stagnant module warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -959,6 +959,7 @@ int mainloop(int toplevel)
         if (strcmp(p->name, "eggdrop") && strcmp(p->name, "encryption") &&
             strcmp(p->name, "uptime")) {
           f++;
+          debug1("stagnant module %s", p->name);
         }
       }
       if (f != 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -953,11 +953,11 @@ int mainloop(int toplevel)
       }
 
       /* Make sure we don't have any modules left hanging around other than
-       * "eggdrop" and the two that are supposed to be.
+       * "eggdrop" and the 3 that are supposed to be.
        */
       for (f = 0, p = module_list; p; p = p->next) {
         if (strcmp(p->name, "eggdrop") && strcmp(p->name, "encryption") &&
-            strcmp(p->name, "uptime")) {
+            strcmp(p->name, "encryption2") && strcmp(p->name, "uptime")) {
           f++;
           debug1("stagnant module %s", p->name);
         }


### PR DESCRIPTION
Found by: ?
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance and fix stagnant module warning

Additional description (if needed):
During `.restart` eggdrop checks for stagnant modules. This check skips modules in a hardcoded whitelist. The 3 skipped modules are: eggdrop core, encryption mod and uptime mod. When pbkdf2 mod (aka encryption2 mod) was added to eggdrop 1.9.0, this list was not extended to cover pbkdf2. This PR not only fixed the whitelist, it also enhances the check for stagnant mods, so that ill will log stagnant modules by name. This will help in debugging such issues in the future.

Test cases demonstrating functionality (if applicable):
With `loadmodule pbkdf2` in eggdrop.conf
`.restart`
Before:
`[02:27:46] Stagnant modules; there WILL be memory leaks!`
After adding addional debug log:
```
[02:27:46] stagnant module encryption2
[02:27:46] Stagnant modules; there WILL be memory leaks!
```
After Fix:
Warning is gone