### PR TITLE
remove mandatory flag for listen script

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1814,9 +1814,9 @@ listen [ip] <port> <type> [options [flag]]
 
       Returns: port number or error message
 
-    listen [ip] <port> script <proc> <flag>
+    listen [ip] <port> script <proc> [flag]
 
-      Description: accepts connections which are immediately routed to a proc. The proc is called with one parameter: the idx of the new connection. If the script type is used, flag must also be set. Flag may currently only be 'pub', which makes the bot allow anyone to connect and not perform an ident lookup.
+      Description: accepts connections which are immediately routed to a proc. The proc is called with one parameter: the idx of the new connection. The optional flag parameter currently only accepts 'pub' as a value. By specifying 'pub' as a flag, Eggdrop will skip the ident check for the user regardless of settings in the config file. This will allow any user to attempt a connection, and result in Eggdrop using "-telnet!telnet@host" instead of "-telnet!<ident>@host" as a hostmask to match against the user.
 
       Returns: port number or error message
 

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1322,14 +1322,10 @@ static int tcl_listen STDVAR
       Tcl_AppendResult(irp, "a proc name must be specified for a script listen", NULL);
       return TCL_ERROR;
     }
-    if ((!ip[0] && (argc==4)) || (ip[0] && argc==5)) {
-      Tcl_AppendResult(irp, "missing flag. allowed flags: pub", NULL);
-      return TCL_ERROR;
-    }
     if ((!ip[0] && (argc==5)) || (argc == 6)) {
       i++;
       if (strcmp(argv[i], "pub")) {
-        Tcl_AppendResult(irp, "unknown flag: ", flag, ". allowed flags: pub",
+        Tcl_AppendResult(irp, "unknown flag: ", argv[i], ". allowed flags: pub",
               NULL);
         return TCL_ERROR;
       }


### PR DESCRIPTION
Found by: Krambaek
Fixes: #1182 

In 1.9.0, docs were misinterpreted and the flag field for 'listen script' was made a requirement, instead of optional. This reverts the change back to being optional, and reclarifies the documents

Tests:
```
listen allows script without IP, without flag                                                                                                                      
| PASS |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
listen allows script without IP, with flag                                  
| PASS |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
listen allows script with IP, without flag                                  
| PASS |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
listen allows script with IP, with flag                                       
| PASS |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
listen errors on script with invalid flag                                    
| PASS |
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5 tests, 5 passed, 0 failed
==================================================================================================
```