### PR TITLE
Fix some year 2038 problems

### DIFF
--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -837,8 +837,8 @@ static void bot_traced(int idx, char *par)
               if (*c == ':')
                 j++;
           }
-          dprintf(i, "%s -> %s (%lu secs, %d hop%s)\n", BOT_TRACERESULT, p,
-                  now - t, j, (j != 1) ? "s" : "");
+          dprintf(i, "%s -> %s (%" PRId64 " secs, %d hop%s)\n", BOT_TRACERESULT,
+                  p, (int64_t) (now - t), j, (j != 1) ? "s" : "");
         } else
           dprintf(i, "%s -> %s\n", BOT_TRACERESULT, p);
       }

--- a/src/dns.c
+++ b/src/dns.c
@@ -86,7 +86,7 @@ static void eof_dcc_dnswait(int idx)
 
 static void display_dcc_dnswait(int idx, char *buf)
 {
-  sprintf(buf, "dns   waited %lis", (long) (now - dcc[idx].timeval));
+  sprintf(buf, "dns   waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 static int expmem_dcc_dnswait(void *x)

--- a/src/main.c
+++ b/src/main.c
@@ -651,13 +651,14 @@ static void core_secondly()
     /* In case for some reason more than 1 min has passed: */
     while (nowmins != lastmin) {
       /* Timer drift, dammit */
-      debug1("timer: drift (%f seconds)", difftime(nowmins, lastmin));
+      debug1("timer: drift (%" PRId64 " seconds)", (int64_t) (nowmins - lastmin));
       i++;
       ++lastmin;
       call_hook(HOOK_MINUTELY);
     }
     if (i > 1)
-      putlog(LOG_MISC, "*", "(!) timer drift -- spun %f minutes", difftime(nowmins, lastmin)/60);
+      putlog(LOG_MISC, "*", "(!) timer drift -- spun %" PRId64 " minutes",
+             ((int64_t) (nowmins - lastmin)) / 60);
     miltime = (nowtm.tm_hour * 100) + (nowtm.tm_min);
     if (((int) (nowtm.tm_min / 5) * 5) == (nowtm.tm_min)) {     /* 5 min */
       call_hook(HOOK_5MINUTELY);

--- a/src/mod/blowfish.mod/blowfish.c
+++ b/src/mod/blowfish.mod/blowfish.c
@@ -153,7 +153,7 @@ static void blowfish_report(int idx, int details)
       dprintf(idx, "      %d of %d boxes in use:", tot, BOXES);
       for (i = 0; i < BOXES; i++)
         if (box[i].P != NULL) {
-          dprintf(idx, " (age: %f)", difftime(now, box[i].lastuse));
+          dprintf(idx, " (age: %" PRId64 ")", (int64_t) (now - box[i].lastuse));
         }
       dprintf(idx, "\n");
     }

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1720,25 +1720,17 @@ static int tcl_channel_modify(Tcl_Interp *irp, struct chanset_t *chan,
 static int tcl_do_masklist(maskrec *m, Tcl_Interp *irp)
 {
   char ts[21], ts1[21], ts2[21], *p;
-  long tv;
   EGG_CONST char *list[6];
 
   for (; m; m = m->next) {
     list[0] = m->mask;
     list[1] = m->desc;
-
-    tv = m->expire;
-    sprintf(ts, "%lu", tv);
+    snprintf(ts, sizeof ts, "%" PRId64, (int64_t) m->expire);
     list[2] = ts;
-
-    tv = m->added;
-    sprintf(ts1, "%lu", tv);
+    snprintf(ts1, sizeof ts1, "%" PRId64, (int64_t) m->added);
     list[3] = ts1;
-
-    tv = m->lastactive;
-    sprintf(ts2, "%lu", tv);
+    snprintf(ts2, sizeof ts2, "%" PRId64, (int64_t) m->lastactive);
     list[4] = ts2;
-
     list[5] = m->user;
     p = Tcl_Merge(6, list);
     Tcl_AppendElement(irp, p);

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -853,9 +853,9 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
       else
         chanflag = ' ';
       if (chan_issplit(m)) {
-        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- netsplit, %fs\n",
-              chanflag, maxnicklen, m->nick, maxhandlen, handle, maxnicklen,
-              m->account, s, atrflag, difftime(now, m->split));
+        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- netsplit, %" PRId64 "s\n",
+                chanflag, maxnicklen, m->nick, maxhandlen, handle, maxnicklen,
+                m->account, s, atrflag, (int64_t) (now - m->split));
       } else if (!rfc_casecmp(m->nick, botname)) {
         dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- it's me!\n", chanflag,
               maxnicklen, m->nick, maxhandlen, handle, maxnicklen, m->account,
@@ -863,11 +863,11 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
       } else {
         /* Determine idle time */
         if (now - (m->last) > 86400)
-          egg_snprintf(s1, sizeof s1, "%2lud", ((now - (m->last)) / 86400));
+          snprintf(s1, sizeof s1, "%2" PRId64 "d", ((int64_t) (now - m->last)) / 86400);
         else if (now - (m->last) > 3600)
-          egg_snprintf(s1, sizeof s1, "%2luh", ((now - (m->last)) / 3600));
+          snprintf(s1, sizeof s1, "%2" PRId64 "h", ((int64_t) (now - m->last)) / 3600);
         else if (now - (m->last) > 180)
-          egg_snprintf(s1, sizeof s1, "%2lum", ((now - (m->last)) / 60));
+          snprintf(s1, sizeof s1, "%2" PRId64 "m", ((int64_t) (now - m->last)) / 60);
         else
           strlcpy(s1, "   ", sizeof s1);
         if (chan_ircaway(m)) {

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -690,13 +690,13 @@ static int tcl_getchanidle STDVAR
 
 static int tcl_chanmasks(masklist *m, Tcl_Interp *irp)
 {
-  char work[20], *p;
+  char work[21], *p;
   EGG_CONST char *list[3];
 
   for (; m && m->mask && m->mask[0]; m = m->next) {
     list[0] = m->mask;
     list[1] = m->who;
-    simple_sprintf(work, "%d", now - m->timer);
+    snprintf(work, sizeof work, "%" PRId64, (int64_t) (now - m->timer));
     list[2] = work;
     p = Tcl_Merge(3, list);
     Tcl_AppendElement(irp, p);

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1232,7 +1232,8 @@ static void share_ufsend(int idx, char *par)
   int i, sock;
   FILE *f;
 
-  egg_snprintf(s, sizeof s, ".share.%s.%li.users", botnetnick, now);
+  snprintf(s, sizeof s, ".share.%s.%" PRId64 ".users", botnetnick,
+           (int64_t) now);
   if (!(b_status(idx) & STAT_SHARE)) {
     dprintf(idx, "s e You didn't ask; you just started sending.\n");
     dprintf(idx, "s e Ask before sending the userfile.\n");
@@ -2038,8 +2039,8 @@ static void start_sending_users(int idx)
   struct chanset_t *cst;
   char s[EGG_INET_ADDRSTRLEN];
 
-  egg_snprintf(share_file, sizeof share_file, ".share.%s.%lu", dcc[idx].nick,
-               now);
+  snprintf(share_file, sizeof share_file, ".share.%s.%" PRId64, dcc[idx].nick,
+           (int64_t) now);
   if (dcc[idx].u.bot->uff_flags & UFF_OVERRIDE) {
     debug1("NOTE: Sharing aggressively with %s, overriding its local bots.",
            dcc[idx].nick);

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -702,9 +702,8 @@ static void build_sock_list(Tcl_Interp *irp, Tcl_Obj *masterlist, char *idxstr,
 /* Gather information for dcclist or socklist */
 static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
   int i;
-  char idxstr[10], timestamp[11], other[160];
+  char idxstr[10], timestamp[21], other[160];
   char portstring[7]; /* ssl + portmax + NULL */
-  long tv;
   char s[EGG_INET_ADDRSTRLEN];
   socklen_t namelen;
   struct sockaddr_storage ss;
@@ -718,8 +717,7 @@ static void dccsocklist(Tcl_Interp *irp, int argc, char *type, int src) {
     if (argc == 1 || ((argc == 2) && (dcc[i].type &&
         !strcasecmp(dcc[i].type->name, type)))) {
       egg_snprintf(idxstr, sizeof idxstr, "%ld", dcc[i].sock);
-      tv = dcc[i].timeval;
-      egg_snprintf(timestamp, sizeof timestamp, "%ld", tv);
+      snprintf(timestamp, sizeof timestamp, "%" PRId64, (int64_t) dcc[i].timeval);
       if (dcc[i].type && dcc[i].type->display)
         dcc[i].type->display(i, other);
       else {
@@ -785,8 +783,7 @@ static int tcl_dcclist STDVAR
 static int tcl_whom STDVAR
 {
   int chan, i;
-  char c[2], idle[32], work[20], *p;
-  long tv = 0;
+  char c[2], idle[21], work[20], *p;
   EGG_CONST char *list[7];
 
   BADARGS(2, 2, " chan");
@@ -815,8 +812,7 @@ static int tcl_whom STDVAR
       if (dcc[i].u.chat->channel == chan || chan == -1) {
         c[0] = geticon(i);
         c[1] = 0;
-        tv = (now - dcc[i].timeval) / 60;
-        egg_snprintf(idle, sizeof idle, "%li", tv);
+        snprintf(idle, sizeof idle, "%" PRId64, (int64_t) ((now - dcc[i].timeval) / 60));
         list[0] = dcc[i].nick;
         list[1] = botnetnick;
         list[2] = dcc[i].host;
@@ -838,10 +834,8 @@ static int tcl_whom STDVAR
       c[1] = 0;
       if (party[i].timer == 0L)
         strcpy(idle, "0");
-      else {
-        tv = (now - party[i].timer) / 60;
-        egg_snprintf(idle, sizeof idle, "%li", tv);
-      }
+      else
+        snprintf(idle, sizeof idle, "%" PRId64, (int64_t) ((now - party[i].timer) / 60));
       list[0] = party[i].nick;
       list[1] = party[i].bot;
       list[2] = party[i].from ? party[i].from : "";

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -404,12 +404,12 @@ static int tcl_duration STDVAR
 
 static int tcl_unixtime STDVAR
 {
-  char s[11];
+  char s[21];
   time_t now2 = time(NULL);
 
   BADARGS(1, 1, "");
 
-  egg_snprintf(s, sizeof s, "%li", (long) now2);
+  snprintf(s, sizeof s, "%" PRId64, (int64_t) now2);
   Tcl_AppendResult(irp, s, NULL);
   return TCL_OK;
 }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -611,7 +611,6 @@ static int tcl_killignore STDVAR
 static int tcl_ignorelist STDVAR
 {
   char expire[21], added[21], *p;
-  long tv;
   EGG_CONST char *list[5];
   struct igrec *i;
 
@@ -620,15 +619,10 @@ static int tcl_ignorelist STDVAR
   for (i = global_ign; i; i = i->next) {
     list[0] = i->igmask;
     list[1] = i->msg;
-
-    tv = i->expire;
-    snprintf(expire, sizeof expire, "%ld", tv);
+    snprintf(expire, sizeof expire, "%" PRId64, (int64_t) i->expire);
     list[2] = expire;
-
-    tv = i->added;
-    snprintf(added, sizeof added, "%ld", tv);
+    snprintf(added, sizeof added, "%" PRId64, (int64_t) i->added);
     list[3] = added;
-
     list[4] = i->user;
     p = Tcl_Merge(5, list);
     Tcl_AppendElement(irp, p);

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -622,11 +622,11 @@ static int tcl_ignorelist STDVAR
     list[1] = i->msg;
 
     tv = i->expire;
-    snprintf(expire, sizeof expire, "%lu", tv);
+    snprintf(expire, sizeof expire, "%ld", tv);
     list[2] = expire;
 
     tv = i->added;
-    snprintf(added, sizeof added, "%lu", tv);
+    snprintf(added, sizeof added, "%ld", tv);
     list[3] = added;
 
     list[4] = i->user;

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -610,7 +610,7 @@ static int tcl_killignore STDVAR
 
 static int tcl_ignorelist STDVAR
 {
-  char expire[11], added[11], *p;
+  char expire[21], added[21], *p;
   long tv;
   EGG_CONST char *list[5];
   struct igrec *i;
@@ -622,11 +622,11 @@ static int tcl_ignorelist STDVAR
     list[1] = i->msg;
 
     tv = i->expire;
-    egg_snprintf(expire, sizeof expire, "%lu", tv);
+    snprintf(expire, sizeof expire, "%lu", tv);
     list[2] = expire;
 
     tv = i->added;
-    egg_snprintf(added, sizeof added, "%lu", tv);
+    snprintf(added, sizeof added, "%lu", tv);
     list[3] = added;
 
     list[4] = i->user;

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -656,7 +656,7 @@ struct userrec *adduser(struct userrec *bu, char *handle, char *host,
   struct userrec *u, *x;
   struct xtra_key *xk;
   int oldshare = noshare;
-  long tv;
+  time_t tv;
 
   noshare = 1;
   u = nmalloc(sizeof *u);
@@ -680,9 +680,9 @@ struct userrec *adduser(struct userrec *bu, char *handle, char *host,
     xk->key = nmalloc(8);
     strcpy(xk->key, "created");
     tv = now;
-    l = snprintf(NULL, 0, "%li", tv);
+    l = snprintf(NULL, 0, "%" PRId64, (int64_t) tv);
     xk->data = nmalloc(l + 1);
-    sprintf(xk->data, "%li", tv);
+    sprintf(xk->data, "%" PRId64, (int64_t) tv);
     set_user(&USERENTRY_XTRA, u, xk);
   }
   /* Strip out commas -- they're illegal */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann and thommey
Fixes: 

One-line summary:
Fix some year 2038 problems

Additional description (if needed):
Fix time_t handling (buffer size, type and format specifier)
POSIX requires time_t to be an integer type, but does not mandate that it be signed or unsigned.
time_t to string conversion used buffersize 11, 10 chars + NULL-terminator, would overflow with unixtime >9999999999 (year 2286)
Also fixes the following compiler warning under OpenBSD 7.1 clang 13.0.0:
```
cc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.6 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c botcmd.c
botcmd.c:841:19: warning: format specifies type 'unsigned long' but the argument has type 'long long' [-Wformat]
                  now - t, j, (j != 1) ? "s" : "");
                  ^~~~~~~
1 warning generated.

```
Test cases demonstrating functionality (if applicable):
