### PR TITLE
Update generatedocs

### DIFF
--- a/misc/generatedocs
+++ b/misc/generatedocs
@@ -69,7 +69,7 @@ SPHINX="$(which sphinx-build)"
 if [ $? -eq 0 ]; then
   echo "Found."
 else
-  echo "Not found. Sphinx can be found at http://www.sphinx-doc.org or via apt-get install python-sphinx. Exiting..."
+  echo "Not found. Sphinx can be found at http://www.sphinx-doc.org or via apt-get install sphinx-common. Exiting..."
   exit 1
 fi
 


### PR DESCRIPTION
sphinx-build replace python-sphinx on debian bulleyes

Found by:Zartek Creole
Patch by:Zartek Creole
Fixes: 
 the old package named python-sphinx is now sphinx-common
One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
