### PR TITLE
Add timers with names

### DIFF
--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -2343,11 +2343,13 @@ utimer <seconds> <tcl-command> [count]
 
   Module: core
 
-^^^^^^
-timers
-^^^^^^
+^^^^^^^^^^^^^^^
+timers [-names]
+^^^^^^^^^^^^^^^
 
-  Returns: a list of active minutely timers. Each entry in the list contains the number of minutes left till activation, the command that will be executed, the timerID, and the remaining number of repeats.
+  Description: lists all active minutely timers.
+
+  Returns: a list of active minutely timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerID, and the remaining numbere of repeats. Additionally, if the -names argument is specified, an additional field displaying the user-provided name for the timer will be shown (or empty if no name was provided).
 
   Module: core
 
@@ -2355,7 +2357,9 @@ timers
 utimers
 ^^^^^^^
 
-  Returns: a list of active secondly timers. Each entry in the list contains the number of minutes left till activation, the command that will be executed, the timerID, and the remaining number of repeats.
+  Description: lists all active secondly timers.
+
+  Returns: a list of active secondly timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerID, and the remaining number of repeats. Additionally, if the -names argument is specified, an additional field displaying the user-provided name for the timer will be shown (or empty if no name was provided).
 
   Module: core
 
@@ -2363,7 +2367,17 @@ utimers
 killtimer <timerID>
 ^^^^^^^^^^^^^^^^^^^
 
-  Description: removes a minutely timer from the list
+  Description: removes the timerID minutely timer from the timer list.
+
+  Returns: nothing
+
+  Module: core
+
+^^^^^^^^^^^^^^^^^^^^^^^^^
+killtimername <timerName>
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Description: if the timer was added with a name, removes the timerName minutely timer from the timer list.
 
   Returns: nothing
 
@@ -2373,7 +2387,17 @@ killtimer <timerID>
 killutimer <timerID>
 ^^^^^^^^^^^^^^^^^^^^
 
