### PR TITLE
remove account2hand

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -229,11 +229,11 @@ validuser <handle>
 
   Module: core
 
-^^^^^^^^^^^^^^^^^^^^^^^^^
-finduser <nick!user@host>
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+finduser [-account] <value>
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: finds the user record which most closely matches the given nick!user\@host
+  Description: finds the internal user record which most closely matches the given value. When used with the -account flag, value is a services account name, otherwise by default value is a string in the hostmask format of nick!user\@host.
 
   Returns: the handle found, or "*" if none
 
@@ -1166,12 +1166,6 @@ nick2hand <nickname> [channel]
   Returns: the handle of a nickname on a channel. If a channel is not specified, the bot will check all of its channels. If the nick is not found, "" is returned. If the nick is found but does not have a handle, "*" is returned. If no channel is specified, all channels are checked.
 
   Module: irc
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-account2hand <nickname> [channel]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-  Returns: the handle associated with the internally-tracked services account of the provided nickname, or "" if no match is found. This command will only work if a server supports (and Eggdrop has enabled) the account-notify and extended-join capabilities, and the server understands WHOX requests (also known as raw 354 responses). If no channel is specified, all channels are checked.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 account2nicks <handle> [channel]

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -1055,44 +1055,6 @@ static int tcl_topic STDVAR
   return TCL_OK;
 }
 
-/* Takes a provided nickname, looks up the account associated with that nick in
- * the channel record, then finds the handle associated with that same account.
- * Returns the first handle found associated with the account, as accounts are
- * unique in a userfile.
- */
-static int tcl_account2hand STDVAR
-{
-  memberlist *m;
-  struct userrec *u;
-  struct chanset_t *chan, *thechan = NULL;
-
-  BADARGS(2, 3, " nick ?channel?");
-
-  if (argc > 2) {
-    chan = findchan_by_dname(argv[2]);
-    thechan = chan;
-    if (chan == NULL) {
-      Tcl_AppendResult(irp, "invalid channel: ", argv[2], NULL);
-      return TCL_ERROR;
-    }
-  } else
-    chan = chanset;
-
-  while (chan && (thechan == NULL || thechan == chan)) {
-        m = ismember(chan, argv[1]);
-    if (m) {                            /* If we find the nickname on a channel */
-      if (m->account[0]) {                 /* And they have an account */
-        u = get_user_by_account(m->account);
-        Tcl_AppendResult(irp, u ? u->handle : "", NULL);
-        return TCL_OK;                  /* Return the handle */
-      }
-    }
-    chan = chan->next;
-  }
-  return TCL_OK;
-}
-
-
 static int tcl_account2nicks STDVAR
 {
   memberlist *m;
@@ -1347,7 +1309,6 @@ static tcl_cmds tclchan_cmds[] = {
   {"hand2nicks",     tcl_hand2nicks},
   {"hand2nick",      tcl_hand2nick},
   {"nick2hand",      tcl_nick2hand},
-  {"account2hand",   tcl_account2hand},
   {"getchanmode",    tcl_getchanmode},
   {"getchanjoin",    tcl_getchanjoin},
   {"flushmode",      tcl_flushmode},

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -57,9 +57,13 @@ static int tcl_finduser STDVAR
 {
   struct userrec *u;
 
-  BADARGS(2, 2, " nick!user@host");
+  BADARGS(2, 3, " ?-account? searchString");
 
-  u = get_user_by_host(argv[1]);
+  if (!strcasecmp(argv[1], "-account")) {
+    u = get_user_by_account(argv[2]);
+  } else {
+    u = get_user_by_host(argv[1]);
+  }
   Tcl_AppendResult(irp, u ? u->handle : "*", NULL);
   return TCL_OK;
 }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -59,8 +59,13 @@ static int tcl_finduser STDVAR
 
   BADARGS(2, 3, " ?-account? searchString");
 
-  if (!strcasecmp(argv[1], "-account")) {
-    u = get_user_by_account(argv[2]);
+  if (argc == 3) {
+    if (!strcasecmp(argv[1], "-account")) {
+      u = get_user_by_account(argv[2]);
+    } else {
+      Tcl_AppendResult(irp, "invalid option, must be -account", NULL);
+      return TCL_ERROR;
+    }
   } else {
     u = get_user_by_host(argv[1]);
   }


### PR DESCRIPTION
modify finduser to search for account records in userfile.
the desired functionality of account2hand will be present in the next release's version of nick2hand, so no need to create a superflous command now

```
  ACCOUNTS: tstuser, goo
.tcl finduser -account tstuser
Tcl: geo
.tcl finduser -account no
Tcl: *
bar@foo.com
Tcl: *
.tcl finduser -who me
Tcl error: invalid option, must be -account
```

Test cases demonstrating functionality (if applicable):
