### PR TITLE
changed some simple_sprintf() into snprintf()

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2816,11 +2816,11 @@ static void cmd_pls_ignore(struct userrec *u, int idx, char *par)
   /* Fix missing ! or @ BEFORE continuing */
   if (!strchr(who, '!')) {
     if (!strchr(who, '@'))
-      simple_sprintf(s, "%s!*@*", who);
+      snprintf(s, sizeof s, "%s!*@*", who);
     else
-      simple_sprintf(s, "*!%s", who);
+      snprintf(s, sizeof s, "*!%s", who);
   } else if (!strchr(who, '@'))
-    simple_sprintf(s, "%s@*", who);
+    snprintf(s, sizeof s, "%s@*", who);
   else
     strcpy(s, who);
 

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -511,7 +511,7 @@ static void eof_dcc_bot(int idx)
 
 static void display_dcc_bot(int idx, char *buf)
 {
-  int i = simple_sprintf(buf, "bot   flags: ");
+  int i = sprintf(buf, "bot   flags: ");
 
   buf[i++] = b_status(idx) & STAT_PINGED ? 'P' : 'p';
   buf[i++] = b_status(idx) & STAT_SHARE ? 'U' : 'u';
@@ -1146,7 +1146,7 @@ static void dcc_chat(int idx, char *buf, int i)
 
 static void display_dcc_chat(int idx, char *buf)
 {
-  int i = simple_sprintf(buf, "chat  flags: ");
+  int i = sprintf(buf, "chat  flags: ");
 
   buf[i++] = dcc[idx].status & STAT_CHAT ? 'C' : 'c';
   buf[i++] = dcc[idx].status & STAT_PARTY ? 'P' : 'p';
@@ -2209,7 +2209,7 @@ struct dcc_table DCC_IDENTWAIT = {
 
 void dcc_ident(int idx, char *buf, int len)
 {
-  char response[512], uid[512], buf1[UHOSTLEN];
+  char response[512], uid[512], buf1[UHOSTLEN + 21];
   int i;
 
   *response = *uid = '\0';
@@ -2224,7 +2224,7 @@ void dcc_ident(int idx, char *buf, int len)
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_IDENTWAIT) &&
         (dcc[i].sock == dcc[idx].u.ident_sock)) {
-      simple_sprintf(buf1, "%s@%s", uid, dcc[idx].host);
+      snprintf(buf1, sizeof buf1, "%s@%s", uid, dcc[idx].host);
       dcc_telnet_got_ident(i, buf1);
     }
   dcc[idx].u.other = 0;
@@ -2234,14 +2234,14 @@ void dcc_ident(int idx, char *buf, int len)
 
 void eof_timeout_dcc_ident(int idx, const char *s)
 {
-  char buf[UHOSTLEN];
+  char buf[7 + UHOSTLEN];
   int i;
 
   for (i = 0; i < dcc_total; i++)
     if ((dcc[i].type == &DCC_IDENTWAIT) &&
         (dcc[i].sock == dcc[idx].u.ident_sock)) {
       putlog(LOG_MISC, "*", s);
-      simple_sprintf(buf, "telnet@%s", dcc[idx].host);
+      snprintf(buf, sizeof buf, "telnet@%s", dcc[idx].host);
       dcc_telnet_got_ident(i, buf);
     }
   killsock(dcc[idx].sock);

--- a/src/misc.c
+++ b/src/misc.c
@@ -1212,7 +1212,7 @@ FILE *resolve_help(int dcc, char *file)
     return NULL;
   }
   /* Since we're not dealing with help files, we should just prepend the filename with textdir */
-  simple_sprintf(s, "%s%s", textdir, file);
+  snprintf(s, sizeof s, "%s%s", textdir, file);
   if (is_file(s))
     return fopen(s, "r");
   else

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -133,7 +133,7 @@ static int check_tcl_msgm(char *cmd, char *nick, char *uhost,
   char args[1024];
 
   if (arg[0])
-    simple_sprintf(args, "%s %s", cmd, arg);
+    snprintf(args, sizeof args, "%s %s", cmd, arg);
   else
     strlcpy(args, cmd, sizeof args);
   get_user_flagrec(u, &fr, NULL);
@@ -529,7 +529,7 @@ static int detect_flood(char *floodnick, char *floodhost, char *from, int which)
     if (check_tcl_flud(floodnick, floodhost, u, ftype, "*"))
       return 0;
     /* Private msg */
-    simple_sprintf(h, "*!*@%s", p);
+    snprintf(h, sizeof h, "*!*@%s", p);
     putlog(LOG_MISC, "*", IRC_FLOODIGNORE1, p);
     addignore(h, botnetnick, (which == FLOOD_CTCP) ? "CTCP flood" :
               "MSG/NOTICE flood", now + (60 * ignore_time));

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -294,13 +294,13 @@ static int tcl_cap STDVAR {
       Tcl_AppendResult(irp, "No CAP request provided", NULL);
       return TCL_ERROR;
     } else {
-      simple_sprintf(s, "CAP REQ :%s", argv[2]);
+      snprintf(s, sizeof s, "CAP REQ :%s", argv[2]);
       dprintf(DP_SERVER, "%s\n", s);
     }
   /* Send a raw CAP command to the server */
   } else if (!strcasecmp(argv[1], "raw")) {
     if (argc == 3) {
-      simple_sprintf(s, "CAP %s", argv[2]);
+      snprintf(s, sizeof s, "CAP %s", argv[2]);
       dprintf(DP_SERVER, "%s\n", s);
     } else {
       Tcl_AppendResult(irp, "Raw requires a CAP sub-command to be provided",

--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -241,7 +241,7 @@ static int check_tcl_whisperm(char *from, char *cmd, char *msg) {
   strlcpy(uhost, from, sizeof buf);
   nick = splitnick(&uhost);
   if (msg[0])                       /* Re-attach the cmd to the msg */
-    simple_sprintf(args, "%s %s", cmd, msg);
+    snprintf(args, sizeof args, "%s %s", cmd, msg);
   else
     strlcpy(args, cmd, sizeof args);
   get_user_flagrec(u, &fr, NULL);

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -54,7 +54,7 @@ void *_user_malloc(int size, const char *file, int line)
   const char *p;
 
   p = strrchr(file, '/');
-  simple_sprintf(x, "userrec.c:%s", p ? p + 1 : file);
+  snprintf(x, sizeof x, "userrec.c:%s", p ? p + 1 : file);
   return n_malloc(size, x, line);
 #else
   return nmalloc(size);
@@ -68,7 +68,7 @@ void *_user_realloc(void *ptr, int size, const char *file, int line)
   const char *p;
 
   p = strrchr(file, '/');
-  simple_sprintf(x, "userrec.c:%s", p ? p + 1 : file);
+  snprintf(x, sizeof x, "userrec.c:%s", p ? p + 1 : file);
   return n_realloc(ptr, size, x, line);
 #else
   return nrealloc(ptr, size);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
In the long term, all `simple_sprintf()` should be changed into `snprintf()` to harden eggdrop against buffer overflows. The compiler is much better at checking length for system functions where it has got some magick in place that doesnt work for eggdrops own string copy functions.

Additional description (if needed):
This PR changes some `simple_sprintf()` to have this merged quickly, because changing all of them would be more intrusive, and i dont know, how much work it would be to check the format specifier stuff. So this PR only changes `simple_sprintf()`, if they use only `%s`.

Test cases demonstrating functionality (if applicable):
