### PR TITLE
(Low Prio) Cleanup: simplify sprintf()/egg_snprintf() -> strlcpy()

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -316,7 +316,7 @@ void tell_verbose_status(int idx)
   }
   cputime = getcputime();
   if (cputime < 0)
-    sprintf(s2, "CPU: unknown");
+    strlcpy(s2, "CPU: unknown", sizeof s2);
   else {
     hr = cputime / 60;
     cputime -= hr * 60;

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1401,7 +1401,7 @@ static void cmd_chaninfo(struct userrec *u, int idx, char *par)
           tmp = 1;
         }
         if (ii == 1)
-          egg_snprintf(work, sizeof work, "    ");
+          strlcpy(work, "    ", sizeof work);
         work_len = strlen(work);
         egg_snprintf(work + work_len, sizeof(work) - work_len, " %c%s",
                      getudef(ul->values, chan->dname) ? '+' : '-', ul->name);

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -887,9 +887,9 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
         else
           strlcpy(s1, "   ", sizeof s1);
         if (chan_ircaway(m)) {
-          egg_snprintf(s1+strlen(s1), ((sizeof s1)-strlen(s1)), " (away)");
+          strlcpy(s1+strlen(s1), " (away)", ((sizeof s1)-strlen(s1)));
         } else {
-          egg_snprintf(s1+strlen(s1), ((sizeof s1)-strlen(s1)), "       ");
+          strlcpy(s1+strlen(s1), "       ", ((sizeof s1)-strlen(s1)));
         }
         if (use_354 && extended_join && account_notify) {
           dprintf(idx, "%c%-*s %-*s %-*s %-6s %c %s  %s\n", chanflag, maxnicklen,

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1857,7 +1857,7 @@ static void dcc_chat_hostresolved(int i)
 #ifdef TLS
   else if (dcc[i].ssl && ssl_handshake(dcc[i].sock, TLS_CONNECT, tls_vfydcc,
                                        LOG_MISC, dcc[i].host, &dcc_chat_sslcb))
-    egg_snprintf(buf, sizeof buf, "TLS negotiation error");
+    strlcpy(buf, "TLS negotiation error", sizeof buf);
 #endif
   if (buf[0]) {
     if (!quiet_reject)
@@ -2035,7 +2035,7 @@ static void server_report(int idx, int details)
     egg_snprintf(s, sizeof s, "(connected %s)", s1);
     if (server_lag && !lastpingcheck) {
       if (server_lag == -1)
-        egg_snprintf(s1, sizeof s1, " (bad pong replies)");
+        strlcpy(s1, " (bad pong replies)", sizeof s1);
       else
         egg_snprintf(s1, sizeof s1, " (lag: %ds)", server_lag);
       strcat(s, s1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup: simplify sprintf()/egg_snprintf() -> strlcpy()

Additional description (if needed):
Because there is no string formatting

Test cases demonstrating functionality (if applicable):
