### PR TITLE
Feature/twitchusernotice

### DIFF
--- a/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
@@ -15,6 +15,13 @@ consequences.
 This list is accurate for Eggdrop v1.9.0, the minimum version for which Twitch
 functionality is possible.
 
+It should also be noted that if you are debugging scripts via the partyline,
+the Eggdrop partyline output has not been updated to handle the potentially
+LONG tag message lines that are sent by a server. This means if you view a
+variable that has stored all the tag messages sent by the server, it may
+appear truncated. Rest assured, the variable does contain the full set of tags,
+they just aren't being displayed.
+
 Commands
 --------
 
@@ -170,3 +177,11 @@ The following is a list of bind types and how they work. Below each bind type is
   procname <chan> <tags>
 
   Description: Called when Eggdrop receives a USERSTATE message. ``mask`` is in the format of ``#channel keys`` and can use wildcards (see the RMST bind for additional details on format). ``chan`` is the channel Eggdrop received the USERSTATE message for, and ``tags`` is a list of key/value pairs provided in the USERSTATE message, suitable for use as a Tcl dict. ``flags`` is ignored.
+
+#. UNTC (USERNOTICE)
+
+  bind untc <flags> <mask> <proc>
+
+  procname <chan> <tags>
+
+  Description: Called when Eggdrop received a USERNOTICE message. `mask`` is in the format of ``#channel keys`` and can use wildcards (see the RMST bind for additional details on format). ``chan`` is the channel Eggdrop received the USERNOTICE message for, and ``tags`` is a list of key/value pairs provided in the USERNOTICE message, suitable for use as a Tcl dict. ``flags`` is ignored.

--- a/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
@@ -122,7 +122,7 @@ Bind Types
 
 The following is a list of bind types and how they work. Below each bind type is the format of the bind command, the list of arguments sent to the Tcl proc, and an explanation.
 
-#. CCHT  (CLEARCHAT)
+1. CCHT  (CLEARCHAT)
 
   bind ccht <flags> <mask> <proc>
 
@@ -130,7 +130,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when the chat history for the channel or a user on the channel is cleared. The value of ``mask`` specified in the bind is matched against ``#channel nick!nick@nick.tmi.twitch.tv`` and can use wildcards. If a user is found that matches ``mask``, they must also match the ``flags`` mask. If the CLEARCHAT is only targeted at a specific user and not the channel, that user's nickname will appear in ``nick``, otherwise ``nick`` is empty. ``chan`` will contain the channel the CLEARCHAT was used on.
 
-#. CMSG (CLEARMSG)
+2. CMSG (CLEARMSG)
 
   bind cmsg <flags> <command> <proc>
 
@@ -138,7 +138,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when a specific message on the channel is cleared. The value of ``mask`` specified in the bind is matched against ``#channel nick!nick@nick.tmi.twitch.tv`` and can use wildcards. If a user is found that matches ``mask``, they must also match the ``flags`` mask. ``nick`` contains the user's nickname, and ``chan`` will contain the channel the CLEARMSG was used on.
 
-#. HTGT (HOSTTARGET)
+3. HTGT (HOSTTARGET)
 
   bind htgt <flags> <mask> <proc>
 
@@ -146,7 +146,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when a broadcaster starts or stops hosting another Twitch channel. ``mask`` is in the format "#channel target", where #channel is the hosting channel and target is the name of the broadcaster being hosted by #channel. Similarly for the proc, ``target`` is the name of the Twitch channel being hosted by ``chan``. A value of ``-`` in ``target`` indicates that the broadcaster has stopped hosting another channel. ``viewers`` contains the number of viewers in ``chan`` that are now watching ``target`` when hosting starts, but has been found to not be reliably provided by Twitch (often arbitrarily set to 0).
 
-#. WSPR (WHISPER)
+4. WSPR (WHISPER)
 
   bind wspr <flags> <command> <proc>
 
@@ -154,7 +154,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when Eggdrop received a whisper from another Twitch user. The first word of the user's msg is matched against ``command``, and the remainder of the text is passed to ``msg``. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``.
 
-#. WSPM (WHISPER)
+5. WSPM (WHISPER)
 
   bind wspr <flags> <mask> <proc>
 
@@ -162,7 +162,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when Eggdrop received a whisper from another Twitch user. The msg is matched against ``mask``, which can contain wildcards. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``. The full text of the whisper is stored in ``msg``.
 
-#. RMST (ROOMSTATE)
+6. RMST (ROOMSTATE)
 
   bind rmst <flags> <mask> <proc>
 
@@ -170,7 +170,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when Eggdrop receives a ROOMSTATE message. ``mask`` is in the format of ``#channel keys`` and can use wildcards. For example, to trigger this bind on #eggdrop for any change, you would use ``#eggdroptest *`` as the mask, or to trigger on #eggdrop specifically for the emote-only setting, you would use ``"#eggdrop *emote-only*"`` as the mask. Due to the nature of multiple keys per roomstate and uncertainty of ordering, it is recommended to use multiple binds if you wish to specify multiple key values. ``chan`` is the channel Eggdrop received the ROOMSTATE message for, and ``tags`` is a list of key/value pairs provided by the ROOMSTATE message, suitable for use as a Tcl dict. ``flags`` is ignored.
 
-#. USST (USERSTATE)
+7. USST (USERSTATE)
 
   bind usst <flags> <mask> <proc>
 
@@ -178,7 +178,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when Eggdrop receives a USERSTATE message. ``mask`` is in the format of ``#channel keys`` and can use wildcards (see the RMST bind for additional details on format). ``chan`` is the channel Eggdrop received the USERSTATE message for, and ``tags`` is a list of key/value pairs provided in the USERSTATE message, suitable for use as a Tcl dict. ``flags`` is ignored.
 
-#. UNTC (USERNOTICE)
+8. UNTC (USERNOTICE)
 
   bind untc <flags> <mask> <proc>
 

--- a/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/twitch-tcl-commands.rst
@@ -152,15 +152,15 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <userhost> <handle> <msg>
 
-  Description: Called when Eggdrop received a whisper from another Twitch user. The first word of the user's msg is matched against ``command``, and the remainder of the text is passed to ``msg``. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``.
+  Description: Checks the first word of a whisper Eggdrop receives from another Twitch user. The first word of the whisper is matched against ``command``, and the remainder of the text is passed to ``msg``. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``.
 
 5. WSPM (WHISPER)
 
-  bind wspr <flags> <mask> <proc>
+  bind wspm <flags> <mask> <proc>
 
   procname <nick> <userhost> <handle> <msg>
 
-  Description: Called when Eggdrop received a whisper from another Twitch user. The msg is matched against ``mask``, which can contain wildcards. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``. The full text of the whisper is stored in ``msg``.
+  Description: Checks the entire contents of a whisper Eggdrop receives from another Twitch user. The contents of the whisper are matched against ``mask``, which can contain wildcards. ``nick`` is populated with the login name of the user messaging the Eggdrop, ``userhost`` contains nick's userhost in the format nick!nick@nick.tmi.twitch.tv. ``handle`` will match the user's handle on the bot if present, otherwise it will return a ``*``. The full text of the whisper is stored in ``msg``.
 
 6. RMST (ROOMSTATE)
 
@@ -178,9 +178,9 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: Called when Eggdrop receives a USERSTATE message. ``mask`` is in the format of ``#channel keys`` and can use wildcards (see the RMST bind for additional details on format). ``chan`` is the channel Eggdrop received the USERSTATE message for, and ``tags`` is a list of key/value pairs provided in the USERSTATE message, suitable for use as a Tcl dict. ``flags`` is ignored.
 
-8. UNTC (USERNOTICE)
+8. USRNTC (USERNOTICE)
 
-  bind untc <flags> <mask> <proc>
+  bind usrntc <flags> <mask> <proc>
 
   procname <chan> <tags>
 

--- a/doc/sphinx_source/mainDocs/twitch.rst
+++ b/doc/sphinx_source/mainDocs/twitch.rst
@@ -23,9 +23,9 @@ Registering with Twitch
 Editing the config file
 ***********************
 
-#. Find addserver options in the server section of the config file. Remove the sample servers listed and add the following line in their place, replacing the alphanumeric string after 'oauth:' with the token you created when registering with Twitch in the previous section. Pretending your Twitch token from the previous step is 'j9irk4vs28b0obz9easys4w2ystji3u', it should look like this::
+#. Find the options to add a server in the server section of the config file. Remove the sample servers listed and add the following line in their place, replacing the alphanumeric string after 'oauth:' with the token you created when registering with Twitch in the previous section. Pretending your Twitch token from the previous step is 'j9irk4vs28b0obz9easys4w2ystji3u', it should look like this::
 
-    addserver irc.chat.twitch.tv 6667 oauth:j9irk4vs28b0obz9easys4w2ystji3u
+    server add irc.chat.twitch.tv 6667 oauth:j9irk4vs28b0obz9easys4w2ystji3u
 
 Make sure you leave the 'oauth:' there, including the ':'.
 

--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -47,7 +47,7 @@
 #undef global
 static Function *global = NULL, *server_funcs = NULL;
 
-static p_tcl_bind_list H_ccht, H_cmsg, H_htgt, H_wspr, H_wspm, H_rmst, H_usst, H_untc;
+static p_tcl_bind_list H_ccht, H_cmsg, H_htgt, H_wspr, H_wspm, H_rmst, H_usst, H_usrntc;
 
 twitchchan_t *twitchchan = NULL;
 static int keepnick;
@@ -285,9 +285,9 @@ static int check_tcl_usernotice(char *chan, char *tags) {
   char mask[TOTALTAGMAX + 200]; /* tags + channel */
 
   snprintf(mask, sizeof mask, "%s %s", chan, tags);
-  Tcl_SetVar(interp, "_untc1", chan, 0);
-  Tcl_SetVar(interp, "_untc2", tags, 0);
-  x = check_tcl_bind(H_untc, mask, NULL, " $_untc1 $_untc2",
+  Tcl_SetVar(interp, "_usrntc1", chan, 0);
+  Tcl_SetVar(interp, "_usrntc2", tags, 0);
+  x = check_tcl_bind(H_usrntc, mask, NULL, " $_usrntc1 $_usrntc2",
         MATCH_MASK | BIND_STACKABLE);
   return (x == BIND_EXEC_LOG);
 }
@@ -835,7 +835,7 @@ static char *twitch_close()
   del_bind_table(H_wspm);
   del_bind_table(H_rmst);
   del_bind_table(H_usst);
-  del_bind_table(H_untc);
+  del_bind_table(H_usrntc);
   module_undepend(MODULE_NAME);
   return NULL;
 }
@@ -854,7 +854,7 @@ static Function twitch_table[] = {
   (Function) & H_wspm,
   (Function) & H_rmst,
   (Function) & H_usst,
-  (Function) & H_untc
+  (Function) & H_usrntc
 };
 
 char *twitch_start(Function *global_funcs)
@@ -904,7 +904,7 @@ char *twitch_start(Function *global_funcs)
   H_wspm = add_bind_table("wspm", HT_STACKABLE, twitch_3char);
   H_rmst = add_bind_table("rmst", HT_STACKABLE, twitch_3char);
   H_usst = add_bind_table("usst", HT_STACKABLE, twitch_3char);
-  H_untc = add_bind_table("untc", HT_STACKABLE, twitch_3char);
+  H_usrntc = add_bind_table("usrntc", HT_STACKABLE, twitch_3char);
 
 /* Override config setting with these values; they are required for Twitch */
   Tcl_SetVar(interp, "cap-request",


### PR DESCRIPTION
Found by: @sx66627
Patch by: Geo
Fixes: #1192, #1190

One-line summary:
Adds Twitch USERNOTICE bind

Additional description (if needed):
It's important to note; the Eggdrop console hasn't been updated to handle the long output associated with tag messages. If you're outputting the full tags to the console it will truncate the display; but the variable does indeed store the complete contents of all the tags.

Test cases demonstrating functionality (if applicable):
