### PR TITLE
Fix incorrect log +host log messagee 

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -3145,6 +3145,7 @@ static void cmd_mns_user(struct userrec *u, int idx, char *par)
 static void cmd_pls_host(struct userrec *u, int idx, char *par)
 
 {
+  int ret;
   char *handle, *host;
   module_entry *me;
 
@@ -3160,13 +3161,14 @@ static void cmd_pls_host(struct userrec *u, int idx, char *par)
     host = handle;
     handle = dcc[idx].nick;
   }
-  add_to_handle(u, idx, handle, host, 0);
-  putlog(LOG_CMDS, "*", "#%s# +host %s %s", dcc[idx].nick, handle, host);
-  dprintf(idx, "Added '%s' to %s.\n", host, handle);
-  if ((me = module_find("irc", 0, 0))) {
-    Function *func = me->funcs;
-
-    (func[IRC_CHECK_THIS_USER]) (handle, 0, NULL);
+  ret = add_to_handle(u, idx, handle, host, 0);
+  if (!ret) {
+    putlog(LOG_CMDS, "*", "#%s# +host %s %s", dcc[idx].nick, handle, host);
+    dprintf(idx, "Added '%s' to %s.\n", host, handle);
+    if ((me = module_find("irc", 0, 0))) {
+      Function *func = me->funcs;
+      (func[IRC_CHECK_THIS_USER]) (handle, 0, NULL);
+    }
   }
 }
 


### PR DESCRIPTION
Found by: thommey
Patch by: Geo

As part of the account tracking PR, a new shared function was added for +host and +account, but only +account checked the return value of this function for an error.