### PR TITLE
Put gotmsg back where it belongs

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -3038,6 +3038,7 @@ static cmd_t irc_raw[] = {
   {"KICK",    "",   (IntFunc) gotkick,        "irc:kick"},
   {"NICK",    "",   (IntFunc) gotnick,        "irc:nick"},
   {"QUIT",    "",   (IntFunc) gotquit,        "irc:quit"},
+  {"PRIVMSG", "",   (IntFunc) gotmsg,          "irc:msg"},
   {"NOTICE",  "",   (IntFunc) gotnotice,    "irc:notice"},
   {"MODE",    "",   (IntFunc) gotmode,        "irc:mode"},
   {"AWAY",    "",   (IntFunc) gotaway,     "irc:gotaway"},
@@ -3052,9 +3053,4 @@ static cmd_t irc_raw[] = {
 static cmd_t irc_isupport_binds[] = {
   {"*",       "",   (IntFunc) irc_isupport, "irc:isupport"},
   {NULL,    NULL,   NULL,                             NULL}
-};
-
-static cmd_t irc_rawt[] = {
-  {"PRIVMSG", "",   (IntFunc) gotmsg,          "irc:msg"},
-  {NULL,      NULL, NULL,                           NULL}
 };

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1301,7 +1301,6 @@ static char *irc_close()
   rem_builtins(H_dcc, irc_dcc);
   rem_builtins(H_msg, C_msg);
   rem_builtins(H_raw, irc_raw);
-  rem_builtins(H_rawt, irc_rawt);
   rem_builtins(H_isupport, irc_isupport_binds);
   rem_tcl_commands(tclchan_cmds);
   rem_help_reference("irc.help");
@@ -1409,7 +1408,6 @@ char *irc_start(Function *global_funcs)
   add_builtins(H_dcc, irc_dcc);
   add_builtins(H_msg, C_msg);
   add_builtins(H_raw, irc_raw);
-  add_builtins(H_rawt, irc_rawt);
   add_builtins(H_isupport, irc_isupport_binds);
   add_tcl_commands(tclchan_cmds);
   add_help_reference("irc.help");

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1990,6 +1990,7 @@ static int server_isupport(char *key, char *isset_str, char *value)
 }
 
 static cmd_t my_raw_binds[] = {
+  {"PRIVMSG",      "",   (IntFunc) gotmsg,          NULL},
   {"NOTICE",       "",   (IntFunc) gotnotice,       NULL},
   {"MODE",         "",   (IntFunc) gotmode,         NULL},
   {"PING",         "",   (IntFunc) gotping,         NULL},
@@ -2035,7 +2036,6 @@ static cmd_t my_raw_binds[] = {
 
 static cmd_t my_rawt_binds[] = {
   {"TAGMSG",       "",   (IntFunc) gottagmsg,       NULL},
-  {"PRIVMSG",      "",   (IntFunc) gotmsg,          NULL},
   {NULL,           NULL, NULL,                      NULL}
 };
 


### PR DESCRIPTION
Found by: CrazyCat

The gotmsg function was inadvertently moved to a rawt bind from the raw bind, which could cause issues with scripts attempting to unbind this internal reference.