### PR TITLE
Add ssl status to .vbottree

### DIFF
--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -723,7 +723,7 @@ static void bot_nlinked(int idx, char *par)
     putlog(LOG_BOTMSG, "*", "(%s) %s %s.", next, NET_LINKEDTO, newbot);
     x = '-';
   }
-  addbot(newbot, dcc[idx].nick, next, x, i);
+  addbot(newbot, dcc[idx].nick, next, x, i, dcc[idx].ssl);
   check_tcl_link(newbot, next);
   u = get_user_by_handle(userlist, newbot);
   if (bot_flags(u) & BOT_REJECT) {

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -636,10 +636,19 @@ void tell_bottree(int idx, int showver)
           strcpy(work + imark, "     ");
         imark += 5;
       }
-      if (cnt > 1)
-        strcpy(work + imark, "  |-");
-      else
-        strcpy(work + imark, "  `-");
+      if (cnt > 1) {
+        if (bot->ssl) {
+          strcpy(work + imark, "  |=");
+        } else {
+          strcpy(work + imark, "  |-");
+        }
+      } else {
+        if (bot->ssl) {
+          strcpy(work + imark, "  `=");
+        } else {
+          strcpy(work + imark, "  `-");
+        }
+      }
       s[0] = 0;
       bot = tandbot;
       while (!s[0]) {
@@ -647,11 +656,10 @@ void tell_bottree(int idx, int showver)
           if (bot->ver) {
             i = sprintf(s, "%c%s", bot->share, bot->bot);
             if (showver)
-              sprintf(s + i, " (%d.%d.%d.%d%s)",
+              sprintf(s + i, " (%d.%d.%d.%d)",
                       bot->ver / 1000000,
                       bot->ver % 1000000 / 10000,
-                      bot->ver % 10000 / 100, bot->ver % 100,
-                      bot->ssl ? " ssl" : "");
+                      bot->ver % 10000 / 100, bot->ver % 100);
           } else
             sprintf(s, "-%s", bot->bot);
         } else
@@ -686,11 +694,10 @@ void tell_bottree(int idx, int showver)
                 if (bot->ver) {
                   i = sprintf(s, "%c%s", bot->share, bot->bot);
                   if (showver)
-                    sprintf(s + i, " (%d.%d.%d.%d%s)",
+                    sprintf(s + i, " (%d.%d.%d.%d)",
                             bot->ver / 1000000,
                             bot->ver % 1000000 / 10000,
-                            bot->ver % 10000 / 100, bot->ver % 100,
-                            bot->ssl ? " ssl" : "");
+                            bot->ver % 10000 / 100, bot->ver % 100);
                 } else
                   sprintf(s, "-%s", bot->bot);
               }
@@ -708,9 +715,9 @@ void tell_bottree(int idx, int showver)
           }
           more = 1;
           if (cnt > 1)
-            dprintf(idx, "%s  |-%s\n", work, s);
+            dprintf(idx, "%s  |%s%s\n", work, bot->ssl ? "=" : "-", s);
           else
-            dprintf(idx, "%s  `-%s\n", work, s);
+            dprintf(idx, "%s  `%s%s\n", work, bot->ssl ? "=" : "-", s);
           this = bot2;
           work[0] = 0;
           if (cnt > 1)

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -735,6 +735,7 @@ void tell_bottree(int idx, int showver)
             this = last[lev];
           }
         }
+        dprintf(idx, "Key: - link    = encrypted link    + userfile sharing");
       }
     }
   }

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -78,7 +78,7 @@ tand_t *findbot(char *who)
 
 /* Add a tandem bot to our chain list
  */
-void addbot(char *who, char *from, char *next, char flag, int vernum)
+void addbot(char *who, char *from, char *next, char flag, int vernum, int ssl)
 {
   tand_t **ptr = &tandbot, *ptr2;
 
@@ -93,6 +93,7 @@ void addbot(char *who, char *from, char *next, char flag, int vernum)
   ptr2->share = flag;
   ptr2->ver = vernum;
   ptr2->next = *ptr;
+  ptr2->ssl = ssl;
   *ptr = ptr2;
   /* May be via itself */
   ptr2->via = findbot(from);
@@ -646,10 +647,11 @@ void tell_bottree(int idx, int showver)
           if (bot->ver) {
             i = sprintf(s, "%c%s", bot->share, bot->bot);
             if (showver)
-              sprintf(s + i, " (%d.%d.%d.%d)",
+              sprintf(s + i, " (%d.%d.%d.%d%s)",
                       bot->ver / 1000000,
                       bot->ver % 1000000 / 10000,
-                      bot->ver % 10000 / 100, bot->ver % 100);
+                      bot->ver % 10000 / 100, bot->ver % 100,
+                      bot->ssl ? " ssl" : "");
           } else
             sprintf(s, "-%s", bot->bot);
         } else
