### PR TITLE
Fix memory leak

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -330,12 +330,17 @@ char *ssl_getfp(int sock)
 
   if (!(cert = ssl_getcert(sock)))
     return NULL;
-  if (!X509_digest(cert, EVP_sha1(), md, &i))
+  if (!X509_digest(cert, EVP_sha1(), md, &i)) {
+    X509_free(cert);
     return NULL;
-  if (!(p = OPENSSL_buf2hexstr(md, i)))
+  }
+  if (!(p = OPENSSL_buf2hexstr(md, i))) {
+    X509_free(cert);
     return NULL;
+  }
   strlcpy(fp, p, sizeof fp);
   OPENSSL_free(p);
+  X509_free(cert);
   return fp;
 }
 
@@ -1025,6 +1030,7 @@ static int tcl_tlsstatus STDVAR
     Tcl_DStringAppendElement(&ds, "serial");
     Tcl_DStringAppendElement(&ds, p);
     nfree(p);
+    X509_free(cert);
   }
   /* We should always have a cipher, but who knows? */
   cipher = SSL_get_current_cipher(td->socklist[j].ssl);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix memory leak: X509_free() memory allocated by SSL_get_peer_certificate()

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
start BotA:
`$ valgrind --leak-check=full ./eggdrop -t BotA.conf`
start BotB
link BotB to BotA via ssl
BotA:
```
.die
[...]
==46177== 6,040 (352 direct, 5,688 indirect) bytes in 1 blocks are definitely lost in loss record 511 of 552
==46177==    at 0x4845899: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==46177==    by 0x4D594CA: CRYPTO_zalloc (in /usr/lib/libcrypto.so.1.1)
==46177==    by 0x4C734EC: ??? (in /usr/lib/libcrypto.so.1.1)
==46177==    by 0x4C70F33: ??? (in /usr/lib/libcrypto.so.1.1)
==46177==    by 0x4C7176D: ASN1_item_ex_d2i (in /usr/lib/libcrypto.so.1.1)
==46177==    by 0x4C717EB: ASN1_item_d2i (in /usr/lib/libcrypto.so.1.1)
==46177==    by 0x4BA4EAF: ??? (in /usr/lib/libssl.so.1.1)
==46177==    by 0x4B91E3C: ??? (in /usr/lib/libssl.so.1.1)
==46177==    by 0x4B690A4: ??? (in /usr/lib/libssl.so.1.1)
==46177==    by 0x4B70475: ??? (in /usr/lib/libssl.so.1.1)
==46177==    by 0x4B7B733: SSL_read (in /usr/lib/libssl.so.1.1)
==46177==    by 0x148B1C: sockread (net.c:963)
[...]
```