### PR TITLE
Flood CTCP used the wrong string for calling Tcl callbacks.

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -227,7 +227,7 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
   case FLOOD_CTCP:
     thr = chan->flood_ctcp_thr;
     lapse = chan->flood_ctcp_time;
-    strcpy(ftype, "pub");
+    strcpy(ftype, "ctcp");
     break;
   case FLOOD_NICK:
     thr = chan->flood_nick_thr;


### PR DESCRIPTION
Found by: DasBrain
Patch by: DasBrain
Fixes:  CTCP flood is calling a Tcl bind with pub as type.

One-line summary: CTCP flood now calls Tcl callbacks with "ctcp" as type.