### PR TITLE
Update ext-join acct for all chans

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2035,7 +2035,7 @@ static int gotjoin(char *from, char *channame)
   int extjoin = 0;
   struct chanset_t *chan;
   struct chanset_t *extchan;
-  memberlist *m;
+  memberlist *m, *n;
   masklist *b;
   struct capability *current;
   struct userrec *u;
@@ -2172,8 +2172,8 @@ static int gotjoin(char *from, char *channame)
           strlcpy(account, newsplit(&channame), sizeof account);
           if (strcmp(account, "*")) {
             for (extchan = chanset; extchan; extchan = extchan->next) {
-              if ((m = ismember(extchan, nick))) {
-                strlcpy (m->account, account, sizeof m->account);
+              if ((n = ismember(extchan, nick))) {
+                strlcpy (n->account, account, sizeof n->account);
               }
             }
           }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2025,6 +2025,7 @@ static void set_delay(struct chanset_t *chan, char *nick)
   m->delay = a_delay;
 }
 
+
 /* Got a join
  */
 static int gotjoin(char *from, char *channame)
@@ -2033,6 +2034,7 @@ static int gotjoin(char *from, char *channame)
   char *ch_dname = NULL;
   int extjoin = 0;
   struct chanset_t *chan;
+  struct chanset_t *extchan;
   memberlist *m;
   masklist *b;
   struct capability *current;
@@ -2166,10 +2168,13 @@ static int gotjoin(char *from, char *channame)
         m->user = u;
         m->flags |= STOPWHO;
         if (extjoin) {
+          /* Update account for all channels the nick is on, not just this one */
           strlcpy(account, newsplit(&channame), sizeof account);
           if (strcmp(account, "*")) {
-            if ((m = ismember(chan, nick))) {
-              strlcpy (m->account, account, sizeof m->account);
+            for (extchan = chanset; extchan; extchan = extchan->next) {
+              if ((m = ismember(extchan, nick))) {
+                strlcpy (m->account, account, sizeof m->account);
+              }
             }
           }
         }


### PR DESCRIPTION
Found by: Jobe
Patch by: Geo
Fixes: #1276 

One-line summary:
Update accounts obtained via extended-join for all channels, not just the current channel

Additional description (if needed):


Test cases demonstrating functionality (if applicable):

User obe is in two channels when Eggdrop joins. User parts and rejoins one, their accout info is made available to the other.

```
.tcl getaccount obe
Tcl: 

[03:17:18] [@] :obe!obe@trophic.failure PART #obe
[03:17:19] [@] :obe!obe@trophic.failure JOIN #obe obe :obe 

.tcl getaccount obe #obe
Tcl: obe
.tcl getaccount obe #unrealircd
Tcl: obe
```