-  Description: removes a secondly timer from the list
+  Description: removes the timerName secondly timer from the timer list.
+
+  Returns: nothing
+
+  Module: core
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+killutimername <timerName>
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Description: if the timer was added with a name, removes the timerName secondly timer from the timer list.
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -2323,33 +2323,34 @@ maskhost <nick!user@host> [masktype]
 
   Module: core
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-timer <minutes> <tcl-command> [count]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+timer <minutes> <tcl-command> [count [timerName]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: executes the given Tcl command after a certain number of minutes have passed, at the top of the minute (ie, if a timer is started at 10:03:34 with 1 minute specified, it will execute at 10:04:00. If a timer is started at 10:06:34 with 2 minutes specified, it will execute at 10:08:00). If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the timer will repeat until it's removed with killtimer or until the bot is restarted.
+  Description: executes the given Tcl command after a certain number of minutes have passed, at the top of the minute (ie, if a timer is started at 10:03:34 with 1 minute specified, it will execute at 10:04:00. If a timer is started at 10:06:34 with 2 minutes specified, it will execute at 10:08:00). If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the timer will repeat until it's removed with killtimer or until the bot is restarted. If timerName is specified, this is the name Eggdrop will associate to the timer. If no timerName is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
 
-  Returns: a timerID
-
-  Module: core
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-utimer <seconds> <tcl-command> [count]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted.
-
-  Returns: a timerID
+  Returns: a timerName
 
   Module: core
 
-^^^^^^^^^^^^^^^
-timers [-names]
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+utimer <seconds> <tcl-command> [count [timerName]]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted. If timerName is specified, this is the name Eggdrop will associate to the timer. If no timer
+Name is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
+
+  Returns: a timerName
+
+  Module: core
+
+^^^^^^
+timers
+^^^^^^
 
   Description: lists all active minutely timers.
 
-  Returns: a list of active minutely timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerID, and the remaining numbere of repeats. Additionally, if the -names argument is specified, an additional field displaying the user-provided name for the timer will be shown (or empty if no name was provided).
+  Returns: a list of active minutely timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerName, and the remaining number of repeats.
 
   Module: core
 
@@ -2359,45 +2360,25 @@ utimers
 
   Description: lists all active secondly timers.
 
-  Returns: a list of active secondly timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerID, and the remaining number of repeats. Additionally, if the -names argument is specified, an additional field displaying the user-provided name for the timer will be shown (or empty if no name was provided).
+  Returns: a list of active secondly timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerName, and the remaining number of repeats.
 
   Module: core
 
 ^^^^^^^^^^^^^^^^^^^
-killtimer <timerID>
+killtimer <timerName>
 ^^^^^^^^^^^^^^^^^^^
 
-  Description: removes the timerID minutely timer from the timer list.
-
-  Returns: nothing
-
-  Module: core
-
-^^^^^^^^^^^^^^^^^^^^^^^^^
-killtimername <timerName>
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Description: if the timer was added with a name, removes the timerName minutely timer from the timer list.
+  Description: removes the timerName minutely timer from the timer list.
 
   Returns: nothing
 
   Module: core
 
 ^^^^^^^^^^^^^^^^^^^^
-killutimer <timerID>
+killutimer <timerName>
 ^^^^^^^^^^^^^^^^^^^^
 
   Description: removes the timerName secondly timer from the timer list.
-
-  Returns: nothing
-
-  Module: core
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-killutimername <timerName>
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Description: if the timer was added with a name, removes the timerName secondly timer from the timer list.
 
   Returns: nothing
 

--- a/doc/sphinx_source/mainDocs/tcl-commands.rst
+++ b/doc/sphinx_source/mainDocs/tcl-commands.rst
@@ -2327,7 +2327,7 @@ maskhost <nick!user@host> [masktype]
 timer <minutes> <tcl-command> [count [timerName]]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: executes the given Tcl command after a certain number of minutes have passed, at the top of the minute (ie, if a timer is started at 10:03:34 with 1 minute specified, it will execute at 10:04:00. If a timer is started at 10:06:34 with 2 minutes specified, it will execute at 10:08:00). If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the timer will repeat until it's removed with killtimer or until the bot is restarted. If timerName is specified, this is the name Eggdrop will associate to the timer. If no timerName is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
+  Description: executes the given Tcl command after a certain number of minutes have passed, at the top of the minute (ie, if a timer is started at 10:03:34 with 1 minute specified, it will execute at 10:04:00. If a timer is started at 10:06:34 with 2 minutes specified, it will execute at 10:08:00). If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the timer will repeat until it's removed with killtimer or until the bot is restarted. If timerName is specified, it will become the unique identifier for the timer. If no timerName is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
 
   Returns: a timerName
 
@@ -2337,7 +2337,7 @@ timer <minutes> <tcl-command> [count [timerName]]
 utimer <seconds> <tcl-command> [count [timerName]]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted. If timerName is specified, this is the name Eggdrop will associate to the timer. If no timer
+  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted. If timerName is specified, it will become the unique identifier for the timer. If no timer
 Name is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
 
   Returns: a timerName

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -616,7 +616,7 @@ int remove_timer_name(tcl_timer_t **stack, char *name)
   int ok = 0;
 
   while (*stack) {
-    if (!strcasecmp((*stack)->name, name)) {
+    if (((*stack)->name) && (!strcasecmp((*stack)->name, name))) {
       ok++;
       remove_timer_from_list(stack);
     } else {
@@ -711,7 +711,7 @@ void list_timers(Tcl_Interp *irp, tcl_timer_t *stack, int names)
   }
 }
 
-/* Find a timer by name
+/* Find a timer by name. Returns 1 if found, 0 if not
  */
 int find_timer(tcl_timer_t *stack, char *name)
 {
@@ -720,11 +720,11 @@ int find_timer(tcl_timer_t *stack, char *name)
   for (mark = stack; mark; mark = mark->next) {
     if (mark->name) {
       if (!strcasecmp(mark->name, name)) {
-        return 0;
+        return 1;
       }
     }
   }
-  return 1;
+  return 0;
 }
 
 int isowner(char *name) {

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -676,7 +676,7 @@ void wipe_timers(Tcl_Interp *irp, tcl_timer_t **stack)
 
 /* Return list of timers
  */
-void list_timers(Tcl_Interp *irp, tcl_timer_t *stack, int names)
+void list_timers(Tcl_Interp *irp, tcl_timer_t *stack)
 {
   char mins[11], count[11], id[26], *x;
   EGG_CONST char *argv[5];

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -678,13 +678,12 @@ void wipe_timers(Tcl_Interp *irp, tcl_timer_t **stack)
  */
 void list_timers(Tcl_Interp *irp, tcl_timer_t *stack)
 {
-  char mins[11], count[11], id[26], *x;
-  EGG_CONST char *argv[5];
+  char mins[11], count[11], *x;
+  EGG_CONST char *argv[4];
   tcl_timer_t *mark;
 
   for (mark = stack; mark; mark = mark->next) {
     snprintf(mins, sizeof mins, "%u", mark->mins);
-    snprintf(id, sizeof id, "timer%lu", mark->id);
     snprintf(count, sizeof count, "%u", mark->count);
     argv[0] = mins;
     argv[1] = mark->cmd;

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -610,7 +610,7 @@ int remove_timer(tcl_timer_t **stack, char *name)
   int ok = 0;
 
   while (*stack) {
-    if (((*stack)->name) && (!strcasecmp((*stack)->name, name))) {
+    if ((*stack)->name && !strcasecmp((*stack)->name, name)) {
       ok++;
       remove_timer_from_list(stack);
     } else {

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -559,7 +559,7 @@ char * add_timer(tcl_timer_t ** stack, int elapse, int count,
 {
   tcl_timer_t *old = (*stack);
   char stringid[8];
-  unsigned int ret = 0;
+  unsigned int ret;
 
   *stack = nmalloc(sizeof **stack);
   (*stack)->next = old;

--- a/src/tclegg.h
+++ b/src/tclegg.h
@@ -139,7 +139,7 @@ typedef struct timer_str {
 char * add_timer(tcl_timer_t **, int, int, char *, char *, unsigned long);
 int find_timer(tcl_timer_t *, char *);
 int remove_timer(tcl_timer_t **, char *);
-void list_timers(Tcl_Interp *, tcl_timer_t *, int names);
+void list_timers(Tcl_Interp *, tcl_timer_t *);
 void wipe_timers(Tcl_Interp *, tcl_timer_t **);
 void do_check_timers(tcl_timer_t **);
 

--- a/src/tclegg.h
+++ b/src/tclegg.h
@@ -136,10 +136,9 @@ typedef struct timer_str {
         }                                                               \
 } while (0)
 
-unsigned long add_timer(tcl_timer_t **, int, int, char *, char *, unsigned long);
+char * add_timer(tcl_timer_t **, int, int, char *, char *, unsigned long);
 int find_timer(tcl_timer_t *, char *);
-int remove_timer(tcl_timer_t **, unsigned long);
-int remove_timer_name(tcl_timer_t **, char *);
+int remove_timer(tcl_timer_t **, char *);
 void list_timers(Tcl_Interp *, tcl_timer_t *, int names);
 void wipe_timers(Tcl_Interp *, tcl_timer_t **);
 void do_check_timers(tcl_timer_t **);

--- a/src/tclegg.h
+++ b/src/tclegg.h
@@ -104,6 +104,7 @@ typedef struct timer_str {
   unsigned int interval;        /* Time to elapse                       */
   char *cmd;                    /* Command linked to                    */
   unsigned long id;             /* Used to remove timers                */
+  char *name;                   /* User-specified name for timer        */
 } tcl_timer_t;
 
 
@@ -135,9 +136,11 @@ typedef struct timer_str {
         }                                                               \
 } while (0)
 
-unsigned long add_timer(tcl_timer_t **, int, int, char *, unsigned long);
+unsigned long add_timer(tcl_timer_t **, int, int, char *, char *, unsigned long);
+int find_timer(tcl_timer_t *, char *);
 int remove_timer(tcl_timer_t **, unsigned long);
-void list_timers(Tcl_Interp *, tcl_timer_t *);
+int remove_timer_name(tcl_timer_t **, char *);
+void list_timers(Tcl_Interp *, tcl_timer_t *, int names);
 void wipe_timers(Tcl_Interp *, tcl_timer_t **);
 void do_check_timers(tcl_timer_t **);
 

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -248,14 +248,15 @@ static int tcl_binds STDVAR
 
 int check_timer_syntax(Tcl_Interp *irp, int argc, char *argv[]) {
   char *endptr;
+  long val;
 
   if (atoi(argv[1]) < 0) {
     Tcl_AppendResult(irp, "time value must be positive", NULL);
     return 1;
   }
   if (argc >=4) {
-    strtol(argv[3], &endptr, 0);
-    if (*endptr != '\0') {
+    val = strtol(argv[3], &endptr, 0);
+    if ((*endptr != '\0') || (val < 0)) {
       Tcl_AppendResult(irp, "count value must be >=0", NULL);
       return 1;
     }

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -274,7 +274,7 @@ static int tcl_timer STDVAR
       }
     }
     x = add_timer(&timer, atoi(argv[1]), (argc >= 4 ? atoi(argv[3]) : 1),
-                  argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
+                  argv[2], (argc == 5 ? argv[4] : NULL), 0L);
     if (!x) {
       Tcl_AppendResult(irp, "Too many timers (wow, impressive). Timer not added", NULL);
       return TCL_ERROR;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -262,14 +262,16 @@ static int tcl_timer STDVAR
     return TCL_ERROR;
   }
   if (argv[2][0] != '#') {
-    if ((argc == 5) && find_timer(timer, argv[4])) {
-      x = add_timer(&timer, atoi(argv[1]), (argc >= 4 ? atoi(argv[3]) : 1),
+    if (argc == 5) {
+      if (find_timer(timer, argv[4])) {
+        x = add_timer(&timer, atoi(argv[1]), (argc >= 4 ? atoi(argv[3]) : 1),
                   argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
-      snprintf(s, sizeof s, "timer%lu", x);
-      Tcl_AppendResult(irp, s, NULL);
-    } else {
-      Tcl_AppendResult(irp, "timer already exists by that name", NULL);
-      return TCL_ERROR;
+        snprintf(s, sizeof s, "timer%lu", x);
+        Tcl_AppendResult(irp, s, NULL);
+      } else {
+        Tcl_AppendResult(irp, "timer already exists by that name", NULL);
+        return TCL_ERROR;
+      }
     }
   }
   return TCL_OK;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -300,7 +300,7 @@ static int tcl_utimer STDVAR
   }
   if (argv[2][0] != '#') {
     if (argc == 5) {
-      /* Precent collisions with unnamed timers */
+      /* Prevent collisions with unnamed timers */
       if (strncmp(argv[4], "timer", 5) == 0) {
         Tcl_AppendResult(irp, "timer name may not begin with \"timer\"", NULL);
         return TCL_ERROR;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -262,17 +262,14 @@ static int tcl_timer STDVAR
     return TCL_ERROR;
   }
   if (argv[2][0] != '#') {
-    if (argc == 5) {
-      if (find_timer(timer, argv[4])) {
-        x = add_timer(&timer, atoi(argv[1]), (argc >= 4 ? atoi(argv[3]) : 1),
-                  argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
-        snprintf(s, sizeof s, "timer%lu", x);
-        Tcl_AppendResult(irp, s, NULL);
-      } else {
-        Tcl_AppendResult(irp, "timer already exists by that name", NULL);
-        return TCL_ERROR;
-      }
+    if ((argc == 5) && (find_timer(timer, argv[4]))) {
+      Tcl_AppendResult(irp, "timer already exists by that name", NULL);
+      return TCL_ERROR;
     }
+    x = add_timer(&timer, atoi(argv[1]), (argc >= 4 ? atoi(argv[3]) : 1),
+                  argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
+    snprintf(s, sizeof s, "timer%lu", x);
+    Tcl_AppendResult(irp, s, NULL);
   }
   return TCL_OK;
 }

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -343,11 +343,7 @@ static int tcl_timers STDVAR
 {
   BADARGS(1, 1, "");
 
-  if ((argc == 2) && (!strcasecmp(argv[1], "-names"))) {
-    list_timers(irp, timer, 1);
-  } else {
-    list_timers(irp, timer, 0);
-  }
+  list_timers(irp, timer);
   return TCL_OK;
 }
 
@@ -355,11 +351,7 @@ static int tcl_utimers STDVAR
 {
   BADARGS(1, 1, "");
 
-  if ((argc == 2) && (!strcasecmp(argv[1], "-names"))) {
-    list_timers(irp, utimer, 1);
-  } else {
-    list_timers(irp, utimer, 0);
-  }
+  list_timers(irp, utimer);
   return TCL_OK;
 }
 

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -291,14 +291,13 @@ static int tcl_utimer STDVAR
   }
   if (argv[2][0] != '#') {
     if ((argc == 5) && find_timer(utimer, argv[4])) {
-      x = add_timer(&utimer, atoi(argv[1]), (argc == 4 ? atoi(argv[3]) : 1),
-                  argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
-      snprintf(s, sizeof s, "timer%lu", x);
-      Tcl_AppendResult(irp, s, NULL);
-    } else {
       Tcl_AppendResult(irp, "timer already exists by that name", NULL);
       return TCL_ERROR;
     }
+    x = add_timer(&utimer, atoi(argv[1]), (argc == 4 ? atoi(argv[3]) : 1),
+                  argv[2], (argc == 5 ? argv[4] : '\0'), 0L);
+    snprintf(s, sizeof s, "timer%lu", x);
+    Tcl_AppendResult(irp, s, NULL);
   }
   return TCL_OK;
 }


### PR DESCRIPTION
Adds the ability to set a custom name when creating timers/utimers. Names are displayed when the eggdrop Tcl 'timers' command is run with the -names flag. Multiple timers with the same name cannot be added. Tcl commands killtimername and killtimeruname are added to kill timers with a provided name. Using -name requires the count positional variable to be specified. #1285 

Test cases:

.tcl timer 10 foo 1
Tcl: timer1
.tcl timer 11 goo 2 myTimer
Tcl: timer2

.tcl timers
Tcl: {11 goo timer2 2} {10 foo timer1 1} 

.tcl timers -names
Tcl: {11 goo timer2 2 myTimer} {10 foo timer1 1 {}}

.tcl killtimername mytimer
Tcl: 
.tcl timers -names
Tcl: {10 foo timer1 1 {}}