### PR TITLE
Add values argument to Tcl cap command

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -156,13 +156,13 @@ clearqueue <queue>
 
   Module: server
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-cap <ls/req/enabled/raw> [arg]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+cap <ls/values/req/enabled/raw> [arg]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities Eggdrop is internally tracking as supported by the server, "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server, "req" will request the capabilities listed in "arg" from the server, and raw will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
+  Description: displays CAP status or sends a raw CAP command to the server. "ls" will list the capabilities Eggdrop is internally tracking as supported by the server. "values" will list all capabilities and their associated CAP 302 values (if any) as a key/value pair, and "values" with a capability name as arg will list the values associated for the capability. "enabled" will list the capabilities Eggdrop is internally tracking as negotiated with the server. "req" will request the capabilities listed in "arg" from the server. "raw" will send a raw CAP command to the server. The arg field is a single argument, and should be submitted as a single string. For example, to request capabilities foo and bar, you would use [cap req "foo bar"], and for example purposes, sending the same request as a raw command would be [cap raw "REQ :foo bar"].
 
-  Returns: a list of CAP capabilities for the "enabled" and "ls" sub-commands; otherwise nothing.
+  Returns: a list of CAP capabilities for the "enabled" and "ls" sub-commands; a dict of capability/value pairs for the "values" command or a list if "values" if followed by an argument; otherwise nothing.
 
   Module: server
 

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -293,6 +293,9 @@ static int tcl_cap STDVAR {
     values = Tcl_NewListObj(0, NULL);
     current = cap;
     while (current != NULL) {
+      if ((argc == 3) &&(!strcasecmp(argv[2], current->name))) {
+        found = 1;
+      }
       currentvalue = current->value;
       while (currentvalue != NULL) {
         if (argc == 3) {
@@ -300,7 +303,6 @@ static int tcl_cap STDVAR {
             /* Don't get confused, we use the capes var but its really values */
             Tcl_ListObjAppendElement(irp, capes,
                     Tcl_NewStringObj(currentvalue->name, -1));
-            found = 1;
           }
         } else {
           Tcl_ListObjAppendElement(irp, values,


### PR DESCRIPTION
Found by: thommey
Patch by: Geo

One-line summary: Add "values" sub-command option to cap command.


Additional description (if needed):
New Tcl option lists values associated with each capability in a variety of formats

Test cases demonstrating functionality (if applicable):
```
.tcl cap values
Tcl: account-notify {} away-notify {} chghost {} extended-join {} multi-prefix {} sasl {PLAIN ECDSA-NIST256P-CHALLENGE EXTERNAL} tls {} account-tag {} cap-notify {} echo-message {} solanum.chat/identify-msg {} solanum.chat/oper {} solanum.chat/realhost {}

.tcl cap ls
Tcl: account-notify away-notify chghost extended-join multi-prefix sasl tls account-tag cap-notify echo-message solanum.chat/identify-msg solanum.chat/oper solanum.chat/realhost

.tcl cap values sasl
Tcl: PLAIN ECDSA-NIST256P-CHALLENGE EXTERNAL

.tcl cap values chghost
Tcl: 

.tcl cap values foo
Tcl error: Capability "foo" is not enabled
```

