### PR TITLE
Fix handling of PASS/PASS2

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -368,7 +368,8 @@ static void dcc_bot_new(int idx, char *buf, int x)
         pass = pass2;
         if (encrypt_pass)
           set_user(&USERENTRY_PASS, u, pass);
-      }
+      } else if (strcmp(pass2, pass) && encrypt_pass2)
+        pass = pass2;
     } else if (pass && encrypt_pass2)
         set_user(&USERENTRY_PASS2, u, pass);
     if (!pass || !strcmp(pass, "-")) {

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -343,7 +343,7 @@ static void dcc_bot_digest(int idx, char *challenge, char *password)
 static void dcc_bot_new(int idx, char *buf, int x)
 {
   struct userrec *u = get_user_by_handle(userlist, dcc[idx].nick);
-  char *code, *pass = NULL;
+  char *code, *pass2 = NULL, *pass = NULL;
 
   if (raw_log) {
     if (!strncmp(buf, "s ", 2))
@@ -361,10 +361,16 @@ static void dcc_bot_new(int idx, char *buf, int x)
     /* We entered the wrong password */
     putlog(LOG_BOTS, "*", DCC_BADPASS, dcc[idx].nick);
   else if (!strcasecmp(code, "passreq")) {
-    if (encrypt_pass2)
-      pass = get_user(&USERENTRY_PASS2, u);
-    if (!pass && encrypt_pass)
-      pass = get_user(&USERENTRY_PASS, u);
+    pass2 = get_user(&USERENTRY_PASS2, u);
+    pass = get_user(&USERENTRY_PASS, u);
+    if (pass2) {
+      if (!pass) {
+        pass = pass2;
+        if (encrypt_pass)
+          set_user(&USERENTRY_PASS, u, pass);
+      }
+    } else if (pass && encrypt_pass2)
+        set_user(&USERENTRY_PASS2, u, pass);
     if (!pass || !strcmp(pass, "-")) {
       putlog(LOG_BOTS, "*", DCC_PASSREQ, dcc[idx].nick);
       dprintf(idx, "-\n");

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -343,7 +343,7 @@ static void dcc_bot_digest(int idx, char *challenge, char *password)
 static void dcc_bot_new(int idx, char *buf, int x)
 {
   struct userrec *u = get_user_by_handle(userlist, dcc[idx].nick);
-  char *code;
+  char *code, *pass = NULL;
 
   if (raw_log) {
     if (!strncmp(buf, "s ", 2))
@@ -361,8 +361,10 @@ static void dcc_bot_new(int idx, char *buf, int x)
     /* We entered the wrong password */
     putlog(LOG_BOTS, "*", DCC_BADPASS, dcc[idx].nick);
   else if (!strcasecmp(code, "passreq")) {
-    char *pass = get_user(&USERENTRY_PASS, u);
-
+    if (encrypt_pass2)
+      pass = get_user(&USERENTRY_PASS2, u);
+    if (!pass && encrypt_pass)
+      pass = get_user(&USERENTRY_PASS, u);
     if (!pass || !strcmp(pass, "-")) {
       putlog(LOG_BOTS, "*", DCC_PASSREQ, dcc[idx].nick);
       dprintf(idx, "-\n");

--- a/src/users.c
+++ b/src/users.c
@@ -482,7 +482,7 @@ static void tell_user(int idx, struct userrec *u)
   }
   egg_snprintf(format, sizeof format, "%%-%us %%-5s%%5d %%-15s %%s (%%s)\n",
                HANDLEN);
-  if ((encrypt_pass2 && get_user(&USERENTRY_PASS2, u)) || (encrypt_pass && get_user(&USERENTRY_PASS, u)))
+  if (!u_pass_match(u, "-"))
     p = 1;
   dprintf(idx, format, u->handle, p ? "yes" : "no", n, s, s1,
           (li && li->lastonplace) ? li->lastonplace : "nowhere");

--- a/src/users.c
+++ b/src/users.c
@@ -482,9 +482,8 @@ static void tell_user(int idx, struct userrec *u)
   }
   egg_snprintf(format, sizeof format, "%%-%us %%-5s%%5d %%-15s %%s (%%s)\n",
                HANDLEN);
-  if ((get_user(&USERENTRY_PASS, u)) || (get_user(&USERENTRY_PASS2, u))) {
+  if ((encrypt_pass2 && get_user(&USERENTRY_PASS2, u)) || (encrypt_pass && get_user(&USERENTRY_PASS, u)))
     p = 1;
-  }
   dprintf(idx, format, u->handle, p ? "yes" : "no", n, s, s1,
           (li && li->lastonplace) ? li->lastonplace : "nowhere");
   /* channel flags? */


### PR DESCRIPTION
Found by: ldm
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix handling of PASS/PASS2

Additional description (if needed):
The problem is, when linking bots, current eggdrop only uses the password in PASS in userfile, not the one in PASS2 (created by pbkdf2). This PR will fix this. Additionally, `.whois <handle>` did report PASS yes/no on hardwired logic. From now on it will use `u_pass_match(u, "-")`.
A problem with this PR is, there would be too many testcases to fully cover everything. So, as discussed on IRC, lets test the most important cases only.

Test cases demonstrating functionality (if applicable):
**Test 1 - Fresh install, pbkdf2 only**
Testing relink between 2 bots. the first link sets the password, the relink must use this password. This testcase if with pbkdf2 and without blowfish loaded. Also there is no PASS or PASS2 in userfile yet for the bots to be linked / new bot records are created for this link test.
**Before:**
BotA:
`.+bot BotB localhost 3353`
BotB:
`.+bot BotA localhost +3343`
BotA:
```
.link BotB
[01:24:25] Linked to BotB.
.unlink BotB
.link BotB
[01:24:50] Bad password on connect attempt to BotB.
[01:24:50] Lost Bot: BotB
```
**After:**
BotA:
`.+bot BotB localhost 3353`
BotB:
`.+bot BotA localhost +3343`
BotA:
```
.link BotB
[01:27:15] Linked to BotB
.unlink BotB
.link BotB
[01:28:10] Linked to BotB.
```

**Test 2 - Upgrade existing userfile from blowfish to pbkdf2**
Testing upgrade path from  blowfish to pbkdf2. Create userfile with PASS (only load blowfish mod), link, relink, then add pbkdf2 mod, link, relink, then remove blowfish mod, link, relink.
Edit Bot config files, so that only blowfish mod is loaded and start the 2 bots.
BotA:
`.+bot BotB localhost 3353`
BotB:
`.+bot BotA localhost +3343`
BotA:
```
.link BotB
[06:16:38] Linked to BotB.
.unlink BotB
.link BotB
[06:17:10] Linked to BotB.
```
Edit Bot config files, so that blowfish mod and pbkdf2 mod is loaded and restart the 2 bots.
BotA:
```
.link BotB
[06:22:36] Linked to BotB.
.unlink BotB
.link BotB
[06:22:54] Linked to BotB.
```
Edit Bot config files, so that only pbkdf2 mod is loaded and restart the 2 bots.
BotA:
```
.link BotB
[08:03:05] Linked to BotB.
.unlink BotB
.link BotB
[08:04:14] Linked to BotB.
```