### PR TITLE
Fix handling of interactive terminal (-t) without active other sockets.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -920,8 +920,6 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
              SELECT_TYPE_ARG5 &t);
   if (x == -1)
     return -2;                  /* socket error */
-  if (x == 0)
-    return -3;                  /* idle */
 
   for (i = 0; i < slistmax; i++) {
     if (!tclonly && ((!(slist[i].flags & (SOCK_UNUSED | SOCK_TCL))) &&
@@ -1391,15 +1389,12 @@ void dequeue_sockets()
   if (!z)
     return;                     /* nothing to write */
 
-  x = select((SELECT_TYPE_ARG1) nfds + 1, SELECT_TYPE_ARG234 NULL,
+  select((SELECT_TYPE_ARG1) nfds + 1, SELECT_TYPE_ARG234 NULL,
          SELECT_TYPE_ARG234 &wfds, SELECT_TYPE_ARG234 NULL,
          SELECT_TYPE_ARG5 &tv);
 
 /* end poptix */
 
-  if (x <= 0) {
-    return;
-  }
   for (i = 0; i < threaddata()->MAXSOCKS; i++) {
     if (!(socklist[i].flags & (SOCK_UNUSED | SOCK_TCL)) &&
         (socklist[i].handler.sock.outbuf != NULL) && (FD_ISSET(socklist[i].sock, &wfds))) {


### PR DESCRIPTION
Fix handling of interactive terminal (-t) without active other sockets.

The highest fd can be 0 (STDIN) for select() which was handled incorrectly by passing NULL to the file descriptor list.
Caused a bot without a connection and only listening to stdin to be blocked in a subsequent read() forever and select() to act as 1-second sleep.

Workaround is to always have a listen socket (e.g. listen 3333 all) so the highest fd we are interested in isn't 0.

Was broken by #554 

Found by: Geo
Patch by: thommey
