### PR TITLE
Fix nat-ip bug

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -109,8 +109,6 @@ extern struct dcc_table DCC_CHAT, DCC_BOT, DCC_LOST, DCC_SCRIPT, DCC_BOT_NEW,
                         DCC_IDENTWAIT, DCC_DNSWAIT;
 #endif
 
-#define iptolong(a) (0xffffffff & (long) (htonl((unsigned long) a)))
-
 #ifdef IPV6
 # define setsnport(s, p) do {                                           \
   if ((s).family == AF_INET6)                                           \

--- a/src/modules.c
+++ b/src/modules.c
@@ -345,7 +345,7 @@ Function global_table[] = {
   (Function) & tls_vfyclients,    /* int                                 */
   (Function) & tls_vfydcc,        /* int                                 */
 #else
-  (Function) 0,                   /* was natip -- use getmyip() instead  */
+  (Function) 0,                   /* was natip                           */
   (Function) 0,                   /* was myip -- use getvhost() instead  */
 #endif
   (Function) origbotname,         /* char *                              */

--- a/src/net.c
+++ b/src/net.c
@@ -1699,7 +1699,6 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
   struct in_addr ia;
 
   value = Tcl_GetVar2(irp, name1, name2, TCL_GLOBAL_ONLY);
-
   if (*value) {
     r = inet_pton(AF_INET, value, &ia);
     if (!r) {
@@ -1710,7 +1709,7 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
     if (r < 0) {
       if (!online_since)
         fatal("ERROR: inet_pton(): nat-ip", 0);
-      putlog(LOG_MISC, "*", "ERROR: inet_pton(): nat-ip", value);
+      putlog(LOG_MISC, "*", "ERROR: inet_pton(): nat-ip %s", value);
       return strerror(errno);
     }
     snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));

--- a/src/net.c
+++ b/src/net.c
@@ -1699,26 +1699,23 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
   struct in_addr ia;
 
   value = Tcl_GetVar2(irp, name1, name2, TCL_GLOBAL_ONLY);
-  strlcpy(nat_ip, value, sizeof nat_ip);
-  if (*nat_ip) {
-    r = inet_pton(AF_INET, nat_ip, &ia);
+
+  if (*value) {
+    r = inet_pton(AF_INET, value, &ia);
     if (!r) {
-      putlog(LOG_MISC, "*",
-        "ERROR: nat-ip %s: address was not parseable in AF_INET", nat_ip);
       if (!online_since)
-        fatal("ERROR: config file", 0);
-      *nat_ip_string = '\0';
-      return NULL;
+        fatal("ERROR: config file: nat-ip address was not parseable in AF_INET", 0);
+      return "address was not parseable in AF_INET";
     }
     if (r < 0) {
-      putlog(LOG_MISC, "*", "ERROR: nat-ip %s: %s", nat_ip, strerror(errno));
       if (!online_since)
-        fatal("ERROR: config file", 0);
-      *nat_ip_string = '\0';
-      return NULL;
+        fatal("ERROR: inet_pton(): nat-ip", 0);
+      putlog(LOG_MISC, "*", "ERROR: inet_pton(): nat-ip", value);
+      return strerror(errno);
     }
     snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));
   } else
     *nat_ip_string = '\0';
+  strlcpy(nat_ip, value, sizeof nat_ip);
   return NULL;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -1705,9 +1705,9 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
     if (!r) {
       putlog(LOG_MISC, "*",
         "ERROR: nat-ip %s: address was not parseable in AF_INET", nat_ip);
-      *nat_ip_string = '\0';
       if (!online_since)
         fatal("ERROR: config file", 0);
+      *nat_ip_string = '\0';
       return NULL;
     }
     if (r < 0) {

--- a/src/net.c
+++ b/src/net.c
@@ -1707,14 +1707,14 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
         "ERROR: nat-ip %s: address was not parseable in AF_INET", nat_ip);
       *nat_ip_string = '\0';
       if (!online_since)
