### PR TITLE
tiny fix for the size parameter of 2 strlcpy()s

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -237,7 +237,7 @@ static void bot_version(int idx, char *par)
 #ifndef NO_OLD_BOTNET
   }
 #endif
-  strlcpy(dcc[idx].u.bot->version, par, 120);
+  strlcpy(dcc[idx].u.bot->version, par, sizeof dcc[idx].u.bot->version);
   putlog(LOG_BOTS, "*", DCC_LINKED, dcc[idx].nick);
   botnet_send_nlinked(idx, dcc[idx].nick, botnetnick, '!',
                       dcc[idx].u.bot->numver);

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -504,7 +504,7 @@ static int tcl_control STDVAR
   /* Do not buffer data anymore. All received and stored data is passed
    * over to the dcc functions from now on.  */
   sockoptions(dcc[idx].sock, EGG_OPTION_UNSET, SOCK_BUFFER);
-  strlcpy(dcc[idx].u.script->command, argv[2], 120);
+  strlcpy(dcc[idx].u.script->command, argv[2], sizeof dcc[idx].u.script->command);
   return TCL_OK;
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
tiny fix for the size parameter of 2 strlcpy()s

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
