### PR TITLE
Fix strcpy param overlap and simplify #1076

### DIFF
--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -162,7 +162,7 @@ static int resolve_dir(char *current, char *change, char **real, int idx)
   if (new[0] == '/') {
     /* EVERYONE has access here */
     (*real)[0] = 0;
-    strcpy(new, &new[1]);
+    memmove(new, new + 1, strlen(new));
   }
   /* Cycle thru the elements */
   strcat(new, "/");

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2421,7 +2421,7 @@ static int gotmsg(char *from, char *msg)
       *p = 0;
       ctcp = buf2;
       strlcpy(buf2, p1, sizeof buf2);
-      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
+      memmove(p1 - 1, p + 1, strlen(p));
       detect_chan_flood(nick, uhost, from, chan, strncmp(ctcp, "ACTION ", 7) ?
                         FLOOD_CTCP : FLOOD_PRIVMSG, NULL);
 
@@ -2540,7 +2540,7 @@ static int gotnotice(char *from, char *msg)
       *p = 0;
       ctcp = buf2;
       strcpy(ctcp, p1);
-      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
+      memmove(p1 - 1, p + 1, strlen(p));
       p = strchr(msg, 1);
       detect_chan_flood(nick, uhost, from, chan,
                         strncmp(ctcp, "ACTION ", 7) ?

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -572,7 +572,7 @@ static int gotmsg(char *from, char *msg, char *tag)
       ctcp = ctcpbuf;
 
       /* remove the ctcp in msg */
-      memmove(p1 - 1, p + 1, strlen(p + 1) + 1);
+      memmove(p1 - 1, p + 1, strlen(p));
 
       if (!ignoring)
         detect_flood(nick, uhost, from,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix strcpy param overlap and simplify #1076

Additional description (if needed):
For `strcpy()`, the result is undefined if src and dst overlap. Solution is to use `memmove()` instead.
The code changed with #1076 became unnecessary complex. `strlen(p + 1) + 1` equals `strlen(p)`.

Test cases demonstrating functionality (if applicable):
