### PR TITLE
fix NULL ptr

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -586,7 +586,7 @@ void tell_bottree(int idx, int showver)
 {
   char s[161];
   char c = '-';
-  tand_t *last[20], *this, *bot, *bot2 = NULL;
+  tand_t *last[20], *this, *bot, *bot2 = NULL, *lastbot = NULL;
   int lev = 0, more = 1, mark[20], ok, cnt, i, imark;
   char work[1024];
   int tothops = 0;
@@ -718,6 +718,7 @@ void tell_bottree(int idx, int showver)
               }
             }
           }
+          lastbot = bot;
         }
         if (cnt) {
           imark = 0;
@@ -730,9 +731,9 @@ void tell_bottree(int idx, int showver)
           }
           more = 1;
           if (cnt > 1)
-            dprintf(idx, "%s  |%s%s\n", work, bot->ssl ? "=" : "-", s);
+            dprintf(idx, "%s  |%s%s\n", work, lastbot->ssl ? "=" : "-", s);
           else
-            dprintf(idx, "%s  `%s%s\n", work, bot->ssl ? "=" : "-", s);
+            dprintf(idx, "%s  `%s%s\n", work, lastbot->ssl ? "=" : "-", s);
           this = bot2;
           work[0] = 0;
           if (cnt > 1)

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -750,8 +750,8 @@ void tell_bottree(int idx, int showver)
             more = 1;
             this = last[lev];
           }
+          dprintf(idx, "------------------------------------------------\n");
         }
-        dprintf(idx, "------------------------------------------------\n");
       }
     }
   }


### PR DESCRIPTION
Found by: tuvok
Patch by: Geo
Fixes: #1259 

One-line summary:
Fix null ptr reference

Additional description (if needed):
bot->ssl was added after a for loop ran through the bot linked list, leaving bot as 'NULL'. Added an holder variable for the final valid bot entry and use that instead.

Initial bug could be triggered with 3+ bots connected in a botnet.

Test cases demonstrating functionality (if applicable):
```
- Link    = Encrypted link    + Userfile Sharing
------------------------------------------------
testbot
  |=+ytestbot
  `=+ztestbot
------------------------------------------------
```