### PR TITLE
(WIP) Make config CAP settings actually request capability

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -1088,8 +1088,9 @@ isvoice <nickname> [channel]
 isidentified <nickname> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: 1 if someone by the specified nickname is on the channel (or
-  any channel if no channel name is specified) and is logged in); 0 otherwise
+  Description: determine if a user is identified to irc services. WARNING: this may not be accurate depending on the server and configuration. For accurate results, the server must support (and Eggdrop must have enabled via CAP) the account-notify and extended-join capabilities, and the server must understand WHOX requests (also known as raw 354 responses)
+
+  Returns: 1 if someone by the specified nickname is on the channel (or any channel if no channel name is specified) and is logged in); 0 otherwise.
 
   Module: irc
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1187,6 +1187,9 @@ server add ssl.example.net +7000
 # To request the account-notify feature via CAP, set this to 1
 #set account-notify 0
 
+# To request the account-notify feature via CAP, set this to 1
+#set extended-join 0
+
 # To request the invite-notify feature via CAP, set this to 1
 #set invite-notify 0
 


### PR DESCRIPTION
Config settings didn't actually request the CAP capabilities they represented
Clarify documentation around isidentified

Found by: Sensiva
Patch by: Geo
Fixes: #1198 
