### PR TITLE
(Low Prio) Cleanup after we removed inline keywords

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -708,7 +708,8 @@ static int builtin_idx STDVAR
 }
 #endif
 
-/* Trigger (execute) a Tcl proc */
+/* Trigger (execute) a Tcl proc
+ */
 static int trigger_bind(const char *proc, const char *param, char *mask)
 {
   int x;
@@ -803,7 +804,8 @@ static int check_bind_match(const char *match, char *mask, int match_type)
 }
 
 
-/* Check if the provided flags suffice for this command/trigger. */
+/* Check if the provided flags suffice for this command/trigger.
+ */
 static int check_bind_flags(struct flag_record *flags, struct flag_record *atr,
                             int match_type)
 {

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -708,12 +708,8 @@ static int builtin_idx STDVAR
 }
 #endif
 
-/* Trigger (execute) a Tcl proc
- *
- * Note: This is INLINE code for check_tcl_bind().
- */
-static int trigger_bind(const char *proc, const char *param,
-                               char *mask)
+/* Trigger (execute) a Tcl proc */
+static int trigger_bind(const char *proc, const char *param, char *mask)
 {
   int x;
   struct rusage ru1, ru2;
@@ -777,11 +773,8 @@ static int trigger_bind(const char *proc, const char *param,
 
 /* Find out whether this bind matches the mask or provides the
  * requested attributes, depending on the specified requirements.
- *
- * Note: This is INLINE code for check_tcl_bind().
  */
-static int check_bind_match(const char *match, char *mask,
-                                   int match_type)
+static int check_bind_match(const char *match, char *mask, int match_type)
 {
   switch (match_type & 0x07) {
   case MATCH_PARTIAL:
@@ -810,12 +803,9 @@ static int check_bind_match(const char *match, char *mask,
 }
 
 
-/* Check if the provided flags suffice for this command/trigger.
- *
- * Note: This is INLINE code for check_tcl_bind().
- */
-static int check_bind_flags(struct flag_record *flags,
-                                   struct flag_record *atr, int match_type)
+/* Check if the provided flags suffice for this command/trigger. */
+static int check_bind_flags(struct flag_record *flags, struct flag_record *atr,
+                            int match_type)
 {
   if (match_type & BIND_USE_ATTR) {
     if (match_type & BIND_HAS_BUILTINS)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup after we removed inline keywords

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
