### PR TITLE
Properly check cap settings outside server.mod

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2040,13 +2040,13 @@ static int gotjoin(char *from, char *channame)
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
   /* Check if extended-join CAP is enabled */
-      current = cap;
-      while (current != NULL) {
-        if (!strcasecmp("extended-join", current->name)) {
-          extjoin = current->enabled ? 1 : 0;
-        }
-        current = current->next;
-      }
+  current = cap;
+  while (current != NULL) {
+    if (!strcasecmp("extended-join", current->name)) {
+      extjoin = current->enabled ? 1 : 0;
+    }
+    current = current->next;
+  }
   strlcpy(uhost, from, sizeof buf);
   nick = splitnick(&uhost);
   chname = newsplit(&channame);

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2031,16 +2031,26 @@ static int gotjoin(char *from, char *channame)
 {
   char *nick, *p, buf[UHOSTLEN], account[NICKMAX], *uhost = buf, *chname;
   char *ch_dname = NULL;
+  int extjoin = 0;
   struct chanset_t *chan;
   memberlist *m;
   masklist *b;
+  struct capability *current;
   struct userrec *u;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
+  /* Check if extended-join CAP is enabled */
+      current = cap;
+      while (current != NULL) {
+        if (!strcasecmp("extended-join", current->name)) {
+          extjoin = current->enabled ? 1 : 0;
+        }
+        current = current->next;
+      }
   strlcpy(uhost, from, sizeof buf);
   nick = splitnick(&uhost);
   chname = newsplit(&channame);
-  if (!extended_join) {
+  if (!extjoin) {
     fixcolon(chname);
   }
   chan = findchan_by_dname(chname);
@@ -2155,7 +2165,7 @@ static int gotjoin(char *from, char *channame)
         strlcpy(m->userhost, uhost, sizeof m->userhost);
         m->user = u;
         m->flags |= STOPWHO;
-        if (extended_join) {
+        if (extjoin) {
           strlcpy(account, newsplit(&channame), sizeof account);
           if (strcmp(account, "*")) {
             if ((m = ismember(chan, nick))) {

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -724,8 +724,21 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
 {
   char handle[HANDLEN + 1], s[UHOSTLEN], s1[UHOSTLEN], atrflag, chanflag;
   struct chanset_t *chan;
+  struct capability *current;
   memberlist *m;
-  int maxnicklen, maxhandlen;
+  int maxnicklen, maxhandlen, extjoin, acctnotify;
+
+  /* Check if CAPs are enabled */
+  current = cap;
+  while (current != NULL) {
+    if (!strcasecmp("extended-join", current->name)) {
+      extjoin = current->enabled ? 1 : 0;
+    }
+    if (!strcasecmp("account-notify", current->name)) {
+      acctnotify = current->enabled ? 1 : 0;
+    }
+    current = current->next;
+  }
 
   chan = get_channel(idx, par);
   if (!chan || !has_oporhalfop(idx, chan))
@@ -757,7 +770,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
       maxhandlen = 9;
 
     dprintf(idx, "(n = owner, m = master, o = op, d = deop, b = bot)\n");
-    if (use_354 && extended_join && account_notify) {
+    if (use_354 && extjoin && acctnotify) {
       dprintf(idx, " %-*s %-*s %-*s  %-6s %-5s %s\n", maxnicklen, "NICKNAME",
                 maxhandlen, "HANDLE", maxnicklen, "ACCOUNT", "JOIN", "IDLE",
                 "USER@HOST");
@@ -858,7 +871,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
       else
         chanflag = ' ';
       if (chan_issplit(m)) {
-        if (use_354 && extended_join && account_notify) {
+        if (use_354 && extjoin && acctnotify) {
           dprintf(idx, "%c%-*s %-*s %-*s %-6s %-5s <- netsplit, %lus\n",
                 chanflag, maxnicklen, m->nick, maxhandlen, handle, maxnicklen,
                 m->account, s, atrflag, now- (m->split));
@@ -868,7 +881,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
                 now- (m->split));
         }
       } else if (!rfc_casecmp(m->nick, botname)) {
-        if (use_354 && extended_join && account_notify) {
+        if (use_354 && extjoin && acctnotify) {
           dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- it's me!\n", chanflag,
                 maxnicklen, m->nick, maxhandlen, handle, maxnicklen, m->account,
                 s, atrflag);
@@ -891,7 +904,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
         } else {
           egg_snprintf(s1+strlen(s1), ((sizeof s1)-strlen(s1)), "       ");
         }
-        if (use_354 && extended_join && account_notify) {
+        if (use_354 && extjoin && acctnotify) {
           dprintf(idx, "%c%-*s %-*s %-*s %-6s %c %s  %s\n", chanflag, maxnicklen,
                 m->nick, maxhandlen, handle, maxnicklen, m->account, s, atrflag,
                 s1, m->userhost);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1090,12 +1090,14 @@ static void irc_report(int idx, int details)
    */
   /* Check if CAPs are enabled */
   current = cap;
+  extjoin = 0;
+  acctnotify = 0;
   while (current != NULL) {
     if (!strcasecmp("extended-join", current->name)) {
-      extjoin = current->enabled ? 1 : 0;
+      extjoin = 1;
     }
     if (!strcasecmp("account-notify", current->name)) {
-      acctnotify = current->enabled ? 1 : 0;
+      acctnotify = 1;
     }
     current = current->next;
   }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1049,8 +1049,9 @@ static void irc_report(int idx, int details)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char ch[1024], q[256], *p;
-  int k, l;
+  int k, l, extjoin, acctnotify;
   struct chanset_t *chan;
+  struct capability *current;
 
   strcpy(q, "Channels: ");
   k = 10;
@@ -1084,17 +1085,29 @@ static void irc_report(int idx, int details)
     dprintf(idx, "    %s\n", q);
   }
   /* List status of account tracking. For 100% accuracy, this requires
-   * WHOX ability (354 messages) and the extended-join and account_notify
+   * WHOX ability (354 messages) and the extended-join and account-notify
    * capabilities to be enabled.
    */
-  if (use_354 && extended_join && account_notify) {
+  /* Check if CAPs are enabled */
+  current = cap;
+  while (current != NULL) {
+    if (!strcasecmp("extended-join", current->name)) {
+      extjoin = current->enabled ? 1 : 0;
+    }
+    if (!strcasecmp("account-notify", current->name)) {
+      acctnotify = current->enabled ? 1 : 0;
+    }
+    current = current->next;
+  }
+
+  if (use_354 && extjoin && acctnotify) {
     dprintf(idx, "    Account tracking: Enabled\n");
   } else {
     dprintf(idx, "    Account tracking: Disabled\n"
                  "      (Missing capabilities:%s%s%s)\n",
                       use_354 ? "" : " use-354",
-                      extended_join ? "" : " extended-join",
-                      account_notify ? "" : " account-notify");
+                      extjoin ? "" : " extended-join",
+                      acctnotify ? "" : " account-notify");
   }
 }
 

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -86,7 +86,7 @@
 /* 40 - 43 */
 #define H_out (*(p_tcl_bind_list *)(server_funcs[40]))
 #define net_type_int (*(int *)(server_funcs[41]))
-#define cap (*(capability_t *)(server_funcs[42]))
+#define cap (*(capability_t **)(server_funcs[42]))
 #define H_account (*(p_tcl_bind_list *)(server_funcs[43]))
 /* 44 - 47 */
 #define extended_join (*(int *)(server_funcs[44]))

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -37,8 +37,8 @@ static time_t last_ctcp = (time_t) 0L;
 static int multistatus = 0, count_ctcp = 0;
 static char altnick_char = 0;
 struct capability *cap;
-int ncapesc, account_notify = 0, extended_join = 0;
-Tcl_Obj **ncapesv, *ncapeslist;
+int account_notify, extended_join;
+Tcl_Obj *ncapeslist;
 
 /* We try to change to a preferred unique nick here. We always first try the
  * specified alternate nick. If that fails, we repeatedly modify the nick


### PR DESCRIPTION
Found by: Lord255
Patch by: Geo

One-line summary:
Properly check cap settings outside server.mod

Additional description (if needed):
Some code was not updated from the last CAP modification so that it relied on a value set in the config (ie, extended-join) rather than actually checking if it was set or not. If a setting was enabled in the config but not requested from the server (for example, the server didn't support that capability), Eggdrop would act like it was enabled, even though it wasn't, and mess things up