### PR TITLE
Check supported SASL mechanisms before sending

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2067,15 +2067,15 @@ static void server_report(int idx, int details)
   if (hq.tot)
     dprintf(idx, "    %s %d%% (%d msgs)\n", IRC_HELPQUEUE,
             (int) ((float) (hq.tot * 100.0) / (float) maxqmsg), (int) hq.tot);
-    current = cap;
-    buf[0] = 0;
-    while (current != NULL) {
-      if (current->enabled) {
-        strncat(buf, current->name, (sizeof buf - strlen(buf)));
-        strncat(buf, " ", (sizeof buf - strlen(buf)));
-      }
-      current = current->next;
+  current = cap;
+  buf[0] = 0;
+  while (current != NULL) {
+    if (current->enabled) {
+      strncat(buf, current->name, (sizeof buf - strlen(buf)));
+      strncat(buf, " ", (sizeof buf - strlen(buf)));
     }
+    current = current->next;
+  }
   dprintf(idx, "    Active CAP negotiations: %s\n", (strlen(buf) > 0) ?
             buf : "None" );
   if (details) {

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1512,6 +1512,13 @@ static int got900(char *from, char *msg)
   return 0;
 }
 
+/* Got 901: RPL_LOGGEDOUT, user account is logged out */
+static int got901(char *from, char *msg)
+{
+  putlog(LOG_SERV, "*", "SASL: Account has been logged out");
+  return 0;
+}
+
 static int sasl_error(char *msg)
 {
   putlog(LOG_SERV, "*", "SASL: %s", msg);
@@ -1524,11 +1531,13 @@ static int sasl_error(char *msg)
   return 1;
 }
 
-/* Got 904: ERR_SASLFAIL, invalid credentials (or something not covered)
-   Got 905: ERR_SASLTOOLONG, AUTHENTICATE command was too long (>400 bytes)
-   Got 906: ERR_SASL_ABORTED, sent AUTHENTICATE command with * as parameter
+/* Got 902: ERR_NICKLOCKED, authentication fails b/c nick is unavailable
+ * Got 904: ERR_SASLFAIL, invalid credentials (or something not covered)
+ * Got 905: ERR_SASLTOOLONG, AUTHENTICATE command was too long (>400 bytes)
+ * Got 906: ERR_SASL_ABORTED, sent AUTHENTICATE command with * as parameter
+ * For easy grepping, this covers got902 got904 got905 got906
  */
-static int got904905and906(char *from, char *msg)
+static int gotsasl90X(char *from, char *msg)
 {
   newsplit(&msg); /* nick */
   fixcolon(msg);
@@ -1543,6 +1552,13 @@ static int got903(char *from, char *msg)
   putlog(LOG_SERV, "*", "SASL: %s", msg);
   dprintf(DP_MODE, "CAP END\n");
   sasl_timeout_time = 0;
+  return 0;
+}
+
+/* Got 907: ERR_SASLALREADY, already authenticated */
+static int got907(char *from, char *msg)
+{
+  putlog(LOG_SERV, "*", "SASL: Already authenticated");
   return 0;
 }
 
@@ -1738,7 +1754,7 @@ static int add_capabilities(char *msg) {
           y->next = newvalue;
         else
           newcap->value = newvalue;
-        newcap->value->next = 0;
+        newvalue->next = 0;
         strlcpy(newvalue->name, valptr, sizeof(newvalue->name));
         valptr = strtok_r(NULL, ",", &saveptr3);
       }
@@ -1753,6 +1769,19 @@ static int add_capabilities(char *msg) {
       cap = newcap;
     capptr = strtok_r(NULL, " ", &saveptr1);
     newcap = NULL;
+  }
+  return 0;
+}
+
+/* Helper function to see if given value exists for a capability */
+static int checkvalue(struct cap_values *list, const char *name) {
+  struct cap_values *current = list;
+
+  while (current != NULL) {
+    if (!strcmp(name, current->name)) {
+      return 1;
+    }
+    current = current->next;
   }
   return 0;
 }
@@ -1875,11 +1904,17 @@ static int gotcap(char *from, char *msg) {
           }
 
           if ((sasl) && (!strcmp(current->name, "sasl")) && (current->enabled)) {
-              putlog(LOG_SERV, "*", "DOING THINGS FOR SASL!");
+            putlog(LOG_DEBUG, "*", "SASL: Starting authentication process");
+            if (!checkvalue(current->value, SASL_MECHANISMS[sasl_mechanism])) {
+              snprintf(buf, sizeof buf,
+                  "%s authentication method not supported",
+                  SASL_MECHANISMS[sasl_mechanism]);
+              return sasl_error(buf);
+            }
 #ifndef HAVE_EVP_PKEY_GET1_EC_KEY
             if (sasl_mechanism != SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) {
 #endif
-              putlog(LOG_DEBUG, "*", "SASL: put AUTHENTICATE %s",
+              putlog(LOG_DEBUG, "*", "SASL: AUTHENTICATE %s",
                   SASL_MECHANISMS[sasl_mechanism]);
               dprintf(DP_MODE, "AUTHENTICATE %s\n", SASL_MECHANISMS[sasl_mechanism]);
               sasl_timeout_time = sasl_timeout;
@@ -1952,10 +1987,13 @@ static cmd_t my_raw_binds[] = {
   {"442",          "",   (IntFunc) got442,          NULL},
   {"465",          "",   (IntFunc) got465,          NULL},
   {"900",          "",   (IntFunc) got900,          NULL},
+  {"901",          "",   (IntFunc) got901,          NULL},
+  {"902",          "",   (IntFunc) gotsasl90X,      NULL},
   {"903",          "",   (IntFunc) got903,          NULL},
-  {"904",          "",   (IntFunc) got904905and906, NULL},
-  {"905",          "",   (IntFunc) got904905and906, NULL},
-  {"906",          "",   (IntFunc) got904905and906, NULL},
+  {"904",          "",   (IntFunc) gotsasl90X,      NULL},
+  {"905",          "",   (IntFunc) gotsasl90X,      NULL},
+  {"906",          "",   (IntFunc) gotsasl90X,      NULL},
+  {"907",          "",   (IntFunc) got907,          NULL},
   {"908",          "",   (IntFunc) got908,          NULL},
   {"NICK",         "",   (IntFunc) gotnick,         NULL},
   {"ERROR",        "",   (IntFunc) goterror,        NULL},


### PR DESCRIPTION
Patch by: Geo

One-line summary: Add full SASL 302 support


Additional description (if needed):
...and a small CAP302 fix

Test Cases:
Supported server method (PLAIN):
```
[03:04:45] CAP: adding capability record: sasl=PLAIN,ECDSA-NIST256P-CHALLENGE,EXTERNAL
[03:04:45] CAP: Adding value PLAIN to capability sasl
[03:04:45] CAP: Adding value ECDSA-NIST256P-CHALLENGE to capability sasl
[03:04:45] CAP: Adding value EXTERNAL to capability sasl
.........
[03:04:46] SASL: Starting authentication process
[03:04:46] SASL: AUTHENTICATE PLAIN
[03:04:46] [m->] AUTHENTICATE PLAIN
```

Unsupported server method (NIST256)
```
[03:03:16] CAP: Adding value PLAIN to capability sasl
[03:03:16] CAP: Adding value EXTERNAL to capability sasl
[03:03:16] CAP: Adding value SCRAM-SHA-256 to capability sasl
.........
[03:03:16] SASL: Starting authentication process
[03:03:16] SASL: ECDSA-NIST256P-CHALLENGE authentication method not supported
```