### PR TITLE
fix char array len for listen-addr

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -55,7 +55,7 @@ extern unsigned long otraffic_irc_today, otraffic_bn_today, otraffic_dcc_today,
                      otraffic_unknown_today;
 
 char natip[121] = "";         /* Public IPv4 to report for systems behind NAT */
-char listen_ip[121] = "";     /* IP (or hostname) for listening sockets       */
+char listen_ip[256] = "";     /* IP (or hostname) for listening sockets       */
 char vhost[121] = "";         /* IPv4 vhost for outgoing connections          */
 #ifdef IPV6
 char vhost6[121] = "";        /* IPv6 vhost for outgoing connections          */

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -413,7 +413,7 @@ static tcl_strings def_tcl_strings[] = {
   {"ssl-cafile",      tls_cafile,     120,           STR_PROTECT},
   {"ssl-protocols",   tls_protocols,  60,            STR_PROTECT},
   {"ssl-dhparam",     tls_dhparam,    120,           STR_PROTECT},
-  {"ssl-ciphers",     tls_ciphers,    2048,           STR_PROTECT},
+  {"ssl-ciphers",     tls_ciphers,    2048,          STR_PROTECT},
   {"ssl-privatekey",  tls_keyfile,    120,           STR_PROTECT},
   {"ssl-certificate", tls_certfile,   120,           STR_PROTECT},
 #endif
@@ -426,7 +426,7 @@ static tcl_strings def_tcl_strings[] = {
 #ifdef IPV6
   {"vhost6",          vhost6,         120,                     0},
 #endif
-  {"listen-addr",     listen_ip,      120,                     0},
+  {"listen-addr",     listen_ip,      255,                     0},
   {"network",         network,        40,                      0},
   {"whois-fields",    whois_fields,   1024,                    0},
   {"nat-ip",          natip,          120,                     0},


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
listen-addr can be ip or hostname with max len `255 + '\0'`

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
