### PR TITLE
Fix telnet ident lookup bind

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1356,8 +1356,11 @@ static void dcc_telnet_hostresolved(int i)
     if (dcc[j].sock >= 0) {
       sockname_t name;
       name.addrlen = sizeof(name.addr);
-      getsockname(dcc[i].sock, &name.addr.sa, &name.addrlen);
-      bind(dcc[j].sock, &name.addr.sa, name.addrlen);
+      if (getsockname(dcc[i].sock, &name.addr.sa, &name.addrlen) < 0)
+        debug2("dcc: dcc_telnet_hostresolved(): getsockname() socket %i error %s", dcc[i].sock, strerror(errno));
+      setsnport(name, 0);
+      if (bind(dcc[j].sock, &name.addr.sa, name.addrlen) < 0)
+        debug2("dcc: dcc_telnet_hostresolved(): bind() socket %i error %s", dcc[j].sock, strerror(errno));
       setsnport(dcc[j].sockname, 113);
       if (connect(dcc[j].sock, &dcc[j].sockname.addr.sa,
           dcc[j].sockname.addrlen) < 0 && (errno != EINPROGRESS)) {


### PR DESCRIPTION
Found by: thommey
Patch by: michaelortmann
Fixes: #1252

One-line summary:
Fix telnet ident lookup bind

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
Enable ident check by setting `ident-timeout > 0`:
```
$ grep ident-timeout BotA.conf 
set ident-timeout 5
```

On host `192.168.16.3`:
`$ strace ./eggdrop -t BotA.conf`

On host `192.168.16.4`:
`$ telnet 192.168.16.3 3333`

**Before:**
strace output:
```
getsockname(8, {sa_family=AF_INET, sin_port=htons(3333), sin_addr=inet_addr("192.168.16.3")}, [28 => 16]) = 0
bind(11, {sa_family=AF_INET, sin_port=htons(3333), sin_addr=inet_addr("192.168.16.3")}, 16) = -1 EADDRINUSE (Address already in use)
connect(11, {sa_family=AF_INET, sin_port=htons(113), sin_addr=inet_addr("192.168.16.4")}, 16) = -1 EINPROGRESS (Operation now in progress)
```
**After:**
strace output:
```
getsockname(8, {sa_family=AF_INET, sin_port=htons(3333), sin_addr=inet_addr("192.168.16.3")}, [28 => 16]) = 0
bind(11, {sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("192.168.16.3")}, 16) = 0
connect(11, {sa_family=AF_INET, sin_port=htons(113), sin_addr=inet_addr("192.168.16.4")}, 16) = -1 EINPROGRESS (Operation now in progress)
```