### PR TITLE
Fix race in tdns

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -543,8 +543,10 @@ void *thread_dns_ipbyhost(void *arg)
 #endif
     freeaddrinfo(res0);
   }
+  pthread_mutex_lock(&dtn->mutex);
   dtn->ok = !i;
   close(dtn->fildes[1]);
+  pthread_mutex_unlock(&dtn->mutex);
   return NULL;
 }
 

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -788,6 +788,7 @@ enum {
 
 /* linked list instead of array because of multi threading */
 struct dns_thread_node {
+  pthread_mutex_t mutex;
   int fildes[2];
   int type;
   sockname_t addr;

--- a/src/net.c
+++ b/src/net.c
@@ -1034,10 +1034,16 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
   for (dtn = dtn_prev->next; dtn; dtn = dtn->next) {
     fd = dtn->fildes[0];
     if (FD_ISSET(fd, &fdr)) {
-      if (dtn->type == DTN_TYPE_HOSTBYIP)
+      if (dtn->type == DTN_TYPE_HOSTBYIP) {
+        pthread_mutex_lock(&dtn->mutex);
         call_hostbyip(&dtn->addr, dtn->host, dtn->ok);
-      else
+        pthread_mutex_unlock(&dtn->mutex);
+      }
+      else {
+        pthread_mutex_lock(&dtn->mutex);
         call_ipbyhost(dtn->host, &dtn->addr, dtn->ok);
+        pthread_mutex_unlock(&dtn->mutex);
+      }
       close(dtn->fildes[0]);
       dtn_prev->next = dtn->next;
       nfree(dtn);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix race in tdns

Additional description (if needed):
found with `gcc -fsanitize=thread`

Test cases demonstrating functionality (if applicable):
```
==================
WARNING: ThreadSanitizer: data race (pid=2353639)
  Read of size 4 at 0x7b4400001030 by main thread:
    #0 sockread /home/michael/projects/eggdrop5/eggdrop/src/net.c:1040 (eggdrop-1.9.1+0x88c49)
    #1 sockgets /home/michael/projects/eggdrop5/eggdrop/src/net.c:1145 (eggdrop-1.9.1+0x89917)
    #2 mainloop main.c:842 (eggdrop-1.9.1+0x746a6)
    #3 main main.c:1298 (eggdrop-1.9.1+0x76ece)

  Previous write of size 4 at 0x7b4400001030 by thread T2:
    #0 thread_dns_ipbyhost /home/michael/projects/eggdrop5/eggdrop/src/dns.c:546 (eggdrop-1.9.1+0x657af)

  Location is heap block of size 320 at 0x7b4400000f00 allocated by main thread:
    #0 malloc /build/gcc/src/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:655 (libtsan.so.0+0x326d9)
    #1 n_malloc /home/michael/projects/eggdrop5/eggdrop/src/mem.c:343 (eggdrop-1.9.1+0x78987)
    #2 core_dns_ipbyhost /home/michael/projects/eggdrop5/eggdrop/src/dns.c:587 (eggdrop-1.9.1+0x65b0e)
    #3 dcc_dnsipbyhost /home/michael/projects/eggdrop5/eggdrop/src/dns.c:224 (eggdrop-1.9.1+0x63f44)
    #4 botlink /home/michael/projects/eggdrop5/eggdrop/src/botnet.c:1085 (eggdrop-1.9.1+0x2e932)
    #5 autolink_cycle /home/michael/projects/eggdrop5/eggdrop/src/users.c:1121 (eggdrop-1.9.1+0xc0e11)
    #6 main main.c:1279 (eggdrop-1.9.1+0x76d30)

  Thread T2 (tid=2353642, finished) created by main thread at:
    #0 pthread_create /build/gcc/src/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x61c3a)
    #1 core_dns_ipbyhost /home/michael/projects/eggdrop5/eggdrop/src/dns.c:597 (eggdrop-1.9.1+0x65c4d)
    #2 dcc_dnsipbyhost /home/michael/projects/eggdrop5/eggdrop/src/dns.c:224 (eggdrop-1.9.1+0x63f44)
    #3 botlink /home/michael/projects/eggdrop5/eggdrop/src/botnet.c:1085 (eggdrop-1.9.1+0x2e932)
    #4 autolink_cycle /home/michael/projects/eggdrop5/eggdrop/src/users.c:1121 (eggdrop-1.9.1+0xc0e11)
    #5 main main.c:1279 (eggdrop-1.9.1+0x76d30)

SUMMARY: ThreadSanitizer: data race /home/michael/projects/eggdrop5/eggdrop/src/net.c:1040 in sockread
==================
```