### PR TITLE
Fixes a DNS bug when DCC connections were lost

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -34,7 +34,6 @@ typedef struct {
 typedef struct {
   char *proc;                   /* Tcl proc                        */
   char *paras;                  /* Additional parameters           */
-  sockname_t sockname;
 } devent_tclinfo_t;
 
 typedef struct devent_str {


### PR DESCRIPTION
In a host->IP scenario, devent_t contains a malloc'd copy of the hostname.
In the IP->host scenario however, devent_t contained an outside allocated pointer
to ip_addr (sockname_t).
In the Tcl case it was embedded in the tclinfo structure, but in the DCC case
it pointed to the idx information in dcc[i].
"Lost connection" wipes that idx info and invalidates it, invalidating
the information about the pending dns request. That would then get stuck with
invalid data.

As soon as the idx is re-used however, the address is overwritten by answer(),
and dns thinks it already sent a request for that IP, also it gets stuck.

The fix treats IP->host the same as host->IP and dynamically allocates the IP
as it does with the hostname.

Found by: DasBrain, ERR1R, CrazyCat
Patch by: thommey
Fixes: #1174

Test case: Setup listening port that gets portscanned constantly (e.g. 8080, 8888) and wait for some connections to be fast enough that the DNS request is still pending. Or use the Linux TC subsystem or iptables to slow down/drop dns traffic temporarily to make it last long enough.