### PR TITLE
Use nick/altnick/randnick on bad nickname

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -878,7 +878,7 @@ static int got432(char *from, char *msg)
   else {
     putlog(LOG_MISC, "*", IRC_BADBOTNICK);
     if (!strcmp(erroneous, origbotname)) {
-      strlcpy(nick, altnick, sizeof nick);
+      strlcpy(nick, get_altbotnick(), sizeof nick);
     } else {
       make_rand_str_from_chars(nick, sizeof nick - 1, CHARSET_LOWER_ALPHA);
     }

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -877,12 +877,14 @@ static int got432(char *from, char *msg)
            botname);
   else {
     putlog(LOG_MISC, "*", IRC_BADBOTNICK);
-    if (!keepnick) {
+    if (!strcmp(erroneous, origbotname)) {
+      strlcpy(nick, altnick, sizeof nick);
+    } else {
       make_rand_str_from_chars(nick, sizeof nick - 1, CHARSET_LOWER_ALPHA);
-      putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (using '%s' instead)",
-              erroneous, nick);
-      dprintf(DP_MODE, "NICK %s\n", nick);
     }
+    putlog(LOG_MISC, "*", "NICK IS INVALID: '%s' (using '%s' instead)",
+            erroneous, nick);
+    dprintf(DP_MODE, "NICK %s\n", nick);
     return 0;
   }
   return 0;


### PR DESCRIPTION
Fixes:  #1201 

One-line summary:
Use nick/altnick/randnick on bad nickname

Additional description (if needed):
See previous discussion in issue- this PR removes reliance on keep-nick, then (if nick is bad) tries altnick, and THEN a random nick.

Test cases demonstrating functionality (if applicable):
```
[14:11:33] [m->] NICK Bad???!
[14:11:34] [@] :calcium.libera.chat 432 * Bad???! :Erroneous Nickname
[14:11:34] Server says my nickname is invalid.
[14:11:34] NICK IS INVALID: 'Bad???!' (using 'MoBad!!??' instead)
[14:11:34] [!m] NICK MoBad!!??
[14:11:35] [m->] NICK MoBad!!??
[14:11:35] [@] :calcium.libera.chat 432 * MoBad!!?? :Erroneous Nickname
[14:11:35] Server says my nickname is invalid.
[14:11:35] NICK IS INVALID: 'MoBad!!??' (using 'peaidhidjfqqjhsv' instead)
[14:11:35] [!m] NICK peaidhidjfqqjhsv
```