@@ -684,10 +686,11 @@ void tell_bottree(int idx, int showver)
                 if (bot->ver) {
                   i = sprintf(s, "%c%s", bot->share, bot->bot);
                   if (showver)
-                    sprintf(s + i, " (%d.%d.%d.%d)",
+                    sprintf(s + i, " (%d.%d.%d.%d%s)",
                             bot->ver / 1000000,
                             bot->ver % 1000000 / 10000,
-                            bot->ver % 10000 / 100, bot->ver % 100);
+                            bot->ver % 10000 / 100, bot->ver % 100,
+                            bot->ssl ? " ssl" : "");
                 } else
                   sprintf(s, "-%s", bot->bot);
               }

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -585,6 +585,7 @@ void tell_bots(int idx)
 void tell_bottree(int idx, int showver)
 {
   char s[161];
+  char c = '-';
   tand_t *last[20], *this, *bot, *bot2 = NULL;
   int lev = 0, more = 1, mark[20], ok, cnt, i, imark;
   char work[1024];
@@ -597,7 +598,7 @@ void tell_bottree(int idx, int showver)
   s[0] = 0;
   i = 0;
 
-  for (bot = tandbot; bot; bot = bot->next)
+  for (bot = tandbot; bot; bot = bot->next) {
     if (!bot->uplink) {
       if (i) {
         s[i++] = ',';
@@ -606,6 +607,9 @@ void tell_bottree(int idx, int showver)
       strcpy(s + i, bot->bot);
       i += strlen(bot->bot);
     }
+  }
+  dprintf(idx, "- Link    = Encrypted link    + Userfile Sharing\n");
+  dprintf(idx, "------------------------------------------------\n");
   if (s[0])
     dprintf(idx, "(%s %s)\n", BOT_NOTRACEINFO, s);
   if (showver)
@@ -627,6 +631,7 @@ void tell_bottree(int idx, int showver)
     for (bot = tandbot; bot; bot = bot->next)
       if (bot->uplink == this)
         cnt++;
+    bot = tandbot;
     if (cnt) {
       imark = 0;
       for (i = 0; i < lev; i++) {
@@ -654,7 +659,12 @@ void tell_bottree(int idx, int showver)
       while (!s[0]) {
         if (bot->uplink == this) {
           if (bot->ver) {
-            i = sprintf(s, "%c%s", bot->share, bot->bot);
+            if ((bot->share=='-') && (bot->ssl)) {
+              c = '=';
+            } else {
+              c = bot->share;
+            }
+            i = sprintf(s, "%c%s", c, bot->bot);
             if (showver)
               sprintf(s + i, " (%d.%d.%d.%d)",
                       bot->ver / 1000000,
@@ -692,7 +702,12 @@ void tell_bottree(int idx, int showver)
               if (cnt == 1) {
                 bot2 = bot;
                 if (bot->ver) {
-                  i = sprintf(s, "%c%s", bot->share, bot->bot);
+                  if ((bot->share=='-') && (bot->ssl)) {
+                    c = '=';
+                  } else {
+                    c = bot->share;
+                  }
+                  i = sprintf(s, "%c%s", c, bot->bot);
                   if (showver)
                     sprintf(s + i, " (%d.%d.%d.%d)",
                             bot->ver / 1000000,
@@ -735,7 +750,7 @@ void tell_bottree(int idx, int showver)
             this = last[lev];
           }
         }
-        dprintf(idx, "Key: - link    = encrypted link    + userfile sharing");
+        dprintf(idx, "------------------------------------------------\n");
       }
     }
   }

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -244,7 +244,7 @@ static void bot_version(int idx, char *par)
   touch_laston(dcc[idx].user, "linked", now);
   dump_links(idx);
   dcc[idx].type = &DCC_BOT;
-  addbot(dcc[idx].nick, dcc[idx].nick, botnetnick, '-', dcc[idx].u.bot->numver);
+  addbot(dcc[idx].nick, dcc[idx].nick, botnetnick, '-', dcc[idx].u.bot->numver, dcc[idx].ssl);
   check_tcl_link(dcc[idx].nick, botnetnick);
   egg_snprintf(x, sizeof x, "v %d", dcc[idx].u.bot->numver);
   bot_share(idx, x);

--- a/src/proto.h
+++ b/src/proto.h
@@ -70,7 +70,7 @@ void tell_bottree(int, int);
 int botlink(char *, int, char *);
 int botunlink(int, char *, char *, char *);
 void dump_links(int);
-void addbot(char *, char *, char *, char, int);
+void addbot(char *, char *, char *, char, int, int);
 void updatebot(int, char *, char, int);
 void rembot(char *);
 struct tand_t_struct *findbot(char *);

--- a/src/tandem.h
+++ b/src/tandem.h
@@ -31,6 +31,7 @@ typedef struct tand_t_struct {
   struct tand_t_struct *next;
   int ver;
   char share;
+  int ssl;
 } tand_t;
 
 /* Keep track of party-line members */


### PR DESCRIPTION
Found by: tuvok
Patch by: michaelortmann
Fixes:  #513

One-line summary:
Add ssl status to `.vbottree` changing it from beeing a `.v(ersion)bottree` into a `.v(erbose)bottree`.

Additional description (if needed):
This is my proposal to #513. Leave `.bottree` untouched and only extending the output of `.vbottree` to include additional ssl information. So `.v(ersion)bottree` becomes `.v(erbose)bottree`. What do you think?

Test cases demonstrating functionality (if applicable):
```
[03:11:22] #-HQ# vbottree
BotA (1.9.1.0)
  `-+BotB (1.9.1.0 ssl)
Average hops: 1.0, total bots: 2
```
I would like someone to test this on a biger eggdrop-botnet.