### PR TITLE
Fix twitch mod crash on .restart and .rehash

### DIFF
--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -828,6 +828,7 @@ static char *twitch_close()
   rem_builtins(H_rawt, twitch_rawt);
   rem_tcl_commands(mytcl);
   rem_tcl_ints(my_tcl_ints);
+  rem_tcl_strings(my_tcl_strings);
   del_bind_table(H_ccht);
   del_bind_table(H_cmsg);
   del_bind_table(H_htgt);

--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -877,6 +877,8 @@ static Function twitch_table[] = {
 
 char *twitch_start(Function *global_funcs)
 {
+  const char *value;
+
   /* Assign the core function table. After this point you use all normal
    * functions defined in src/mod/modules.h
    */
@@ -911,7 +913,7 @@ char *twitch_start(Function *global_funcs)
  */
   if (net_type_int != NETT_TWITCH) {
     fatal("ERROR: ATTEMPTED TO LOAD TWITCH MODULE WITH INCORRECT NET-TYPE SET\n"
-          "  Please check net-type in config and try again", 0);
+          "  Please check that net-type is set to twitch in config before loadmodule twitch and try again", 0);
   }
 
   H_ccht = add_bind_table("ccht", HT_STACKABLE, twitch_2char);
@@ -927,6 +929,9 @@ char *twitch_start(Function *global_funcs)
   Tcl_SetVar(interp, "cap-request",
         "twitch.tv/commands twitch.tv/membership twitch.tv/tags", 0);
   /* keep-nick causes ISONs to be sent, which are not supported */
+  if ((value = Tcl_GetVar2(interp, "keep-nick", NULL, TCL_GLOBAL_ONLY)) && strcmp(value, "0")) {
+    putlog(LOG_MISC, "*", "Twitch: keep-nick is forced to be 0 when twitch.mod is loaded");
+  }
   Tcl_SetVar2(interp, "keep-nick", NULL, "0", TCL_GLOBAL_ONLY);
   Tcl_TraceVar(interp, "keep-nick", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_keepnick, NULL);
 


### PR DESCRIPTION
Found by: roughnecks
Patch by: Lord255, michaelortmann, thommey
Fixes: #1263

One-line summary: Fix twitch.mod restart and rehash


Additional description (if needed):
https://github.com/eggheads/eggdrop/issues/1263 mentions 2 problems:
1. crash on `.restart`
2. problem with `.rehash`

This patch here fixes the `.restart` crash
Please test and merge now
The 2nd problem should  be done in a new PR (later), for its independent and probably will take more time to think about the design.

Test cases demonstrating functionality (if applicable):
```
$ tail -3 BotA.conf 
set net-type "twitch"
set keep-nick 1
loadmodule twitch
```
before:
```
$ ./eggdrop BotA.conf
$ telnet 127.1 3333
Trying 127.0.0.1...
[...]
.restart
[14:36:43] tcl: builtin dcc call: *dcc:restart testuser 8 
[14:36:43] #testuser# restart
Restarting.
[14:36:43] Writing user file...
[14:36:42] Writing channel file...
[14:36:42] Restarting ...
[...]
[14:36:42] * Last context: twitch:twitch.c/825 []
[14:36:42] * Please REPORT this BUG!
[14:36:42] * Check doc/BUG-REPORT on how to do so.
[14:36:42] * Wrote DEBUG
[14:36:42] * SEGMENT VIOLATION -- CRASHING!
Connection closed by foreign host.
```
after:
```
$ ./eggdrop BotA.conf
$ telnet 127.1 3333
Trying 127.0.0.1...
[...]
.restart
[14:37:54] tcl: builtin dcc call: *dcc:restart testuser 8 
[14:37:54] #testuser# restart
Restarting.
[14:37:54] Writing user file...
[14:37:53] Writing channel file...
[14:37:53] Restarting ...
[...]
[14:37:53] Module loaded: twitch
[...]
```