### PR TITLE
Added -n option explanation

### DIFF
--- a/README
+++ b/README
@@ -131,6 +131,8 @@ COMMAND LINE
 
   The options available are:
 
+    -n: Don't background, send all log entries to console.
+    
     -t: Don't background, use terminal. This is just like -n, except that
 
         instead of seeing log entries, your console will simulate a DCC


### PR DESCRIPTION
-t and -c reference -n but it wasn't explained

Found by:
Patch by:
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
