### PR TITLE
Update port tls to 6697 - rfc7194

### DIFF
--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -95,7 +95,7 @@ set network "I.didn't.edit.my.config.file.net"
 server add you.need.to.change.this 6667
 server add another.example.com 6669 password
 server add 2001:db8:618:5c0:263:: 6669 password
-server add ssl.example.net +7000
+server add ssl.example.net +6697
 
 ############################################################################
 ## Network settings overview

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1095,7 +1095,7 @@ set default-port 6667
 server add you.need.to.change.this 6667
 server add another.example.com 6669 password
 server add 2001:db8:618:5c0:263:: 6669 password
-server add ssl.example.net +7000
+server add ssl.example.net +6697
 
 #### CAP Features ####
 # This section controls IRCv3 capabilities supported natively by Eggdrop. You


### PR DESCRIPTION
Found by: ZarTeK
Patch by: ZarTeK
Fixes: port tls per default is 6697 and not 7000 in rfc7194

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
