### PR TITLE
Update ssl.conf

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -313,10 +313,10 @@ sslstart:
 	fi
 
 sslcert: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
+	openssl req -new -x509 -nodes -days 3650 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
 
 sslsilent: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
+	openssl req -new -x509 -nodes -days 3650 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
 	    -subj "/O=Eggheads/OU=Eggdrop/CN=Self-generated Eggdrop Certificate"
 
 install: ainstall

--- a/ssl.conf
+++ b/ssl.conf
@@ -10,7 +10,7 @@ default_ca			= CA_default	# The default ca section
 ####################################################################
 [ CA_default ]
 
-default_days			= 365		# how long to certify for
+default_days			= 3650		# how long to certify for
 default_crl_days		= 30		# how long before next CRL
 default_md			= sha1		# which md to use.
 


### PR DESCRIPTION
Most of the generators I know, use 3650 days (~10 years) for self-signed certificates. IMHO, eggdrop could do the same.
 As someone stated on IRC: 
  - 10 year is the usual "next employee's problem" duration