-        fatal("bogus nat-ip", 0);
+        fatal("ERROR: config file", 0);
       return NULL;
     }
     if (r < 0) {
       putlog(LOG_MISC, "*", "ERROR: nat-ip %s: %s", nat_ip, strerror(errno));
-      *nat_ip_string = '\0';
       if (!online_since)
-        fatal("bogus nat-ip", 0);
+        fatal("ERROR: config file", 0);
+      *nat_ip_string = '\0';
       return NULL;
     }
     snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));

--- a/src/net.c
+++ b/src/net.c
@@ -721,7 +721,7 @@ int getdccaddr(sockname_t *addr, char *s, size_t l)
  */
 int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
 {
-  char h[121];
+  char h[256];
   sockname_t name, *r = &name;
   int af = AF_UNSPEC;
 #ifdef IPV6

--- a/src/net.c
+++ b/src/net.c
@@ -797,7 +797,7 @@ int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
         strlcpy(s, nat_ip_string, l);
       else {
         memcpy(&ip, r->addr.s6.sin6_addr.s6_addr + 12, sizeof ip);
-        egg_snprintf(s, l, "%u", ntohl(ip));
+        snprintf(s, l, "%u", ntohl(ip));
       }
     } else
       inet_ntop(AF_INET6, &r->addr.s6.sin6_addr, s, l);

--- a/src/net.c
+++ b/src/net.c
@@ -1704,8 +1704,8 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
     r = inet_pton(AF_INET, value, &ia);
     if (!r) {
       if (!online_since)
-        fatal("ERROR: config file: nat-ip address was not parseable in AF_INET", 0);
-      return "address was not parseable in AF_INET";
+        fatal("ERROR: nat-ip was not a valid IPv4 address", 0);
+      return "nat-ip was not a valid IPv4 address";
     }
     if (r < 0) {
       if (!online_since)

--- a/src/net.c
+++ b/src/net.c
@@ -793,11 +793,12 @@ int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
   if (r->family == AF_INET6) {
     if (IN6_IS_ADDR_V4MAPPED(&r->addr.s6.sin6_addr) ||
         IN6_IS_ADDR_UNSPECIFIED(&r->addr.s6.sin6_addr)) {
-      memcpy(&ip, r->addr.s6.sin6_addr.s6_addr + 12, sizeof ip);
       if (*nat_ip_string)
         strlcpy(s, nat_ip_string, l);
-      else
+      else {
+        memcpy(&ip, r->addr.s6.sin6_addr.s6_addr + 12, sizeof ip);
         egg_snprintf(s, l, "%u", ntohl(ip));
+      }
     } else
       inet_ntop(AF_INET6, &r->addr.s6.sin6_addr, s, l);
   } else

--- a/src/net.c
+++ b/src/net.c
@@ -1704,8 +1704,8 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
     r = inet_pton(AF_INET, value, &ia);
     if (!r) {
       if (!online_since)
-        fatal("ERROR: nat-ip was not a valid IPv4 address", 0);
-      return "nat-ip was not a valid IPv4 address";
+        fatal("ERROR: nat-ip is not a valid IPv4 address", 0);
+      return "nat-ip is not a valid IPv4 address";
     }
     if (r < 0) {
       if (!online_since)

--- a/src/net.c
+++ b/src/net.c
@@ -1715,6 +1715,5 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
     snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));
   } else
     *nat_ip_string = '\0';
-  strlcpy(nat_ip, value, sizeof nat_ip);
   return NULL;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -1718,8 +1718,7 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
       return NULL;
     }
     snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));
-  }
-  else
+  } else
     *nat_ip_string = '\0';
   return NULL;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -797,7 +797,7 @@ int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
         strlcpy(s, nat_ip_string, l);
       else {
         memcpy(&ip, r->addr.s6.sin6_addr.s6_addr + 12, sizeof ip);
-        snprintf(s, l, "%u", ntohl(ip));
+        snprintf(s, l, "%" PRIu32, ntohl(ip));
       }
     } else
       inet_ntop(AF_INET6, &r->addr.s6.sin6_addr, s, l);
