### PR TITLE
Don't require message-tags to check for message-tags

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2188,7 +2188,7 @@ static Function server_table[] = {
   /* 12 - 15 */
   (Function) match_my_nick,
   (Function) check_tcl_flud,
-  /* Empty */
+  (Function) NULL,              /* was msgtag in 1.9.0, 1.9.1           */
   (Function) & answer_ctcp,     /* int                                  */
   /* 16 - 19 */
   (Function) & trigger_on_ignore, /* int                                */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -95,7 +95,6 @@ static int kick_method;
 static int optimize_kicks;
 static int msgrate;             /* Number of seconds between sending
                                  * queued lines to server. */
-static int msgtag;              /* Enable IRCv3 message-tags capability    */
 #ifdef TLS
 static int use_ssl;             /* Use SSL for the next server connection? */
 static int tls_vfyserver;       /* Certificate validation mode for servrs  */
@@ -2189,7 +2188,7 @@ static Function server_table[] = {
   /* 12 - 15 */
   (Function) match_my_nick,
   (Function) check_tcl_flud,
-  (Function) & msgtag,          /* int                                  */
+  /* Empty */
   (Function) & answer_ctcp,     /* int                                  */
   /* 16 - 19 */
   (Function) & trigger_on_ignore, /* int                                */

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -51,7 +51,7 @@
 /* 12 - 15 */
 #define match_my_nick ((int(*)(char *))server_funcs[12])
 #define check_tcl_flud ((int (*)(char *,char *,struct userrec *,char *,char *))server_funcs[13])
-#define msgtag (*(int *)(server_funcs[14]))
+/* Empty, formally msgtag */
 #define answer_ctcp (*(int *)(server_funcs[15]))
 /* 16 - 19 */
 #define trigger_on_ignore (*(int *)(server_funcs[16]))

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1652,7 +1652,7 @@ struct capability *find_capability(char *capname) {
   struct capability *current = cap;
 
   while (current != NULL) {
-    if (!strcmp(capname, current->name)) {
+    if (!strcasecmp(capname, current->name)) {
       return current;
     }
     current = current->next;
@@ -1896,16 +1896,16 @@ static int gotcap(char *from, char *msg) {
           remove = 1;
           splitstr++;
         }
-        if (!strcmp(splitstr, current->name)) {
+        if (!strcasecmp(splitstr, current->name)) {
           if (remove) {
             current->enabled = 0;
           } else {
             current->enabled = 1;
           }
 
-          if ((sasl) && (!strcmp(current->name, "sasl")) && (current->enabled)) {
+          if ((sasl) && (!strcasecmp(current->name, "sasl")) && (current->enabled)) {
             putlog(LOG_DEBUG, "*", "SASL: Starting authentication process");
-            if (!checkvalue(current->value, SASL_MECHANISMS[sasl_mechanism])) {
+            if (current->value && !checkvalue(current->value, SASL_MECHANISMS[sasl_mechanism])) {
               snprintf(buf, sizeof buf,
                   "%s authentication method not supported",
                   SASL_MECHANISMS[sasl_mechanism]);
@@ -1939,7 +1939,7 @@ static int gotcap(char *from, char *msg) {
     }
     current = find_capability("sasl");
     /* Let SASL code send END if SASL is enabled, to avoid race condition */
-    if (!current->enabled) {
+    if (!current || !current->enabled) {
       dprintf(DP_MODE, "CAP END\n");
     }
     current = cap;

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -226,11 +226,13 @@ static int tcl_tagmsg STDVAR {
   char tag[CLITAGMAX-9];    /* minus @, TAGMSG and two spaces */
   char tagdict[CLITAGMAX-9];
   char target[MSGMAX];
+  struct capability *current = 0;
   char *p;
   int taglen = 0, i = 1;
   BADARGS(3, 3, " tag target");
 
-  if (!msgtag) {
+  current = find_capability("message-tags");
+  if ((!current) || (!(current->enabled))) {
     Tcl_AppendResult(irp, "message-tags not enabled, cannot send tag", NULL);
     return TCL_ERROR;
   }


### PR DESCRIPTION
Found by: DasBrain, Lord255
Patch by: Geo 
Fixes: #1179 

One-line summary: 
Don't require message-tags to check for message-tags

Additional description (if needed):
account-tag, server-time and batch can all use message-tags without the message-tags capability actually being enabled. The previous implementation incorrectly assumed any capability requiring message-tags would... well, would require message-tags to be enabled. Eggdrop would then enter a bad state. This corrects the implementation to always check for message-tags present in a message, rather than only if message-tags is enabled.


Test cases demonstrating functionality (if applicable):
account-tags works without message-tags enabled
```
.tcl cap enabled
Tcl: account-notify account-tag away-notify chghost extended-join invite-notify sasl
[20:02:18] [@] :Foo!~u@tffc6xfgjae7q.oragono ACCOUNT Bar
[20:02:18] Foo!~u@tffc6xfgjae7q.oragono has logged into account Bar
[20:02:18] triggering bind testproc
[20:02:18] Foo is Bar!
```