### PR TITLE
Add server list Tcl command

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -200,6 +200,15 @@ server remove <ip/host> [[+]port]
 
   Module: server
 
+^^^^^^^^^^^
+server list
+^^^^^^^^^^^
+
+  Description: lists all servers currently added to the bots internal server list
+
+  Returns: A list of lists in the format {{hostname} {port} {password}}
+
+  Module: server
 
 User Record Manipulation Commands
 ---------------------------------

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -448,15 +448,29 @@ static int tcl_server STDVAR {
   int ret;
   char s[7];
   struct server_list *z;
-
+  Tcl_Obj *server;
 
   BADARGS(2, 5, " subcommand host ?port ?password??");
   if (!strcmp(argv[1], "add")) {
     ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");
+    if (!ret) {
+      server = Tcl_NewListObj(0, NULL);
+      Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj(argv[2], -1));
+      if ((argc >= 4) && argv[3]) {
+        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj(argv[3], -1));
+      } else {
+        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj("", -1));
+      }
+      if ((argc >= 5) && argv[4]) {
+        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj(argv[3], -1));
+      } else {
+        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj("", -1));
+      }
+      Tcl_SetObjResult(irp, server);
+    }
   } else if (!strcmp(argv[1], "remove")) {
     ret = del_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "");
   } else if (!strcmp(argv[1], "list")) {
-    Tcl_Obj *server;
     Tcl_Obj *servers = Tcl_NewListObj(0, NULL);
     z = serverlist;
     while(z != NULL) {

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -450,7 +450,7 @@ static int tcl_server STDVAR {
   struct server_list *z;
   Tcl_Obj *server;
 
-  BADARGS(2, 5, " subcommand host ?port ?password??");
+  BADARGS(2, 5, " subcommand ?host ?port? ?password?");
   if (!strcmp(argv[1], "add")) {
     ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");
     if (!ret) {

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -462,7 +462,7 @@ static int tcl_server STDVAR {
         Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj("", -1));
       }
       if ((argc >= 5) && argv[4]) {
-        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj(argv[3], -1));
+        Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj(argv[4], -1));
       } else {
         Tcl_ListObjAppendElement(irp, server, Tcl_NewStringObj("", -1));
       }

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -473,7 +473,7 @@ static int tcl_server STDVAR {
     return TCL_OK;
   } else {
     Tcl_AppendResult(irp, "Invalid subcommand: ", argv[1],
-        ". Should be \"add\" or \"remove\"", NULL);
+        ". Should be \"add\", \"remove\", or \"list\"", NULL);
     return TCL_ERROR;
   }
   if (ret == 0) {


### PR DESCRIPTION
Found by:
Patch by:
Fixes: 

One-line summary:
Add server list Tcl command

Additional description (if needed):
Adds server list command (similar to server add/server remove), returns a list of all servers added to the bot as a list of lists; in the format {{host} {port} {password}}. The port will have a + prepended if it is an SSL-enabled port

Test cases demonstrating functionality (if applicable):
