### PR TITLE
Fix missing ACCOUNT bind value in docs

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -3492,7 +3492,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   bind account <flags> <mask> <proc>
 
-  procname <nick> <user> <hand> <account>
+  procname <nick> <user> <hand> <chan> <account>
 
   Description: triggered when Eggdrop receives an ACCOUNT message. The mask for the bind is in the format "#channel nick!user@hostname.com account" where channel is the channel the user was found on when the bind was triggered, the hostmask is the user's hostmask, and account is the account name the user is logging in to, or "" for logging out. The mask argument can accept wildcards. For the proc, nick is the nickname of the user logging into/out of an account, user is the user@host.com hostmask, hand is the handle of the user (or * if none), and account is the name of the account the user logged in to (or "" if the user logged out of an account).
 


### PR DESCRIPTION
Found by: Geo
Fixes: #1211 

Test:

.tcl proc foo {nick user hand acct} {putlog "$nick is ${acct}!"}
[execute bind]
[19:51:49] Tcl error [foo]: wrong # args: should be "foo nick user hand acct"
wrong # args: should be "foo nick user hand acct"
    while executing
"foo $_acnt1 $_acnt2 $_acnt3 $_acnt4 $_acnt5"


.tcl proc foo {nick user hand chan acct} {putlog "$nick is ${acct}!"}
[execute bind]
[20:02:18] Foo is Bar!

