### PR TITLE
fix format specifier

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -193,14 +193,14 @@ static void ident_oidentd()
     }
     if (ss.ss_family == AF_INET) {
       struct sockaddr_in *saddr = (struct sockaddr_in *)&ss;
-      fprintf(fd, "lport %i from %s { reply \"%s\" } "
+      fprintf(fd, "lport %" PRIu16 " from %s { reply \"%s\" } "
                 "### eggdrop_%s !%" PRId64 "\n", ntohs(saddr->sin_port),
                 inet_ntop(AF_INET, &(saddr->sin_addr), s, INET_ADDRSTRLEN),
                 botuser, pid_file, (int64_t) now);
 #ifdef IPV6
     } else if (ss.ss_family == AF_INET6) {
       struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)&ss;
-      fprintf(fd, "lport %i from %s { reply \"%s\" } "
+      fprintf(fd, "lport %" PRIu16 " from %s { reply \"%s\" } "
                 "### eggdrop_%s !%" PRId64 "\n", ntohs(saddr->sin6_port),
                 inet_ntop(AF_INET6, &(saddr->sin6_addr), s, INET6_ADDRSTRLEN),
                 botuser, pid_file, (int64_t) now);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
fix format specifier

Additional description (if needed):
`uint16_t ntohs(uint16_t netshort);`
so we need PRIu16
ty thommey for the inspiration to this one

Test cases demonstrating functionality (if applicable):
no functional change, but i didnt test it explicitely, hope thats fine, *cross fingers*