### PR TITLE
add vscode contenaire in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,47 @@ config.cache
 eggdrop
 EGGMOD.stamp
 mod.xlibs
+# CVS default ignores begin
+tags
+TAGS
+.make.state
+.nse_depinfo
+*~
+#*
+.#*
+,*
+_$*
+*$
+*.old
+*.bak
+*.BAK
+*.orig
+*.rej
+.del-*
+*.a
+*.olb
+*.o
+*.obj
+*.so
+*.exe
+*.Z
+*.elc
+*.ln
+core
+# CVS default ignores end
+autom4te.cache
+Makefile
+.modules
+.known_modules
+/config.h
+/eggint.h
+/lush.h
+config.log
+config.status
+config.cache
+eggdrop
+EGGMOD.stamp
+mod.xlibs
+# vscode container
+.devcontainer/*
+.vscode/*


### PR DESCRIPTION
Found by:ZarTek
Patch by:
Fixes: 

One-line summary:
Added two directories for those who use vscode and the vscode container

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
