### PR TITLE
Add net-type Libera.Chat

### DIFF
--- a/doc/sphinx_source/coreDocs/server.rst
+++ b/doc/sphinx_source/coreDocs/server.rst
@@ -21,10 +21,9 @@ There are also some variables you can set in your config file:
 
   set net-type Efnet
     What is your network? Possible allowed values are Efnet, IRCnet, Undernet,
-    DALnet, freenode, Quakenet, Rizon, Other. If the network you use is not
-    listed, using "Other" is a good sane choice and can be customized with
-    settings both here and in the IRC module sections of the config file.
-
+    DALnet, Libera.Chat, freenode, Quakenet, Rizon, Other. If the network you
+    use is not listed, using "Other" is a good sane choice and can be customized
+    with settings both here and in the IRC module sections of the config file.
 
   set nick "LamestBot"
     Set the nick the bot uses on IRC, and on the botnet unless you specify a

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -331,6 +331,7 @@ set chanfile "LamestBot.chan"
 ##   IRCnet
 ##   Undernet
 ##   DALnet
+##   Libera.Chat
 ##   freenode
 ##   QuakeNet
 ##   Rizon

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1065,6 +1065,7 @@ loadmodule server
 ##   IRCnet
 ##   Undernet
 ##   DALnet
+##   Libera.Chat
 ##   freenode
 ##   QuakeNet
 ##   Rizon

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1520,6 +1520,8 @@ static char *traced_nettype(ClientData cdata, Tcl_Interp *irp,
     net_type_int = NETT_DALNET;
   else if (!strcasecmp(net_type, "EFnet"))
     net_type_int = NETT_EFNET;
+  else if (!strcasecmp(net_type, "Libera.Chat"))
+    net_type_int = NETT_FREENODE;
   else if (!strcasecmp(net_type, "freenode"))
     net_type_int = NETT_FREENODE;
   else if (!strcasecmp(net_type, "IRCnet"))
@@ -1558,8 +1560,9 @@ static char *traced_nettype(ClientData cdata, Tcl_Interp *irp,
     net_type_int = NETT_OTHER; 
     warn = 1;
   } else {
-    fatal("ERROR: NET-TYPE NOT SET.\n Must be one of DALNet, EFnet, freenode, "
-          "IRCnet, Quakenet, Rizon, Undernet, Other.", 0);
+    fatal("ERROR: NET-TYPE NOT SET.\n Must be one of DALNet, EFnet, "
+          "Libera.Chat, freenode, IRCnet, Quakenet, Rizon, Undernet, Other.",
+          0);
   }
   if (warn) {
     putlog(LOG_MISC, "*",

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -119,7 +119,7 @@ typedef struct cap_list {
 enum {
   NETT_DALNET,       /* DALnet                            */
   NETT_EFNET,        /* EFnet                             */
-  NETT_FREENODE,     /* freenode                          */
+  NETT_FREENODE,     /* Libera.Chat/freenode              */
   NETT_HYBRID_EFNET, /* Hybrid-6+ EFnet +e/+I/max-bans 20 */
   NETT_IRCNET,       /* IRCnet                            */
   NETT_QUAKENET,     /* QuakeNet                          */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add net-type Libera.Chat

Additional description (if needed):
For now, eggdrop will use freenode settings for net-type Libera.Chat. But we need this new seeting to make it super easy to setup eggdrops net-type. Also, both networks are already using difference irc servers, so settings may diverge in the future.

Test cases demonstrating functionality (if applicable):
