### PR TITLE
Fix eggdrop build without ssl/tls

### DIFF
--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -723,7 +723,11 @@ static void bot_nlinked(int idx, char *par)
     putlog(LOG_BOTMSG, "*", "(%s) %s %s.", next, NET_LINKEDTO, newbot);
     x = '-';
   }
+#ifdef TLS
   addbot(newbot, dcc[idx].nick, next, x, i, dcc[idx].ssl);
+#else
+  addbot(newbot, dcc[idx].nick, next, x, i, 0);
+#endif
   check_tcl_link(newbot, next);
   u = get_user_by_handle(userlist, newbot);
   if (bot_flags(u) & BOT_REJECT) {

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -244,7 +244,11 @@ static void bot_version(int idx, char *par)
   touch_laston(dcc[idx].user, "linked", now);
   dump_links(idx);
   dcc[idx].type = &DCC_BOT;
+#ifdef TLS
   addbot(dcc[idx].nick, dcc[idx].nick, botnetnick, '-', dcc[idx].u.bot->numver, dcc[idx].ssl);
+#else
+  addbot(dcc[idx].nick, dcc[idx].nick, botnetnick, '-', dcc[idx].u.bot->numver, 0);
+#endif
   check_tcl_link(dcc[idx].nick, botnetnick);
   egg_snprintf(x, sizeof x, "v %d", dcc[idx].u.bot->numver);
   bot_share(idx, x);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1271

One-line summary:
Fix eggdrop build without ssl/tls

Additional description (if needed):
Add ifdef TLS around new ssl code

Test cases demonstrating functionality (if applicable):
