### PR TITLE
Fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -204,7 +204,7 @@ Eggdrop v1.9.0:
       with 'refreshchan w', described above.
     - Added the hand2nicks command, an alternative to the hand2nick command.
       hand2nicks returns ALL nicks matching a handle, not just the first one.
-    - Aded the socklist command, an update to the dcclist command. Returns
+    - Added the socklist command, an update to the dcclist command. Returns
       similar info as a Tcl dict, and adds the IP to the information.
     - Use the system's strftime formatting instead of Eggdrop-provided
       GNU version/extensions. This could cause formatting differences

--- a/doc/html/install/upgrading.html
+++ b/doc/html/install/upgrading.html
@@ -105,7 +105,7 @@
   <div class="section" id="upgrading-eggdrop">
 <h1>Upgrading Eggdrop<a class="headerlink" href="#upgrading-eggdrop" title="Permalink to this headline">¶</a></h1>
 <blockquote>
-<div><p>It is easy to upgrade Eggdrop to a new version! To have a full picture of the changes made since your last upgrade, we recommed reading the NEWS file. Upgrades from the 1.6 and 1.8 lines of Eggdrop should take place with little to no issues. The config file, user files, and channel files can all be reused.</p>
+<div><p>It is easy to upgrade Eggdrop to a new version! To have a full picture of the changes made since your last upgrade, we recommend reading the NEWS file. Upgrades from the 1.6 and 1.8 lines of Eggdrop should take place with little to no issues. The config file, user files, and channel files can all be reused.</p>
 <p>For support, feel free to visit us on Libera #eggdrop.</p>
 </div></blockquote>
 <div class="section" id="how-to-upgrade">

--- a/doc/sphinx_source/modules/mod/filesys.rst
+++ b/doc/sphinx_source/modules/mod/filesys.rst
@@ -222,7 +222,7 @@ rm <file> [files] ...
   Cleans up the current directory's database. If you have a large
   directory with many files you may want to use this command if
   you experience slow-downs/delays over time. Normally, the db
-  should clean up itsself though.
+  should clean up itself though.
 
 ^^^^^^^
 .unhide

--- a/doc/sphinx_source/modules/mod/irc.rst
+++ b/doc/sphinx_source/modules/mod/irc.rst
@@ -84,7 +84,7 @@ There are also some variables you can set in your config file:
   | bind msg - myword \*msg:hello
 
     Many IRCops find bots by seeing if they reply to 'hello' in a msg. You
-    can change this to another word by un-commenting thse two lines and
+    can change this to another word by un-commenting these two lines and
     changing "myword" to the word wish to use instead of'hello'. It must be
     a single word.
 

--- a/src/language.c
+++ b/src/language.c
@@ -44,7 +44,7 @@
  * FILE FORMAT: language.lang
  *              <textidx>,<text>
  * TEXT MESSAGE USAGE:
- *              get_language(<textidx> [,<PARMS>])
+ *              get_language(<textidx> [,<PARAMS>])
  *
  * ADDING LANGUAGES:
  *              o       Copy an existing <section>.<oldlanguage>.lang to a

--- a/src/mod/filesys.mod/help/filesys.help
+++ b/src/mod/filesys.mod/help/filesys.help
@@ -167,7 +167,7 @@ see also: unshare, lsa, ln
    cleans up the current directory's database.  if you have a large
    directory with many files you may want to use this command if
    you experience slow-downs/delays over time.  normally, the db
-   should clean up itsself though.
+   should clean up itself though.
 %{help=filesys/sort}%{+j}
 ###  %bsort%b
    this command is obsolete, because the directory is always

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1881,7 +1881,7 @@ static int gotinvite(char *from, char *msg)
   check_tcl_invite(nick, from, msg, invitee);
 /* Because who needs RFCs? Freakin IRCv3... */
   if (!match_my_nick(invitee)) {
-    putlog(LOG_DEBUG, "*", "Received invite notifiation for %s to %s by %s.",
+    putlog(LOG_DEBUG, "*", "Received invite notification for %s to %s by %s.",
             invitee, msg, nick);
     return 1;
   }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -460,7 +460,7 @@ void reset_chan_info(struct chanset_t *chan, int reset, int do_reset)
 }
 
 /* Leave the specified channel and notify registered Tcl procs. This
- * should not be called by itsself.
+ * should not be called by itself.
  */
 static void do_channel_part(struct chanset_t *chan)
 {

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -935,7 +935,7 @@ int check_tcl_bind(tcl_bind_list_t *tl, const char *match,
   if (tm_p && tm_p->next) {
     tm = tm_p->next;            /* Move mask to front of bind's mask list. */
     tm_p->next = tm->next;      /* Unlink mask from list. */
-    tm->next = tl->first;       /* Readd mask to front of list. */
+    tm->next = tl->first;       /* Re-add mask to front of list. */
     tl->first = tm;
   }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix typos

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
