### PR TITLE
Uptime dns cache expiry

### DIFF
--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -260,6 +260,11 @@ void check_secondly()
   }
 }
 
+void expire_dnscache()
+{
+  uptimeip = -1;
+}
+
 static char *uptime_close()
 {
   return "You cannot unload the uptime module "
@@ -288,6 +293,7 @@ char *uptime_start(Function *global_funcs)
 
     add_help_reference("uptime.help");
     add_hook(HOOK_MINUTELY, (Function) check_minutely);
+    add_hook(HOOK_DAILY, (Function) expire_dnscache);
     init_uptime();
   }
   return NULL;


### PR DESCRIPTION
every time we have to switch uptime server IPs we have this problem, this fixes it

I don't think the expiry time needs to honor the normal dns settings or be configurable

Found by: Geo
Patch by: thommey
Fixes: #1300 