### PR TITLE
RAWT blocks RAW

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -3109,7 +3109,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   IMPORTANT: While not necessarily deprecated, this bind has been supplanted by the RAWT bind as of 1.9.0. You probably want to be using RAWT, not RAW.
 
-  Description: previous versions of Eggdrop required a special compile option to enable this binding, but it's now standard. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. The order of the arguments is identical to the order that the IRC server sends to the bot. The pre-processing only splits it apart enough to determine the keyword. If the proc returns 1, Eggdrop will not process the line any further (this could cause unexpected behavior in some cases). The RAW bind does not support the IRCv3 message-tags capability, please see RAWT for more information.
+  Description: previous versions of Eggdrop required a special compile option to enable this binding, but it's now standard. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. The order of the arguments is identical to the order that the IRC server sends to the bot. The pre-processing only splits it apart enough to determine the keyword. If the proc returns 1, Eggdrop will not process the line any further (this could cause unexpected behavior in some cases), although RAWT binds are processed before RAW binds (and thus, a RAW bind cannot block a RAWT bind). The RAW bind does not support the IRCv3 message-tags capability, please see RAWT for more information.
 
   Module: server
 
@@ -3486,7 +3486,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <from> <keyword> <text> <tag>
 
-  Description: similar to the RAW bind, but allows an extra field for the IRCv3 message-tags capability. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG" or "TAGMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. "tag" will be the contents, if any, of the entire tag message prefixed to the server message in a dict format, such as "msgid 890157217279768 aaa bbb". The order of the arguments is identical to the order that the IRC server sends to the bot. If the proc returns 1, Eggdrop will not process the line any further (this could cause unexpected behavior in some cases). As of 1.9.0, it is recommended to use the RAWT bind instead of the RAW bind.
+  Description: similar to the RAW bind, but allows an extra field for the IRCv3 message-tags capability. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG" or "TAGMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. "tag" will be the contents, if any, of the entire tag message prefixed to the server message in a dict format, such as "msgid 890157217279768 aaa bbb". The order of the arguments is identical to the order that the IRC server sends to the bot. If the proc returns 1, Eggdrop will not process the line any further, to include not being processed by a RAW bind (this could cause unexpected behavior in some cases). As of 1.9.0, it is recommended to use the RAWT bind instead of the RAW bind.
 
 (53) ACCOUNT (stackable)
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1135,7 +1135,7 @@ static void server_activity(int idx, char *tagmsg, int len)
   char *from, *code, *s1, *s2, *saveptr1=NULL, *saveptr2=NULL, *tagstrptr=NULL;
   char *token, *subtoken, tagstr[TOTALTAGMAX+1], tagdict[TOTALTAGMAX+1] = "";
   char *msgptr, rawmsg[RECVLINEMAX+7];
-  int taglen, i, found;
+  int taglen, i, found, ret;
 
   if (trying_server) {
     strcpy(dcc[idx].nick, "(server)");
@@ -1194,9 +1194,11 @@ static void server_activity(int idx, char *tagmsg, int len)
     putlog(LOG_RAW, "*", "[@] %s", rawmsg);
   }
   /* Check both raw and rawt, to allow backwards compatibility with older
-   * scripts */
-  check_tcl_rawt(from, code, msgptr, tagdict);
-  check_tcl_raw(from, code, msgptr);
+   * scripts. If rawt returns 1 (blocking), don't process raw binds.*/
+  ret = check_tcl_rawt(from, code, msgptr, tagdict);
+  if (!ret) {
+    check_tcl_raw(from, code, msgptr);
+  }
 }
 
 static int gotping(char *from, char *msg)


### PR DESCRIPTION
Found by: DasBrain
Patch by: Geo
Fixes: #1164

One-line summary:
Block RAW binds on return of 1 from RAWT

Additional description (if needed):
Docs state RAW and RAWT binds should block any further processing, but because they were both called, if one returned a 1, the other might not, and the line would still be processed further. This PR gives precedence to the RAWT bind over a RAW bind (in other words, if the RAWT bind returns a 1, the RAW bind will not be processed. If a RAW bind returns a 1, the RAWT still triggers). If a user encounters issues with this, it is suggested to switch their RAW binds to RAWT binds.
