### PR TITLE
tcl_server: Fix crash when not specifying port.

### DIFF
--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -449,9 +449,9 @@ static int tcl_server STDVAR {
 
   BADARGS(3, 5, " subcommand host ?port ?password??");
   if (!strcmp(argv[1], "add")) {
-    ret = add_server(argv[2], argv[3] ? argv[3] : "", argv[4] ? argv[4] : "");
+    ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");
   } else if (!strcmp(argv[1], "remove")) {
-    ret = del_server(argv[2], argv[3] ? argv[3] : "");
+    ret = del_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "");
   } else {
     Tcl_AppendResult(irp, "Invalid subcommand: ", argv[1],
         ". Should be \"add\" or \"remove\"", NULL);
@@ -467,8 +467,8 @@ static int tcl_server STDVAR {
     Tcl_AppendResult(irp, "Attempted to add SSL-enabled server, but Eggdrop "
             "was not compiled with SSL libraries.", NULL);
   } else if (ret == 3) {    /* del_server only */
-    Tcl_AppendResult(irp, "Server ", argv[2], argv[3] ? ":" : "",
-            argv[3] ? argv[3] : ""," not found.", NULL);
+    Tcl_AppendResult(irp, "Server ", argv[2], argc >= 4 && argv[3] ? ":" : "",
+            argc >= 4 && argv[3] ? argv[3] : ""," not found.", NULL);
   }
   return TCL_ERROR;
 }

--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -716,7 +716,8 @@ static int tcl_twcmd STDVAR {
     Tcl_AppendResult(irp, "Invalid channel", NULL);
     return TCL_ERROR;
   }
-  dprintf(DP_SERVER, "PRIVMSG %s :/%s %s", argv[1], argv[2], argv[3] ? argv[3] : "");
+  dprintf(DP_SERVER, "PRIVMSG %s :/%s %s", argv[1], argv[2],
+      argc >= 4 && argv[3] ? argv[3] : "");
   return TCL_OK;
 }
 

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1359,14 +1359,14 @@ static int tcl_boot STDVAR
       if (i < 0)
         return TCL_OK;
       botnet_send_reject(i, botnetnick, NULL, whonick, who,
-                         argv[2] ? argv[2] : "");
+                         argc >= 3 && argv[2] ? argv[2] : "");
     } else
       return TCL_OK;
   }
   for (i = 0; i < dcc_total; i++)
     if (!ok && (dcc[i].type->flags & DCT_CANBOOT) &&
         !strcasecmp(dcc[i].nick, who)) {
-      do_boot(i, botnetnick, argv[2] ? argv[2] : "");
+      do_boot(i, botnetnick, argc >= 3 && argv[2] ? argv[2] : "");
       ok = 1;
     }
   return TCL_OK;


### PR DESCRIPTION
tcl_boot and tcl_twcmd had similar code-correctness problems but were getting lucky because argv[argc] == NULL.

This crash exists in 1.9.0 and needs backport.

Found by: bdrewery
Patch by: bdrewery
Fixes: 59d1b044f2cbacf20c5f2425922a7ae3918fc9bd f4bcf4d10b4415a898a77d87c5a58bdfec6d4109 35c333bb5b640cc15c48f39c5654517771a79bf2

One-line summary: Primarily fixes `server add <server>` crashing when no port or pass is given. Also fixes similar issues in `boot` and `twcmd`.


Additional description (if needed):

Note that `argv[argc] == NULL` [as a terminator](https://github.com/eggheads/eggdrop/blob/develop/src/tcl.c#L324), so `boot` and `twcmd` were just getting lucky but were not correct.

Test cases demonstrating functionality (if applicable):

Bot doesn't crash on startup now.

```
Program received signal SIGBUS, Bus error.
0x000000080d7935d7 in add_server (name=0x810380f50 "us.undernet.org", port=0x80d799d32 "", pass=0x65646e752e637269 <error: Cannot access memory at address 0x65646e752e637269>) at .././server.mod/server.c:1046
1046      if (pass[0]) {
(gdb) up
#1  0x000000080d790073 in tcl_server (cd=0x0, irp=0x8102c3000, argc=3, argv=0x8103151a0) at .././server.mod/tclserv.c:452
452         ret = add_server(argv[2], argv[3] ? argv[3] : "", argv[4] ? argv[4] : "");
(gdb) p argc
$1 = 3
```
