### PR TITLE
change configure to make tdns default

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -72,7 +72,7 @@ AC_DEFUN([EGG_MSG_SUMMARY],
     fi
   fi
   AC_MSG_RESULT([SSL/TLS Support: $tls_enabled$ADD])
-  AC_MSG_RESULT([Threaded DNS core (beta): $tdns_enabled])
+  AC_MSG_RESULT([Threaded DNS core: $tdns_enabled])
   AC_MSG_RESULT
 ])
 
@@ -1718,18 +1718,15 @@ dnl EGG_TDNS_ENABLE
 dnl
 AC_DEFUN([EGG_TDNS_ENABLE],
 [
-  AC_MSG_CHECKING(for threaded dns core (beta))
-  AC_ARG_ENABLE([tdns], [  --enable-tdns           enable threaded DNS core (beta)],
-    [
-      AC_MSG_RESULT(yes)
-      AC_DEFINE([EGG_TDNS], [1], [Define this to enable threaded DNS core.])
-      LDFLAGS="${LDFLAGS} -lpthread"
-      tdns_enabled="yes"
-    ],
-    [
-      AC_MSG_RESULT(no)
-      tdns_enabled="no"
-    ])
+  AC_ARG_ENABLE([tdns],
+    [AS_HELP_STRING([--disable-tdns],
+      [disable threaded DNS core])],
+    [tdns_enabled="$enableval"],
+    [tdns_enabled="yes"])
+  if test "$tdns_enabled" = "yes"; then
+    AC_DEFINE([EGG_TDNS], [1], [Define this to enable threaded DNS core.])
+    LDFLAGS="${LDFLAGS} -lpthread"
+  fi
 ])
 
 

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -22,7 +22,6 @@
 ## For a complete description of each module, please consult eggdrop.conf
 loadmodule pbkdf2    ; # Generation 2 userfile encryption
 loadmodule blowfish  ; # Legacy userfile encryption support
-loadmodule dns       ; # Asynchronous DNS support
 loadmodule channels  ; # Channel support
 loadmodule server    ; # Core server support
 loadmodule ctcp      ; # CTCP functionality
@@ -305,16 +304,6 @@ set ssl-capath "/etc/ssl/"
 ## this to "". If you use 'make install' (like all good kiddies do ;), this
 ## is a fine default. Otherwise, use your head :)
 set mod-path "modules/"
-
-#### DNS MODULE ####
-
-## In case your bot has trouble finding dns servers or you want to use
-## specific ones, you can set them here. The value is a list of dns servers.
-## The order doesn't matter. You can also specify a non-standard port.
-## The default is to use the system specified dns servers. You don't need to
-## modify this setting normally. Default kernel implementations limit this list
-## to 3 servers.
-#set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
 
 #### CHANNELS MODULE ####
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -596,6 +596,42 @@ set cidr-support 0
 # text/motd) and remove its display from there.
 set show-uname 1
 
+#### DNS Settings ####
+## New in 1.9.2 - We have updated the core DNS functionality to (hopefully)
+## not use the DNS module for asynchronous DNS support. If you are having
+## with the new DNS functionality, or just want to use the DNS instead, compile
+## Eggdrop with the --disable-tdns flag (./configure --disdable-tdns). The
+## settings previously associated with the DNS module are still used in the new
+## core functionality.
+## You should not enable the DNS module!
+
+# In case your bot has trouble finding dns servers or you want to use
+# specific ones, you can set them here. The value is a list of dns servers.
+# The order doesn't matter. You can also specify a non-standard port.
+# The default is to use the system specified dns servers. You don't need to
+# modify this setting normally. Default kernel implementations limit this list
+## to 3 servers.
+#set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
+
+# Specify how long should the DNS module cache replies at maximum. The value
+# must be in seconds.
+# Note that it will respect the TTL of the reply and this is just an upper
+# boundary.
+set dns-cache 86400
+
+# Specify how long should the DNS module cache negative replies (NXDOMAIN,
+# DNS Lookup failed). The value must be in seconds.
+set dns-negcache 600
+
+# How many times should the DNS module resend the query for a given domain
+# if it receives no reply?
+set dns-maxsends 4
+
+# Specify how long should the DNS module wait for a reply before resending the
+# query. The value must be in seconds.
+set dns-retrydelay 3
+
+
 # You MUST remove this line for your bot to start. This has been added to
 # prevent you from starting up a bot that is not fully configured. Bots
 # that have not been fully configured may join the wrong IRC network, the