@@ -807,7 +807,7 @@ int getdccfamilyaddr(sockname_t *addr, char *s, size_t l, int restrict_af)
     if (*nat_ip_string)
       strlcpy(s, nat_ip_string, l);
     else
-      snprintf(s, l, "%u", ntohl(r->addr.s4.sin_addr.s_addr));
+      snprintf(s, l, "%" PRIu32, ntohl(r->addr.s4.sin_addr.s_addr));
   }
   return 1;
 }
@@ -1713,7 +1713,7 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
       putlog(LOG_MISC, "*", "ERROR: inet_pton(): nat-ip %s", value);
       return strerror(errno);
     }
-    snprintf(nat_ip_string, sizeof nat_ip_string, "%u", ntohl(ia.s_addr));
+    snprintf(nat_ip_string, sizeof nat_ip_string, "%" PRIu32, ntohl(ia.s_addr));
   } else
     *nat_ip_string = '\0';
   return NULL;

--- a/src/proto.h
+++ b/src/proto.h
@@ -271,7 +271,6 @@ int crypto_verify(const char *, const char *);
 
 /* net.c */
 IP my_atoul(char *);
-unsigned long iptolong(IP);
 void setsock(int, int);
 int allocsock(int, int);
 int alloctclsock(int, int, Tcl_FileProc *, ClientData);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -41,14 +41,13 @@ typedef struct {
 } intinfo;
 
 
-extern time_t online_since;
+extern time_t now, online_since;
 
 extern char origbotname[], botuser[], motdfile[], admin[], userfile[],
             firewall[], helpdir[], notify_new[], vhost[], moddir[], owner[],
-            network[], botnetnick[], bannerfile[], egg_version[], natip[],
+            network[], botnetnick[], bannerfile[], egg_version[], nat_ip[],
             configfile[], logfile_suffix[], log_ts[], textdir[], pid_file[],
             listen_ip[], stealth_prompt[], language[];
-
 
 extern int flood_telnet_thr, flood_telnet_time, shtime, share_greet,
            require_p, keep_all_logs, allow_new_telnets, stealth_telnets,
@@ -95,8 +94,7 @@ int quiet_save = 0;
 int strtot = 0;
 int handlen = HANDLEN;
 
