### PR TITLE
Simplify main loop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -790,20 +790,10 @@ int init_language(int);
 int ssl_init();
 #endif
 
-static void garbage_collect(void)
+static void mainloop(int toplevel)
 {
-  static uint8_t run_cnt = 0;
-
-  if (run_cnt == 3)
-    garbage_collect_tclhash();
-  else
-    run_cnt++;
-}
-
-int mainloop(int toplevel)
-{
-  static int socket_cleanup = 0;
-  int xx, i, eggbusy = 1, tclbusy = 0;
+  static int cleanup = 5;
+  int xx, i, eggbusy = 1;
   char buf[8702];
 
   /* Lets move some of this here, reducing the number of actual
@@ -816,7 +806,7 @@ int mainloop(int toplevel)
    * This is done by returning -1 in tickle_WaitForEvent.
    */
   if (do_restart && do_restart != -2 && !toplevel)
-    return -1;
+    return;
 
   /* Once a second */
   if (now != then) {
@@ -825,19 +815,19 @@ int mainloop(int toplevel)
   }
 
   /* Only do this every so often. */
-  if (!socket_cleanup) {
-    socket_cleanup = 5;
+  if (!cleanup) {
+    cleanup = 5;
 
     /* Remove dead dcc entries. */
     dcc_remove_lost();
 
     /* Check for server or dcc activity. */
     dequeue_sockets();
-  } else
-    socket_cleanup--;
 
-  /* Free unused structures. */
-  garbage_collect();
+    /* Free unused structures. */
+    garbage_collect_tclhash();
+  } else
+    cleanup--;
 
   xx = sockgets(buf, &i);
   if (xx >= 0) {              /* Non-error */
@@ -909,18 +899,16 @@ int mainloop(int toplevel)
     }
   } else if (xx == -3) {
     call_hook(HOOK_IDLE);
-    socket_cleanup = 0;       /* If we've been idle, cleanup & flush */
+    cleanup = 0; /* If we've been idle, cleanup & flush */
     eggbusy = 0;
-  } else if (xx == -5) {
+  } else if (xx == -5)
     eggbusy = 0;
-    tclbusy = 1;
-  }
 
   if (do_restart) {
     if (do_restart == -2)
       rehash();
     else if (!toplevel)
-      return -1; /* Unwind to toplevel before restarting */
+      return; /* Unwind to toplevel before restarting */
     else {
       /* Unload as many modules as possible */
       int f = 1;
@@ -994,15 +982,11 @@ int mainloop(int toplevel)
   if (!eggbusy) {
 /* Process all pending tcl events */
 #  ifdef REPLACE_NOTIFIER
-    if (Tcl_ServiceAll())
-      tclbusy = 1;
+    Tcl_ServiceAll();
 #  else
-    while (Tcl_DoOneEvent(TCL_DONT_WAIT | TCL_ALL_EVENTS))
-      tclbusy = 1;
+    while (Tcl_DoOneEvent(TCL_DONT_WAIT | TCL_ALL_EVENTS));
 #  endif /* REPLACE_NOTIFIER */
   }
-
-  return (eggbusy || tclbusy);
 }
 
 static void init_random(void) {

--- a/src/proto.h
+++ b/src/proto.h
@@ -190,7 +190,6 @@ void eggContext(const char *, int, const char *);
 void eggContextNote(const char *, int, const char *, const char *);
 void eggAssert(const char *, int, const char *);
 void backup_userfile(void);
-int mainloop(int);
 
 /* match.c */
 int casecharcmp(unsigned char, unsigned char);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Simplify main loop

One-line summary:
1. `mainloop()` is only called in `main.c`, so i removed it from `proto.h` and made it `static`
2. the return value of `mainloop()` is not used, so i made it `void`
3. `garbage_collect()` is a mechanism to call `garbage_collect_tclhash()` every 3rd second. there is already a mechanism in `mainloop()` doing cleanup every 5th second. so i fused `garbage_collect()` into that cleanup block.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
