### PR TITLE
Fix tdns mutex

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -504,8 +504,10 @@ void *thread_dns_hostbyip(void *arg)
 #endif
       inet_ntop(AF_INET, &addr->addr.s4.sin_addr.s_addr, dtn->host, sizeof dtn->host);
   }
+  pthread_mutex_lock(&dtn->mutex);
   dtn->ok = !i;
   close(dtn->fildes[1]);
+  pthread_mutex_unlock(&dtn->mutex);
   return NULL;
 }
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -555,6 +555,8 @@ void core_dns_hostbyip(sockname_t *addr)
   struct dns_thread_node *dtn = nmalloc(sizeof(struct dns_thread_node));
   pthread_t thread; /* only used by pthread_create(), no need to save */
 
+  if (pthread_mutex_init(&dtn->mutex, NULL))
+    fatal("ERROR: core_dns_hostbyip(): pthread_mutex_init() failed", 0);
   if (pipe(dtn->fildes) < 0) {
     putlog(LOG_MISC, "*", "core_dns_hostbyip(): pipe(): error: %s", strerror(errno));
     call_hostbyip(addr, iptostr(&addr->addr.sa), 0);
@@ -587,6 +589,8 @@ void core_dns_ipbyhost(char *host)
     return;
   }
   dtn = nmalloc(sizeof(struct dns_thread_node));
+  if (pthread_mutex_init(&dtn->mutex, NULL))
+    fatal("ERROR: core_dns_ipbyhost(): pthread_mutex_init() failed", 0);
   if (pipe(dtn->fildes) < 0) {
     putlog(LOG_MISC, "*", "core_dns_ipbyhost(): pipe(): error: %s", strerror(errno));
     call_ipbyhost(host, &addr, 0);


### PR DESCRIPTION
Found by: ldm
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix initialization of mutex

Additional description (if needed):
Please check if this fixes https://github.com/eggheads/eggdrop/pull/1251#issuecomment-1008352252
Info: the mutex was introduced by #1237
Added one more lock around for writing to the dns thread linked list

Test cases demonstrating functionality (if applicable):
```
$ valgrind ./eggdrop -t BotA.conf

[08:27:20] main: entering loop
==467352== Thread 3:
==467352== Conditional jump or move depends on uninitialised value(s)
==467352==    at 0x4888433: pthread_mutex_lock (in /usr/lib/libpthread-2.33.so)
==467352==    by 0x139BE0: thread_dns_ipbyhost (dns.c:546)
==467352==    by 0x4886258: start_thread (in /usr/lib/libpthread-2.33.so)
==467352==    by 0x50505E2: clone (in /usr/lib/libc-2.33.so)
```