@@ -683,49 +719,23 @@ loadmodule blowfish
 set blowfish-use-mode cbc
 
 
-#### DNS MODULE ####
+#### DNS MODULE (Deprecated) ####
 
-# This module provides asynchronous dns support. This will avoid long
-# periods where the bot just hangs there, waiting for a hostname to
-# resolve, which will often let it timeout on all other connections.
+## This module provided asychronous dns support, but as of v1.9.2, this
+## functionality was moved into the core code. If you are having issues with the
+## new DNS functionality, or just want to continue using this module, compile
+## Eggdrop with the --disable-tdns flag (./configure --disdable-tdns). See the DNS
+## section above for more details (and the proper location to customize these
+## settings)
 #
-## New in 1.9.0 - We have updated the core DNS functionality to (hopefully)
-## not need to use this module any more. If you want to give this *BETA* 
-## capability a try, compile Eggdrop with the --enable-tdns flag 
-## (./configure --enable-tdns). We expect it will *finally* resolve some of the
-## long-standing issues Eggdrop has had with DNS and negate the need to use the
-## DNS module (In other words, if you enable the new core DNS, don't load this
-## DNS module). And lastly, if you enable the new core DNS, it will still
-## respect the dns-servers setting below, even though the DNS module is not
-## loaded.
+## You really probably don't want to uncomment this!!!!
 #
-loadmodule dns
-
-# In case your bot has trouble finding dns servers or you want to use
-# specific ones, you can set them here. The value is a list of dns servers.
-# The order doesn't matter. You can also specify a non-standard port.
-# The default is to use the system specified dns servers. You don't need to
-# modify this setting normally. Default kernel implementations limit this list
-## to 3 servers.
+#loadmodule dns
 #set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
-
-# Specify how long should the DNS module cache replies at maximum. The value
-# must be in seconds.
-# Note that it will respect the TTL of the reply and this is just an upper
-# boundary.
-set dns-cache 86400
-
-# Specify how long should the DNS module cache negative replies (NXDOMAIN,
-# DNS Lookup failed). The value must be in seconds.
-set dns-negcache 600
-
-# How many times should the DNS module resend the query for a given domain
-# if it receives no reply?
-set dns-maxsends 4
-
-# Specify how long should the DNS module wait for a reply before resending the
-# query. The value must be in seconds.
-set dns-retrydelay 3
+#set dns-cache 86400
+#set dns-negcache 600
+#set dns-maxsends 4
+#set dns-retrydelay 3
 
 #### CHANNELS MODULE ####
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -598,11 +598,12 @@ set show-uname 1
 
 #### DNS Settings ####
 ## New in 1.9.2 - We have updated the core DNS functionality to (hopefully)
-## not use the DNS module for asynchronous DNS support. If you are having
-## with the new DNS functionality, or just want to use the DNS instead, compile
-## Eggdrop with the --disable-tdns flag (./configure --disdable-tdns). The
-## settings previously associated with the DNS module are still used in the new
-## core functionality.
+## not require the DNS module for asynchronous DNS support. If you are having
+## issues with the new DNS functionality, or just want to use the DNS module
+## instead, compile Eggdrop with the --disable-tdns flag
+## (./configure --disdable-tdns). The settings previously associated with the
+## DNS module are still used in the new core functionality.
+##
 ## You should not enable the DNS module!
 
 # In case your bot has trouble finding dns servers or you want to use

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -601,36 +601,9 @@ set show-uname 1
 ## not require the DNS module for asynchronous DNS support. If you are having
 ## issues with the new DNS functionality, or just want to use the DNS module
 ## instead, compile Eggdrop with the --disable-tdns flag
