### PR TITLE
reduce TLS log noise

### DIFF
--- a/help/cmds2.help
+++ b/help/cmds2.help
@@ -210,8 +210,8 @@ See also: whom
 See also: rehash, reload, save
 %{help=save}%{+m|m}
 ###  %bsave%b
-   This makes the bot write its entire userfile to disk. This is useful if you
-   think the bot is about to crash or something, since the user file is only
+   This makes the bot write its entire userfile and channel file to disk. This
+   is useful if you want to force a save of these files since they are only
    written to disk about once an hour.
 
 See also: reload, rehash, backup

--- a/src/tls.c
+++ b/src/tls.c
@@ -739,7 +739,7 @@ static void ssl_info(const SSL *ssl, int where, int ret)
            "established.");
 
     if ((cert = SSL_get_peer_certificate(ssl))) {
-      ssl_showcert(cert, data->loglevel);
+      ssl_showcert(cert, LOG_DEBUG);
       X509_free(cert);
     }
     else

--- a/src/tls.c
+++ b/src/tls.c
@@ -748,7 +748,7 @@ static void ssl_info(const SSL *ssl, int where, int ret)
     /* Display cipher information */
     cipher = SSL_get_current_cipher(ssl);
     processed = SSL_CIPHER_get_bits(cipher, &secret);
-    putlog(data->loglevel, "*", "TLS: cipher used: %s %s; %d bits (%d secret)",
+    putlog(LOG_DEBUG, "*", "TLS: cipher used: %s %s; %d bits (%d secret)",
            SSL_CIPHER_get_name(cipher), SSL_get_version(ssl),
            processed, secret);
     /* secret are the actually secret bits. If processed and secret differ,


### PR DESCRIPTION
Found by:
Patch by:
Fixes: #1292
Fixes: #1293

and update save help

Before:
```
[21:03:04] TLS: handshake successful. Secure connection established.
[21:03:04] TLS: certificate subject: CN=molybdenum.libera.chat
[21:03:04] TLS: certificate issuer: C=US, O=Let's Encrypt, CN=R3
[21:03:04] TLS: certificate SHA1 Fingerprint: F8:CF:59:4F:D7:E4:35:29:6F:EC:DA:C7:E4:18:ED:EE:9B:71:C9:D8
[21:03:04] TLS: certificate SHA-256 Fingerprint: 59:11:B8:75:D2:6E:8B:FA:0A:9A:BE:69:1E:AC:BE:CC:A9:F7:47:4E:C0:73:10:B1:54:6F:04:4F:6E:8D:25:51
[21:03:04] TLS: certificate valid from Jul  4 05:01:57 2022 GMT to Oct  2 05:01:56 2022 GMT
[21:03:04] TLS: cipher used: TLS_AES_256_GCM_SHA384 TLSv1.3; 256 bits (256 secret)
[21:03:04] TLS: cipher details: TLS_AES_256_GCM_SHA384  TLSv1.3 Kx=any      Au=any  Enc=AESGCM(256) Mac=AEAD
```

After:
```
[20:58:18] TLS: handshake successful. Secure connection established.
[20:58:18] TLS: cipher used: TLS_CHACHA20_POLY1305_SHA256 TLSv1.3; 256 bits (256 secret)
```