### PR TITLE
Don't overwrite socket IP on CTCP

### DIFF
--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -185,7 +185,7 @@ static int ctcp_CHAT(char *nick, char *uhost, char *handle, char *object,
 #endif
           (!strcmp(dcc[i].nick, "(telnet)") ||
            !strcmp(dcc[i].nick, "(users)")) &&
-          getdccfamilyaddr(&dcc[i].sockname, s, sizeof s, chatv)) {
+          getdccfamilyaddr(NULL, s, sizeof s, chatv)) {
         /* Do me a favour and don't change this back to a CTCP reply,
          * CTCP replies are NOTICE's this has to be a PRIVMSG
          * -poptix 5/1/1997 */


### PR DESCRIPTION
Found by: [TriiiX]
Patch by: Geo
Fixes: #1160

One-line summary:
Don't overwrite socket IP on CTCP

Additional description (if needed):

After responding to a ctcp chat, if Eggdrop is listening on all addresses, it incorrectly overwrites the listening socket structure with the IP used to respond to the CTCP. Maybe an issue with DCC as well.