-## (./configure --disdable-tdns). The settings previously associated with the
-## DNS module are still used in the new core functionality.
+## (./configure --disdable-tdns).
 ##
-## You should not enable the DNS module!
-
-# In case your bot has trouble finding dns servers or you want to use
-# specific ones, you can set them here. The value is a list of dns servers.
-# The order doesn't matter. You can also specify a non-standard port.
-# The default is to use the system specified dns servers. You don't need to
-# modify this setting normally. Default kernel implementations limit this list
-## to 3 servers.
-#set dns-servers "8.8.8.8 1.1.1.1 185.222.222.222"
-
-# Specify how long should the DNS module cache replies at maximum. The value
-# must be in seconds.
-# Note that it will respect the TTL of the reply and this is just an upper
-# boundary.
-set dns-cache 86400
-
-# Specify how long should the DNS module cache negative replies (NXDOMAIN,
-# DNS Lookup failed). The value must be in seconds.
-set dns-negcache 600
-
-# How many times should the DNS module resend the query for a given domain
-# if it receives no reply?
-set dns-maxsends 4
-
-# Specify how long should the DNS module wait for a reply before resending the
-# query. The value must be in seconds.
-set dns-retrydelay 3
+## You should no longer need to enable the DNS module!
 
 
 # You MUST remove this line for your bot to start. This has been added to
@@ -725,9 +698,7 @@ set blowfish-use-mode cbc
 ## This module provided asychronous dns support, but as of v1.9.2, this
 ## functionality was moved into the core code. If you are having issues with the
 ## new DNS functionality, or just want to continue using this module, compile
-## Eggdrop with the --disable-tdns flag (./configure --disdable-tdns). See the DNS
-## section above for more details (and the proper location to customize these
-## settings)
+## Eggdrop with the --disable-tdns flag (./configure --disdable-tdns).
 #
 ## You really probably don't want to uncomment this!!!!
 #

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -372,9 +372,9 @@ void tell_verbose_status(int idx)
   dprintf(idx, "IPv6 support is not available.\n"
 #endif
 #ifdef EGG_TDNS
-               "Threaded DNS core (beta) is enabled.\n"
+               "Threaded DNS core is enabled.\n"
 #else
-               "Threaded DNS core (beta) is disabled.\n"
+               "Threaded DNS core is disabled.\n"
 #endif
                "Socket table: %d/%d\n", threaddata()->MAXSOCKS, max_socks);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -517,7 +517,7 @@ static void show_ver() {
   printf("TLS, ");
 #endif
 #ifdef EGG_TDNS
-  printf("Threaded DNS core (beta), ");
+  printf("Threaded DNS core, ");
 #endif
   printf("handlen=%d\n", HANDLEN);
   bg_send_quit(BG_ABORT);


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: #1221

One-line summary:


Additional description (if needed):
Please run **misc/runautotools** after merge

Test cases demonstrating functionality (if applicable):
This PR will only change configure,
TDNS in config.h and code will be untouched

Test1:
```
$ ./configure --help
[...]
  --disable-tdns          disable threaded DNS core
```
Test2:
```
$ ./configure
[...]
Threaded DNS core: yes
$ grep TDNS config.h
#define EGG_TDNS 1
```
Test3:
```
$ ./configure --enable-tdns
Threaded DNS core: yes
$ grep TDNS config.h
#define EGG_TDNS 1
```
Test4:
```
$ ./configure --disable-tdns
[...]
Threaded DNS core: no
$ grep TDNS config.h
/* #undef EGG_TDNS */
```