### PR TITLE
Update core.help

### DIFF
--- a/help/core.help
+++ b/help/core.help
@@ -7,7 +7,7 @@ DCC commands for %B, %V:
       %bwhoami       echo         strip        su%b
       %btrace        fixcodes     bottree      vbottree%b
       %bbotinfo      relay        -host        fprint%b
-      %chfinger%b
+      %bchfinger%b
 %{o|o}
    For ops:
       %baddlog       console      match        whois%b
@@ -214,7 +214,7 @@ ssl-verify-dcc
       %bwhoami       echo         strip        su%b
       %btrace        fixcodes     bottree      vbottree%b
       %bbotinfo      relay        -host        fprint%b
-      %chfinger%b
+      %bchfinger%b
 %{o|o}
    For ops:
       %baddlog       console      match        whois%b


### PR DESCRIPTION
Found by: wilk
Patch by: wilk
Fixes: Broken format code (%b) in core.help file.

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