-extern Tcl_VarTraceProc traced_myiphostname, traced_remove_pass;
-extern time_t now;
+extern Tcl_VarTraceProc traced_myiphostname, traced_natip, traced_remove_pass;
 
 int expmem_tcl()
 {
@@ -429,7 +427,7 @@ static tcl_strings def_tcl_strings[] = {
   {"listen-addr",     listen_ip,      120,                     0},
   {"network",         network,        40,                      0},
   {"whois-fields",    whois_fields,   1024,                    0},
-  {"nat-ip",          natip,          120,                     0},
+  {"nat-ip",          nat_ip,         INET_ADDRSTRLEN - 1,     0},
   {"username",        botuser,        USERLEN,                 0},
   {"version",         egg_version,    0,                       0},
   {"firewall",        firewall,       120,                     0},
@@ -514,8 +512,9 @@ static void init_traces()
   add_tcl_coups(def_tcl_coups);
   add_tcl_strings(def_tcl_strings);
   add_tcl_ints(def_tcl_ints);
-  Tcl_TraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
   Tcl_TraceVar(interp, "my-hostname", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
+  Tcl_TraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
+  Tcl_TraceVar(interp, "nat-ip", TCL_TRACE_WRITES, traced_natip, NULL);
   Tcl_TraceVar(interp, "remove-pass", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES, traced_remove_pass, NULL);
 }
 
@@ -524,8 +523,9 @@ void kill_tcl()
   rem_tcl_coups(def_tcl_coups);
   rem_tcl_strings(def_tcl_strings);
   rem_tcl_ints(def_tcl_ints);
-  Tcl_UntraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
   Tcl_UntraceVar(interp, "my-hostname", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
+  Tcl_UntraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
+  Tcl_UntraceVar(interp, "nat-ip", TCL_TRACE_WRITES, traced_natip, NULL);
   Tcl_UntraceVar(interp, "remove-pass", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES, traced_remove_pass, NULL);
   kill_bind();
   Tcl_DeleteInterp(interp);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -514,7 +514,7 @@ static void init_traces()
   add_tcl_ints(def_tcl_ints);
   Tcl_TraceVar(interp, "my-hostname", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
   Tcl_TraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
-  Tcl_TraceVar(interp, "nat-ip", TCL_TRACE_WRITES, traced_natip, NULL);
+  Tcl_TraceVar(interp, "nat-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_natip, NULL);
   Tcl_TraceVar(interp, "remove-pass", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES, traced_remove_pass, NULL);
 }
 
@@ -525,7 +525,7 @@ void kill_tcl()
   rem_tcl_ints(def_tcl_ints);
   Tcl_UntraceVar(interp, "my-hostname", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
   Tcl_UntraceVar(interp, "my-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, NULL);
-  Tcl_UntraceVar(interp, "nat-ip", TCL_TRACE_WRITES, traced_natip, NULL);
+  Tcl_UntraceVar(interp, "nat-ip", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_natip, NULL);
   Tcl_UntraceVar(interp, "remove-pass", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES, traced_remove_pass, NULL);
   kill_bind();
   Tcl_DeleteInterp(interp);


### PR DESCRIPTION
Found by: Fatale_gg
Patch by: michaelortmann
Fixes: #1181

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
**Test1:**
eggdrop.conf:
`#set nat-ip`
```
/ctcp BotA chat
*** DCC CHAT (chat) request received from BotA [127.0.0.1:3333]
```
**Test2:**
`set nat-ip ""`
```
/ctcp BotA chat
*** DCC CHAT (chat) request received from BotA [127.0.0.1:3333]
```
**Test3:**
eggdrop.conf:
`set nat-ip "192.168.42.1"`
```
/ctcp BotA chat
*** DCC CHAT (chat) request received from BotA [192.168.42.1:3333]
```
```
.set nat-ip 192.168.23.1
[12:25:52] tcl: builtin dcc call: *dcc:set -HQ 1 nat-ip 192.168.23.1
[12:25:52] #-HQ# set nat-ip 192.168.23.1
Ok, set.
.set nat-ip
[12:26:45] tcl: builtin dcc call: *dcc:set -HQ 1 nat-ip
[12:26:45] #-HQ# set nat-ip
Currently: 192.168.23.1
.set nat-ip test
[12:27:08] tcl: builtin dcc call: *dcc:set -HQ 1 nat-ip test
[12:27:08] #-HQ# set nat-ip test
Error: can't set "nat-ip": address was not parseable in AF_INET
.set nat-ip
[12:27:12] tcl: builtin dcc call: *dcc:set -HQ 1 nat-ip
[12:27:12] #-HQ# set nat-ip
Currently: 192.168.23.1
```
**Test4:**
eggdrop.conf:
`set nat-ip "test"`
```
$ ./eggdrop -t BotA.conf 

Eggdrop v1.9.1+monitor (C) 1997 Robey Pointer (C) 1999-2021 Eggheads
--- Loading eggdrop v1.9.1+monitor (Sun Oct 31 2021)
* ERROR: config file: nat-ip address was not parseable in AF_INET
```
**Test5:**
```
$ ./configure --disable-ipv6
[...]
$ ./eggdrop -v
Eggdrop v1.9.1+monitor (C) 1997 Robey Pointer (C) 1999-2021 Eggheads
Configure flags: '--disable-ipv6'
Compiled with: TLS, handlen=32
```
eggdrop.conf:
`#set nat-ip`
```
/ctcp BotA chat
*** DCC CHAT (chat) request received from BotA [127.0.0.1:3333]
```
