### PR TITLE
Task/finishaccountbind

### DIFF
--- a/doc/html/using/accounts.html
+++ b/doc/html/using/accounts.html
@@ -1,0 +1,219 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Account tracking in Eggdrop &#8212; Eggdrop 1.9.3 documentation</title>
+    <link rel="stylesheet" href="../_static/eggdrop.css" type="text/css" />
+    <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+    <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
+    <script type="text/javascript" src="../_static/jquery.js"></script>
+    <script type="text/javascript" src="../_static/underscore.js"></script>
+    <script type="text/javascript" src="../_static/doctools.js"></script>
+    <script type="text/javascript" src="../_static/language_data.js"></script>
+    <link rel="search" title="Search" href="../search.html" />
+    <link rel="next" title="Encryption/Hashing" href="pbkdf2info.html" />
+    <link rel="prev" title="IRCv3 support" href="ircv3.html" /> 
+  </head><body>
+    <div class="header-wrapper" role="banner">
+      <div class="header">
+          <p class="logo"><a href="../index.html">
+            <img class="logo" src="../_static/eggman.png.gif" alt="Logo"/>
+          </a></p>
+        <div class="headertitle"><a
+          href="../index.html">Eggdrop 1.9.3 documentation</a></div>
+        <div class="rel" role="navigation" aria-label="related navigation">
+          <a href="ircv3.html" title="IRCv3 support"
+             accesskey="P">previous</a> |
+          <a href="pbkdf2info.html" title="Encryption/Hashing"
+             accesskey="N">next</a>
+        </div>
+       </div>
+    </div>
+
+    <div class="content-wrapper">
+      <div class="content">
+        <div class="sidebar">
+          
+          <h3>Table of Contents</h3>
+          <p class="caption"><span class="caption-text">Installing Eggdrop</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../install/readme.html">README</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../install/install.html">Installing Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../install/upgrading.html">Upgrading Eggdrop</a></li>
+</ul>
+<p class="caption"><span class="caption-text">Using Eggdrop</span></p>
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="features.html">Eggdrop Features</a></li>
+<li class="toctree-l1"><a class="reference internal" href="core.html">Eggdrop Core Settings</a></li>
+<li class="toctree-l1"><a class="reference internal" href="partyline.html">The Party Line</a></li>
+<li class="toctree-l1"><a class="reference internal" href="users.html">Users and Flags</a></li>
+<li class="toctree-l1"><a class="reference internal" href="bans.html">Bans, Invites, and Exempts</a></li>
+<li class="toctree-l1"><a class="reference internal" href="botnet.html">Botnet Sharing and Linking</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ipv6.html">IPv6 support</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tls.html">TLS support</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ircv3.html">IRCv3 support</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">Account tracking in Eggdrop</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="#required-server-capabilities">Required Server Capabilities</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#enabling-eggdrop-account-tracking">Enabling Eggdrop Account Tracking</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#checking-account-tracking-status">Checking Account-tracking Status</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#determining-if-a-server-supports-account-capabilities">Determining if a Server Supports Account Capabilities</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#best-effort-account-tracking">Best-Effort Account Tracking</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#using-accounts-with-tcl-scripts">Using Accounts with Tcl Scripts</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="pbkdf2info.html">Encryption/Hashing</a></li>
+<li class="toctree-l1"><a class="reference internal" href="twitchinfo.html">Twitch</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tricks.html">Advanced Tips</a></li>
+<li class="toctree-l1"><a class="reference internal" href="text-sub.html">Textfile Substitutions</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tcl-commands.html">Eggdrop Tcl Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="twitch-tcl-commands.html">Eggdrop Twitch Tcl Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="patch.html">Patching Eggdrop</a></li>
+</ul>
+<p class="caption"><span class="caption-text">Tutorials</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/setup.html">Setting Up Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/firststeps.html">Common First Steps</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/tlssetup.html">Enabling TLS Security on Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/firstscript.html">Writing an Eggdrop Script</a></li>
+</ul>
+<p class="caption"><span class="caption-text">Eggdrop Modules</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../modules/index.html">Eggdrop Module Information</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../modules/included.html">Modules included with Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../modules/writing.html">Writing an Eggdrop Module</a></li>
+</ul>
+<p class="caption"><span class="caption-text">About Eggdrop</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../about/about.html">About Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../about/legal.html">Boring legal stuff</a></li>
+</ul>
+
+          <div role="search">
+            <h3 style="margin-top: 1.5em;">Search</h3>
+            <form class="search" action="../search.html" method="get">
+                <input type="text" name="q" />
+                <input type="submit" value="Go" />
+            </form>
+          </div>
+
+        </div>
+        <div class="document">
+            
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+          <div class="body" role="main">
+            
+  <div class="section" id="account-tracking-in-eggdrop">
+<h1>Account tracking in Eggdrop<a class="headerlink" href="#account-tracking-in-eggdrop" title="Permalink to this headline">¶</a></h1>
+<p>In Eggdrop 1.9.3, Eggdrop added the ability to associate nicknames with the service accounts they are logged into. It is IMPORTANT to note that Eggdrop’s ability to do this is dependent on an IRC server’s implementation of three features- the IRCv3 extended-join capability, the IRCv3 account-notify capability, and WHOX support. All three of these features must be supported by the server and, in the case of extended-join and account-notify, requested by Eggdrop in order for Eggdrop to maintain “perfect” association between nicknames and account statuses.</p>
+<div class="section" id="required-server-capabilities">
+<h2>Required Server Capabilities<a class="headerlink" href="#required-server-capabilities" title="Permalink to this headline">¶</a></h2>
+<p>You’re going to see this repeated a lot- the IRC server must support three features in order for Eggdrop to accurately associate accounts with nicknames. These three features allow Eggdrop to always know the current association between an account and a nickname by getting account statuses of users already on a channel when it joins, new users joining a channel, and users who authenticate while on a channel.</p>
+<div class="section" id="extended-join">
+<h3>extended-join<a class="headerlink" href="#extended-join" title="Permalink to this headline">¶</a></h3>
+<p><a class="reference external" href="https://ircv3.net/specs/extensions/extended-join">extended-join</a> is an IRCv3-defined capability that adds the account name of a user to the JOIN message sent by the IRC server, alerting clients that a new member has joined a channel. Enabling this capability allows Eggdrop to immediately determine the account name associated with a user joining a channel</p>
+</div>
+<div class="section" id="account-notify">
+<h3>account-notify<a class="headerlink" href="#account-notify" title="Permalink to this headline">¶</a></h3>
+<p><a class="reference external" href="https://ircv3.net/specs/extensions/account-notify">account-notify</a> is an IRCv3-defined capability that sends a message to a channel when a member of the channel either authenticates or deauthenticates from their account. Enabling this capability allows Eggdrop to immediately associate an account to a channel member when they authenticate or deauthenticate.</p>
+</div>
+<div class="section" id="whox">
+<h3>WHOX<a class="headerlink" href="#whox" title="Permalink to this headline">¶</a></h3>
+<p>‘WHOX &lt;<a class="reference external" href="https://ircv3.net/specs/extensions/whox">https://ircv3.net/specs/extensions/whox</a>&gt;`_ is a server feature that allows a client to request custom fields to be returned in a WHO response. If a server supports this capability, Eggdrop sends a WHOX query to the server when it joins a channel, allowing it to immediately determine accounts associated with channel members when Eggdrop joins a channel.</p>
+</div>
+</div>
+<div class="section" id="enabling-eggdrop-account-tracking">
+<h2>Enabling Eggdrop Account Tracking<a class="headerlink" href="#enabling-eggdrop-account-tracking" title="Permalink to this headline">¶</a></h2>
+<p>By default, the Eggdrop config file will attempt to enable all the capabilities required for account tracking. There are two settings to pay attention to</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># To request the account-notify feature via CAP, set this to 1</span>
+<span class="nb">set</span> <span class="n">account</span><span class="o">-</span><span class="n">notify</span> <span class="mi">1</span>
+
+<span class="c1"># To request the extended-join feature via CAP, set this to 1</span>
+<span class="nb">set</span> <span class="n">extended</span><span class="o">-</span><span class="n">join</span> <span class="mi">1</span>
+</pre></div>
+</div>
+<p>The ability of a server to support WHOX queries is determined via a server’s ISUPPORT (005) reply. If a server supports WHOX queries, Eggdrop will automatically enable this feature.</p>
+</div>
+<div class="section" id="checking-account-tracking-status">
+<h2>Checking Account-tracking Status<a class="headerlink" href="#checking-account-tracking-status" title="Permalink to this headline">¶</a></h2>
+<p>While Eggdrop is running, join the partyline and type <cite>.status</cite>. If account-tracking is enabled (both the server supports and Eggdrop has requested), you’ll see this line</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">Loaded</span> <span class="n">module</span> <span class="n">information</span><span class="p">:</span>
+  <span class="c1">#eggdroptest        : (not on channel)</span>
+  <span class="n">Channels</span><span class="p">:</span> <span class="c1">#eggdroptest (trying)</span>
+  <span class="n">Account</span> <span class="n">tracking</span><span class="p">:</span> <span class="n">Enabled</span>           <span class="o">&lt;---</span> <span class="n">This</span> <span class="n">line</span>
+  <span class="n">Online</span> <span class="k">as</span><span class="p">:</span> <span class="n">BeerBot</span> <span class="p">(</span><span class="n">BeerBot</span><span class="p">)</span>
+</pre></div>
+</div>
+<p>Otherwise, the prompt will tell you which required capability is missing/not enabled</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">Loaded</span> <span class="n">module</span> <span class="n">information</span><span class="p">:</span>
+  <span class="c1">#eggdroptest        :   2 members, enforcing &quot;+tn&quot; (greet)</span>
+  <span class="n">Channels</span><span class="p">:</span> <span class="c1">#eggdroptest (need ops)</span>
+  <span class="n">Account</span> <span class="n">tracking</span><span class="p">:</span> <span class="n">Best</span><span class="o">-</span><span class="n">effort</span> <span class="p">(</span><span class="n">Missing</span> <span class="n">capabilities</span><span class="p">:</span> <span class="n">extended</span><span class="o">-</span><span class="n">join</span><span class="p">,</span> <span class="n">see</span> <span class="o">.</span><span class="n">status</span> <span class="nb">all</span> <span class="k">for</span> <span class="n">details</span><span class="p">)</span>      <span class="o">&lt;----</span> <span class="n">This</span> <span class="n">line</span>
+  <span class="n">Online</span> <span class="k">as</span><span class="p">:</span> <span class="n">Eggdrop</span> <span class="p">(</span><span class="n">Eggdrop</span><span class="p">)</span>
+</pre></div>
+</div>
+</div>
+<div class="section" id="determining-if-a-server-supports-account-capabilities">
+<h2>Determining if a Server Supports Account Capabilities<a class="headerlink" href="#determining-if-a-server-supports-account-capabilities" title="Permalink to this headline">¶</a></h2>
+<p>A server announces the capabilities it supports via a CAP request. If you have Tcl enabled on the partyline (or via a raw message from a client), you can send <cite>.tcl cap ls</cite> and see if the extended-join and account-notify capabilities are supported by the server. If they are not listed, the server does not support it.</p>
+<p>A server announces if it supports WHOX via its ISUPPORT (005) announcement. If you have Tcl enabled on the partyline, you can send <cite>.tcl issupport isset WHOX</cite> and if it returns ‘1’, WHOX is supported by the server.</p>
+</div>
+<div class="section" id="best-effort-account-tracking">
+<h2>Best-Effort Account Tracking<a class="headerlink" href="#best-effort-account-tracking" title="Permalink to this headline">¶</a></h2>
+<p>If a server only supports some, but not all, of the required capabilities, Eggdrop will switch to ‘best effort’ account tracking. This means Eggdrop will update account statuses whenever it sees account information, but Eggdrop cannnot guarantee the accuracy of account association at any given time.</p>
+<p>If a server does not support extended-join, Eggdrop will not be able to determine the account associated with a user when they join. Eggdrop can update this information by sending a WHOX to the server.</p>
+<p>If a server does not support account-notify, Eggdrop will not be able to determine the account assoicated with a user if they authenticate/deauthenticate from their account after joining a channel. Eggdrop can update this information by sending a WHOX to the server.</p>
+<p>If a server does not support WHOX, Eggdrop will not be able to determine the accounts associated with users already on a channel before Eggdrop joined. There is no reliable way to update this information.</p>
+<p>One workaround to significantly increase the accuracy of account tracking for scripts in a ‘best effort’ scenario would be to issue a WHOX query (assuming the server supports it), wait for the reply from the eserver, and then query for the account information.</p>
+<div class="section" id="account-tag">
+<h3>account-tag<a class="headerlink" href="#account-tag" title="Permalink to this headline">¶</a></h3>
+<p>One supplementary capability that can assist a best-effort account tracking scenario is the IRCv3-defined <a class="reference external" href="https://ircv3.net/specs/extensions/account-tag">account-tag capability</a>. The account-tag capability attaches a tag with the account name associated with the user sending a command. Enabling this capability allows Eggdrop to update its account tracking every time a user talks in channel, sets a mode, sends a kick, etc. While still not able to offer the same level of accuracy as enabling the “main three” account tracking features, it can increase the accuracy and can help with scripts that react to user commands/messages.</p>
+</div>
+</div>
+<div class="section" id="using-accounts-with-tcl-scripts">
+<h2>Using Accounts with Tcl Scripts<a class="headerlink" href="#using-accounts-with-tcl-scripts" title="Permalink to this headline">¶</a></h2>
+<p>The Eggdrop Tcl ACCOUNT bind is triggered whenver an existing account record stored by Eggdrop is modified, such as a user de/authenticating to their account while in a channel, or information such as an account-tag being seen that updates an existing user. However, the ACCOUNT bind will NOT be triggered for the creation of a new user record, such as a user joining a channel. The bind is triggered for every channel the user is seen on- this means if a user is present with Eggdrop on four channels, the bind will be executed four times, each time with a different channel variable being passed to the associated Tcl procedure. Additionally, in a best-effort account tracking situation, Eggdrop will update the account associated with a user on all channels, not just the channel the event is seen on (and thus resulting in a bind trigger for each channel the user is on).</p>
+<p>In order to trigger Tcl script events to cover all instances where a user logs in, you need to pair an ACCOUNT bind with a JOIN bind. This will allow you to execute account-based events when a user joins as well as if they authenticate after joining.</p>
+</div>
+</div>
+
+
+          </div>
+        </div>
+      </div>
+        </div>
+        <div class="clearer"></div>
+      </div>
+    </div>
+
+    <div class="footer-wrapper">
+      <div class="footer">
+        <div class="left">
+          <div role="navigation" aria-label="related navigaton">
+            <a href="ircv3.html" title="IRCv3 support"
+              >previous</a> |
+            <a href="pbkdf2info.html" title="Encryption/Hashing"
+              >next</a>
+          </div>
+          <div role="note" aria-label="source link">
+          </div>
+        </div>
+
+        <div class="right">
+          
+    <div class="footer" role="contentinfo">
+        &#169; Copyright 2022, Eggheads.
+      Last updated on Sep 18, 2022.
+      Created using <a href="http://sphinx-doc.org/">Sphinx</a> 1.8.5.
+    </div>
+        </div>
+        <div class="clearer"></div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/doc/sphinx_source/index.rst
+++ b/doc/sphinx_source/index.rst
@@ -61,6 +61,7 @@ The Eggheads development team can be found lurking on #eggdrop on the Libera net
     using/ipv6
     using/tls
     using/ircv3
+    using/accounts
     using/pbkdf2info
     using/twitchinfo
     using/tricks

--- a/doc/sphinx_source/using/accounts.rst
+++ b/doc/sphinx_source/using/accounts.rst
@@ -1,0 +1,81 @@
+Account tracking in Eggdrop
+===========================
+
+In Eggdrop 1.9.3, Eggdrop added the ability to associate nicknames with the service accounts they are logged into. It is IMPORTANT to note that Eggdrop's ability to do this is dependent on an IRC server's implementation of three features- the IRCv3 extended-join capability, the IRCv3 account-notify capability, and WHOX support. All three of these features must be supported by the server and, in the case of extended-join and account-notify, requested by Eggdrop in order for Eggdrop to maintain "perfect" association between nicknames and account statuses.
+
+Required Server Capabilities
+----------------------------
+You're going to see this repeated a lot- the IRC server must support three features in order for Eggdrop to accurately associate accounts with nicknames. These three features allow Eggdrop to always know the current association between an account and a nickname by getting account statuses of users already on a channel when it joins, new users joining a channel, and users who authenticate while on a channel.
+
+extended-join
+^^^^^^^^^^^^^
+`extended-join <https://ircv3.net/specs/extensions/extended-join>`_ is an IRCv3-defined capability that adds the account name of a user to the JOIN message sent by the IRC server, alerting clients that a new member has joined a channel. Enabling this capability allows Eggdrop to immediately determine the account name associated with a user joining a channel
+
+account-notify
+^^^^^^^^^^^^^^
+`account-notify <https://ircv3.net/specs/extensions/account-notify>`_ is an IRCv3-defined capability that sends a message to a channel when a member of the channel either authenticates or deauthenticates from their account. Enabling this capability allows Eggdrop to immediately associate an account to a channel member when they authenticate or deauthenticate.
+
+WHOX
+^^^^
+'WHOX <https://ircv3.net/specs/extensions/whox>`_ is a server feature that allows a client to request custom fields to be returned in a WHO response. If a server supports this capability, Eggdrop sends a WHOX query to the server when it joins a channel, allowing it to immediately determine accounts associated with channel members when Eggdrop joins a channel.
+
+Enabling Eggdrop Account Tracking
+---------------------------------
+By default, the Eggdrop config file will attempt to enable all the capabilities required for account tracking. There are two settings to pay attention to
+::
+
+  # To request the account-notify feature via CAP, set this to 1
+  set account-notify 1
+
+  # To request the extended-join feature via CAP, set this to 1
+  set extended-join 1
+
+The ability of a server to support WHOX queries is determined via a server's ISUPPORT (005) reply. If a server supports WHOX queries, Eggdrop will automatically enable this feature.
+
+Checking Account-tracking Status
+--------------------------------
+While Eggdrop is running, join the partyline and type `.status`. If account-tracking is enabled (both the server supports and Eggdrop has requested), you'll see this line
+::
+
+  Loaded module information:
+    #eggdroptest        : (not on channel)
+    Channels: #eggdroptest (trying)
+    Account tracking: Enabled           <--- This line
+    Online as: BeerBot (BeerBot)
+
+Otherwise, the prompt will tell you which required capability is missing/not enabled
+::
+
+  Loaded module information:
+    #eggdroptest        :   2 members, enforcing "+tn" (greet)
+    Channels: #eggdroptest (need ops)
+    Account tracking: Best-effort (Missing capabilities: extended-join, see .status all for details)      <---- This line
+    Online as: Eggdrop (Eggdrop)
+
+Determining if a Server Supports Account Capabilities
+-----------------------------------------------------
+A server announces the capabilities it supports via a CAP request. If you have Tcl enabled on the partyline (or via a raw message from a client), you can send `.tcl cap ls` and see if the extended-join and account-notify capabilities are supported by the server. If they are not listed, the server does not support it.
+
+A server announces if it supports WHOX via its ISUPPORT (005) announcement. If you have Tcl enabled on the partyline, you can send `.tcl issupport isset WHOX` and if it returns '1', WHOX is supported by the server.
+
+Best-Effort Account Tracking
+----------------------------
+If a server only supports some, but not all, of the required capabilities, Eggdrop will switch to 'best effort' account tracking. This means Eggdrop will update account statuses whenever it sees account information, but in this mode Eggdrop cannnot guarantee that all account associations are up to date.
+
+If a server does not support extended-join, Eggdrop will not be able to determine the account associated with a user when they join. Eggdrop can update this information by sending a WHOX to the server.
+
+If a server does not support account-notify, Eggdrop will not be able to determine the account assoicated with a user if they authenticate/deauthenticate from their account after joining a channel. Eggdrop can update this information by sending a WHOX to the server.
+
+If a server does not support WHOX, Eggdrop will not be able to determine the accounts associated with users already on a channel before Eggdrop joined. There is no reliable way to update this information.
+
+One workaround to significantly increase the accuracy of account tracking for scripts in a 'best effort' scenario would be to issue a WHOX query (assuming the server supports it), wait for the reply from the server, and then query for the account information.
+
+account-tag
+^^^^^^^^^^^
+One supplementary capability that can assist a best-effort account tracking scenario is the IRCv3-defined `account-tag capability <https://ircv3.net/specs/extensions/account-tag>`_. The account-tag capability attaches a tag with the account name associated with the user sending a command. Enabling this capability allows Eggdrop to update its account tracking every time a user talks in channel, sets a mode, sends a kick, etc. While still not able to offer the same level of accuracy as enabling the "main three" account tracking features, it can increase the overall accuracy of the account list. Additionally, binds that react to user activity (pub, kick, mode, etc) containing account-tag will update the internal account list prior to executing the associated callback, so looking up the account name in the callback can be considered accurate.
+
+Using Accounts with Tcl Scripts
+-------------------------------
+The Eggdrop Tcl ACCOUNT bind is triggered whenver an existing account record stored by Eggdrop is modified, such as a user de/authenticating to their account while in a channel, or information such as an account-tag being seen that updates an existing user. However, the ACCOUNT bind will NOT be triggered for the creation of a new user record, such as a user joining a channel. The bind is triggered for every channel the user is seen on- this means if a user is present with Eggdrop on four channels, the bind will be executed four times, each time with a different channel variable being passed to the associated Tcl procedure. Additionally, in a best-effort account tracking situation, Eggdrop will update the account associated with a user on all channels, not just the channel the event is seen on (and thus resulting in a bind trigger for each channel the user is on).
+
+In order to trigger Tcl script events to cover all instances where a user logs in, you need to pair an ACCOUNT bind with a JOIN bind. This will allow you to execute account-based events when a user joins as well as if they authenticate after joining. 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -367,6 +367,8 @@ botattr <handle> [changes [channel]]
 
   Module: core
 
+.. _matchattr:
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 matchattr <handle> <flags> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1372,7 +1374,7 @@ onchansplit <nick> [channel]
 chanlist <channel> [flags][<&|>chanflags]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: flags are any global flags; the '&' or '\|' denotes to look for channel specific flags, where '&' will return users having ALL chanflags and '|' returns users having ANY of the chanflags (See matchattr above for additional examples).
+  Description: flags are any global flags; the '&' or '\|' denotes to look for channel specific flags, where '&' will return users having ALL chanflags and '|' returns users having ANY of the chanflags (See matchattr_ above for additional examples).
 
   Returns: Searching for flags optionally preceded with a '+' will return a list of nicknames that have all the flags listed. Searching for flags preceded with a '-' will return a list of nicknames that do not have have any of the flags (differently said, '-' will hide users that have all flags listed). If no flags are given, all of the nicknames on the channel are returned.
 
@@ -2357,8 +2359,7 @@ timer <minutes> <tcl-command> [count [timerName]]
 utimer <seconds> <tcl-command> [count [timerName]]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted. If timerName is specified, it will become the unique identifier for the timer. If no timer
-Name is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
+  Description: executes the given Tcl command after a certain number of seconds have passed. If count is specified, the command will be executed count times with the given interval in between. If you specify a count of 0, the utimer will repeat until it's removed with killutimer or until the bot is restarted. If timerName is specified, it will become the unique identifier for the timer. If no timerName is specified, Eggdrop will assign a timerName in the format of "timer<integer>".
 
   Returns: a timerName
 
@@ -2908,22 +2909,23 @@ language
 Binds
 -----
 
-You can use the 'bind' command to attach Tcl procedures to certain events.
-For example, you can write a Tcl procedure that gets called every time a
-user says "danger" on the channel.
+You can use the 'bind' command to attach Tcl procedures to certain events. For example, you can write a Tcl procedure that gets called every time a user says "danger" on the channel. When a bind is triggered, ALL of the Tcl procs that are bound to it will be called. Raw binds are triggered before builtin binds, as a builtin bind has the potential to modify args.
 
-Some bind types are marked as "stackable". That means that you can bind
-multiple commands to the same trigger. Normally, for example, a bind such
-as 'bind msg - stop msg:stop' (which makes a msg-command "stop" call the
-Tcl proc "msg:stop") will overwrite any previous binding you had for the
-msg command "stop". With stackable bindings, like 'msgm' for example,
-you can bind the same command to multiple procs. When the bind is triggered,
-ALL of the Tcl procs that are bound to it will be called. Raw binds are
-triggered before builtin binds, as a builtin bind has the potential to
-modify args.
+^^^^^^^^^^^^^^^
+Stackable binds
+^^^^^^^^^^^^^^^
+Some bind types are marked as "stackable". That means that you can bind multiple commands to the same trigger. Normally, for example, a bind such as 'bind msg - stop msg:stop' (which makes a msg-command "stop" call the Tcl proc "msg:stop") will overwrite any previous binding you had for the msg command "stop". With stackable bindings, like 'msgm' for example, you can bind the same command to multiple procs.
 
+^^^^^^^^^^^^^^^
+Removing a bind
+^^^^^^^^^^^^^^^
 To remove a bind, use the 'unbind' command. For example, to remove the
 bind for the "stop" msg command, use 'unbind msg - stop msg:stop'.
+
+^^^^^^^^^^
+Flag Masks
+^^^^^^^^^^
+In the next section, you will see several references to "flags". The "flags" argument is a value that represents the type of user that is allowed to trigger the procedure associated to that bind. The flags can be any of the standard Eggdrop flags (o, m, v, etc), or a "-" or "*" can be used to denote "any user". For example, a flag mask of "ov" would allow a bind to be triggered by a user added to Eggdrop with either the o or v global flags. A flag mask of of "-\|m" would allow a bind to be triggered by a user with the m channel flag. For more advanced information on how flag matching works, please see the matchattr_ description.
 
 ^^^^^^^^^^
 Bind Types
@@ -3528,7 +3530,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <user> <hand> <chan> <account>
 
-  Description: this bind will trigger when eggdrop detects a change in the authentication status of a user's service account. The mask for the bind is in the format "#channel nick!user@hostname.com account" and accepts :ref:`<wildcards>Match Characters`. account is either the account name the user is logging in to or "*" if the user is not logged in to an account.
+  Description: this bind will trigger when eggdrop detects a change in the authentication status of a user's service account. The mask for the bind is in the format "#channel nick!user@hostname.com account" and accepts wildcards_. account is either the account name the user is logging in to or "*" if the user is not logged in to an account.
 
   NOTE: the three required IRC components for account tracking are: the WHOX feature, the extended-join IRCv3 capability and the account-notify IRCv3 capability. if only some of the three feature are available, eggdrop provides best-effort account tracking but this bind could be triggered late or never on account changes. Please see doc/ACCOUNTS for additional information.
 
@@ -3701,6 +3703,8 @@ When a new connection arrives in port 6687, Eggdrop will create a new idx for th
 Secure connection can be also established after a connection is active. You can connect/listen normally and switch later using the 'starttls' command. Your script should first inform the other side of the connection that it wants to switch to SSL. How to do this is application specific.
 
 The best way to learn how to use these commands is to find a script that uses them and follow it carefully. However, hopefully this has given you a good start.
+
+.. _wildcards:
 
 Match Characters
 ----------------

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3137,13 +3137,13 @@ The following is a list of bind types and how they work. Below each bind type is
 
 (17) RAW (stackable)
 
-  bind raw <flags> <keyword> <proc>
+  bind raw <flags> <mask> <proc>
 
   procname <from> <keyword> <text>
 
-  IMPORTANT: While not necessarily deprecated, this bind has been supplanted by the RAWT bind as of 1.9.0. You probably want to be using RAWT, not RAW.
+  IMPORTANT: While not necessarily deprecated, this bind has been supplanted by the RAWT bind, which supports the IRCv3 message-tags capability, as of 1.9.0. You probably want to be using RAWT, not RAW.
 
-  Description: previous versions of Eggdrop required a special compile option to enable this binding, but it's now standard. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. The order of the arguments is identical to the order that the IRC server sends to the bot. The pre-processing only splits it apart enough to determine the keyword. If the proc returns 1, Eggdrop will not process the line any further (this could cause unexpected behavior in some cases), although RAWT binds are processed before RAW binds (and thus, a RAW bind cannot block a RAWT bind). The RAW bind does not support the IRCv3 message-tags capability, please see RAWT for more information.
+  Description: The mask can contain wildcards and is matched against the keyword, which is either a numeric, like "368", or a keyword, such as "PRIVMSG". "from" will be the server name or the source nick!ident@host (depending on the keyword); flags are ignored. If the proc returns 1, Eggdrop will not process the line any further (this could cause unexpected behavior in some cases), although RAWT binds are processed before RAW binds (and thus, a RAW bind cannot block a RAWT bind).
 
   Module: server
 
@@ -3516,11 +3516,11 @@ The following is a list of bind types and how they work. Below each bind type is
 
 (52) RAWT (stackable)
 
-  bind rawt <flags> <keyword> <proc>
+  bind rawt <flags> <mask> <proc>
 
-  procname <from> <keyword> <text> <tag>
+  procname <from> <keyword> <text> <tags>
 
-  Description: similar to the RAW bind, but allows an extra field for the IRCv3 message-tags capability. The keyword is either a numeric, like "368", or a keyword, such as "PRIVMSG" or "TAGMSG". "from" will be the server name or the source user (depending on the keyword); flags are ignored. "tag" will be the contents, if any, of the entire tag message prefixed to the server message in a dict format, such as "msgid 890157217279768 aaa bbb". The order of the arguments is identical to the order that the IRC server sends to the bot. If the proc returns 1, Eggdrop will not process the line any further, to include not being processed by a RAW bind (this could cause unexpected behavior in some cases). As of 1.9.0, it is recommended to use the RAWT bind instead of the RAW bind.
+  Description: similar to the RAW bind, but allows an extra field for the IRCv3 message-tags capability. The mask can contain wildcards and is matched against the keyword which is either a numeric, like "368", or a keyword, such as "PRIVMSG" or "TAGMSG". "from" will be the server name or the source nick!ident@host (depending on the keyword); flags are ignored. "tag" is a dictionary (flat key/value list) of the message tags with "" for empty values (e.g. "account eggdrop realname LamestBot"). If the proc returns 1, Eggdrop will not process the line any further, to include not being processed by a RAW bind (this could cause unexpected behavior in some cases). As of 1.9.0, it is recommended to use the RAWT bind instead of the RAW bind.
 
 (53) ACCOUNT (stackable)
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -1157,7 +1157,9 @@ accounttracking
 getaccount <nickname> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: the services account name associated with nickname (if Eggdrop is configured to track account status), and  "" if they are not logged in or Eggdrop is not able to determine the account status. WARNING: this account list may not be accurate depending on the server and configuration. This command is only accurate if a server supports (and Eggdrop has enabled) the account-notify and extended-join capabilities, and the server understands WHOX requests (also known as raw 354 responses).
+  Returns: the services account name associated with nickname, "*" if the user is not logged into services, or "" if eggdrop does not know the account status of the user.
+
+  NOTE: the three required IRC components for account tracking are: the WHOX feature, the extended-join IRCv3 capability and the account-notify IRCv3 capability. if only some of the three feature are available, eggdrop provides best-effort account tracking. please see doc/ACCOUNTS for additional information.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 nick2hand <nickname> [channel]
@@ -3526,7 +3528,9 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <user> <hand> <chan> <account>
 
-  Description: triggered when Eggdrop detects a change in a service account status. The change could be initiated by receiving an IRCv3 ACCOUNT message, receiving IRCv3 extended-join information when a user on an existing channel joins a new channel, or detecting an IRCv3 account-tag in a PRIVMSG. The mask for the bind is in the format "#channel nick!user@hostname.com account" where channel is the channel the user was found on when the bind was triggered, the hostmask is the user's hostmask, and account is the account name the user is logging in to, or "" for logging out. The mask argument can accept wildcards. For the proc, nick is the nickname of the user logging into/out of an account, user is the user@host.com hostmask, hand is the handle of the user (or * if none), and account is the name of the account the user logged in to (or "" if the user logged out of an account).
+  Description: this bind will trigger when eggdrop detects a change in the authentication status of a user's service account. The mask for the bind is in the format "#channel nick!user@hostname.com account" and accepts :ref:`<wildcards>Match Characters`. account is either the account name the user is logging in to or "*" if the user is not logged in to an account.
+
+  NOTE: the three required IRC components for account tracking are: the WHOX feature, the extended-join IRCv3 capability and the account-notify IRCv3 capability. if only some of the three feature are available, eggdrop provides best-effort account tracking but this bind could be triggered late or never on account changes. Please see doc/ACCOUNTS for additional information.
 
 (54) ISUPPORT (stackable)
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3719,5 +3719,8 @@ are the four special characters:
 | ~   | matches 1 or more space characters (can be used for whitespace between   |
 |     | words) (This char only works in binds, not in regular matching)          |
 +-----+--------------------------------------------------------------------------+
+| \\* | matches a literal \*, but please note that Tcl needs escaping as well,   |
+|     | so a bind would have to use "\\*" or {\*} for a mask argument            |
++-----+--------------------------------------------------------------------------+
 
   Copyright (C) 1999 - 2022 Eggheads Development Team

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1158,17 +1158,22 @@ server add ssl.example.net +7000
 #set sasl-timeout 15
 
 # To request the account-notify feature via CAP, set this to 1
-#set account-notify 0
+set account-notify 1
 
 # To request the extended-join feature via CAP, set this to 1
-#set extended-join 0
+set extended-join 1
 
 # To request the invite-notify feature via CAP, set this to 1
 #set invite-notify 0
 
-# To request the message-tags feature via CAP, set this to 1. NOTE: Enabling
-# this feature may interfere with RAW binds in scripts.
+# To request the message-tags feature via CAP, set this to 1
 #set message-tags 0
+
+# To request the account-tag feature via CAP, set this to 1
+# This can be enabled if necessary for imperfect account tracking if you don't
+# have the WHOX (use_354), account-notify and extended-join features available
+# see doc/ACCOUNT for details
+#set account-tag 0
 
 # If you have any additional CAP features you would like to request at
 # registration but are not listed above, set them here as space separated

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1172,7 +1172,7 @@ set extended-join 1
 # To request the account-tag feature via CAP, set this to 1
 # This can be enabled if necessary for imperfect account tracking if you don't
 # have the WHOX (use_354), account-notify and extended-join features available
-# see doc/ACCOUNT for details
+# see doc/ACCOUNTS for details
 #set account-tag 0
 
 # If you have any additional CAP features you would like to request at

--- a/misc/generatedocs
+++ b/misc/generatedocs
@@ -143,6 +143,7 @@ mv tmpdocs/tls.txt $BASEDIR/../doc/TLS
 mv tmpdocs/tricks.txt $BASEDIR/../doc/TRICKS
 mv tmpdocs/twitchinfo.txt $BASEDIR/../doc/TWITCH
 mv tmpdocs/users.txt $BASEDIR/../doc/USERS
+mv tmpdocs/accounts.txt $BASEDIR/../doc/ACCOUNTS
 rm -rf tmpdocs
 rm -rf $BASEDIR/../doc/html/_sources
 rm -rf $BASEDIR/../doc/doctrees/

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2982,6 +2982,18 @@ static int irc_isupport(char *key, char *isset_str, char *value)
   return 0;
 }
 
+static int gotrawt(char *from, char *msg, Tcl_Obj *tags) {
+  Tcl_Obj *valueobj;
+  if (TCL_OK != Tcl_DictObjGet(interp, tags, Tcl_NewStringObj("account", -1), &valueobj)) {
+    putlog(LOG_MISC, "*", "ERROR: irc:rawt called with invalid dictionary");
+    return 0;
+  }
+  if (valueobj) {
+    setaccount(splitnick(&from), Tcl_GetString(valueobj));
+  }
+  return 0;
+}
+
 static cmd_t irc_raw[] = {
   {"324",     "",   (IntFunc) got324,          "irc:324"},
   {"352",     "",   (IntFunc) got352,          "irc:352"},
@@ -3021,6 +3033,11 @@ static cmd_t irc_raw[] = {
   {"349",     "",   (IntFunc) got349,          "irc:349"},
   {"ACCOUNT", "",   (IntFunc) gotaccount,  "irc:account"},
   {NULL,     NULL,  NULL,                           NULL}
+};
+
+static cmd_t irc_rawt[] = {
+  {"*",       "",   (IntFunc) gotrawt,        "irc:rawt"},
+  {NULL,    NULL,   NULL,                           NULL}
 };
 
 static cmd_t irc_isupport_binds[] = {

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -226,9 +226,9 @@ static void setaccount(char *nick, char *account)
         /* account was known */
         if (m->account[0]) {
           if (!strcmp(account, "*")) {
-            putlog(LOG_JOIN, chan->dname, "%s!%s has logged out of their account", nick, m->userhost);
+            putlog(LOG_MODES, chan->dname, "%s!%s has logged out of their account", nick, m->userhost);
           } else {
-            putlog(LOG_JOIN, chan->dname, "%s!%s logged in to their account %s", nick, m->userhost, account);
+            putlog(LOG_MODES, chan->dname, "%s!%s logged in to their account %s", nick, m->userhost, account);
           }
           check_tcl_account(m->nick, m->userhost, m->user, chan->dname, account);
         }
@@ -1415,10 +1415,10 @@ static int gotaway(char *from, char *msg)
       if (strlen(msg)) {
         m->flags |= IRCAWAY;
         fixcolon(msg);
-        putlog(LOG_JOIN, chan->dname, "%s is now away: %s", from, msg);
+        putlog(LOG_MODES, chan->dname, "%s is now away: %s", from, msg);
       } else {
         m->flags &= ~IRCAWAY;
-        putlog(LOG_JOIN, chan->dname, "%s has returned from away status", from);
+        putlog(LOG_MODES, chan->dname, "%s has returned from away status", from);
       }
     }
   }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -212,6 +212,32 @@ static void update_idle(char *chname, char *nick)
   }
 }
 
+/* set user account on all members on all channels,
+ * trigger account bind if account state was not "unknown" (empty string)
+ */
+static void setaccount(char *nick, char *account)
+{
+  memberlist *m;
+  struct chanset_t *chan;
+
+  for (chan = chanset; chan; chan = chan->next) {
+    if ((m = ismember(chan, nick))) {
+      if (rfc_casecmp(m->account, account)) {
+        /* account was known */
+        if (m->account[0]) {
+          if (!strcmp(account, "*")) {
+            putlog(LOG_JOIN, chan->dname, "%s!%s has logged out of their account", nick, m->userhost);
+          } else {
+            putlog(LOG_JOIN, chan->dname, "%s!%s logged in to their account %s", nick, m->userhost, account);
+          }
+          check_tcl_account(m->nick, m->userhost, m->user, chan->dname, account);
+        }
+        strlcpy(m->account, account, sizeof m->account);
+      }
+    }
+  }
+}
+
 /* Returns the current channel mode.
  */
 static char *getchanmode(struct chanset_t *chan)
@@ -1163,10 +1189,8 @@ static int got324(char *from, char *msg)
 static int got352or4(struct chanset_t *chan, char *user, char *host,
                      char *nick, char *flags, char *account)
 {
-  char userhost[UHOSTLEN], mask[CHANNELLEN+UHOSTLEN+NICKMAX+2];
-  struct chanset_t *acctchan;
+  char userhost[UHOSTLEN];
   memberlist *m;
-  int empty_accounts;
 
   m = ismember(chan, nick);     /* In my channel list copy? */
   if (!m) {                     /* Nope, so update */
@@ -1216,25 +1240,11 @@ static int got352or4(struct chanset_t *chan, char *user, char *host,
   /* Update accountname in channel records, 0 means logged out */
   /* A 0 is not a change from "" */
   if (account) {
-    empty_accounts = (!strcmp(account, "0") && (!strcmp(m->account, "")));
-    /* If the account has changed... */
-    if (strcmp(account, m->account) && !empty_accounts) {
-      for (acctchan = chanset; acctchan; acctchan = acctchan->next) {
-        if ((m = ismember(chan, nick))) {
-          if (strcmp(account, "0")) {
-            strlcpy(m->account, account, sizeof(m->account));
-            snprintf(mask, sizeof mask, "%s %s", acctchan->dname, userhost);
-            if (strcasecmp(chan->dname, acctchan->dname)) {
-            }
-          } else {      /* Explicitly clear, in case someone deauthenticated? */
-            m->account[0] = 0;
-            snprintf(mask, sizeof mask, "%s %s", acctchan->dname, userhost);
-            if (strcasecmp(chan->dname, acctchan->dname)) {
-            }
-          }
-        }
-      }
+    if (!strcmp(account, "0")) {
+      /* normalize "logged out" to "*" */
+      account = "*";
     }
+    setaccount(nick, account);
   }
   return 0;
 }
@@ -2046,12 +2056,11 @@ static void set_delay(struct chanset_t *chan, char *nick)
  */
 static int gotjoin(char *from, char *channame)
 {
-  char *nick, *p, buf[UHOSTLEN], account[NICKMAX], *uhost = buf, *chname;
-  char *ch_dname = NULL, mask[CHANNELLEN+UHOSTLEN+NICKMAX+2];
+  char *nick, *p, buf[UHOSTLEN], *uhost = buf, *chname;
+  char *ch_dname = NULL;
   int extjoin = 0;
   struct chanset_t *chan;
-  struct chanset_t *extchan;
-  memberlist *m, *n;
+  memberlist *m;
   masklist *b;
   struct capability *current;
   struct userrec *u;
@@ -2183,42 +2192,23 @@ static int gotjoin(char *from, char *channame)
         strlcpy(m->userhost, uhost, sizeof m->userhost);
         m->user = u;
         m->flags |= STOPWHO;
+
         if (extjoin) {
-          /* Update account for all channels the nick is on, not just this one */
-          strlcpy(account, newsplit(&channame), sizeof account);
-          for (extchan = chanset; extchan; extchan = extchan->next) {
-            if ((n = ismember(extchan, nick))) {
-              if (strcmp(account, "*")) {
-                strlcpy (n->account, account, sizeof n->account);
-              } else {
-                n->account[0] = 0;
-              }
-              /* Don't trigger for the channel the user joined, but do trigger
-               * for other channels the user is already in
-               */
-              if (strcasecmp(chname, extchan->dname)) {
-                snprintf(mask, sizeof mask, "%s %s", chname, from);
-                //check_tcl_account(nick, from, mask, u, extchan->dname, account);
-              }
-            }
+          /* calls check_tcl_account which can delete the channel */
+          setaccount(nick, newsplit(&channame));
+          
+          if (!(chan = findchan(chname)) && !(chan = findchan_by_dname(ch_dname ? ch_dname : chname))) {
+            /* The channel doesn't exist anymore, so get out of here. */
+            goto exit;
           }
         }
+
         check_tcl_join(nick, uhost, u, chan->dname);
 
-        /* The tcl binding might have deleted the current user and the
-         * current channel, so we'll now have to re-check whether they
-         * both still exist.
-         */
-        chan = findchan(chname);
-        if (!chan) {
-          if (ch_dname)
-            chan = findchan_by_dname(ch_dname);
-          else
-            chan = findchan_by_dname(chname);
-        }
-        if (!chan)
+        if (!(chan = findchan(chname)) && !(chan = findchan_by_dname(ch_dname ? ch_dname : chname))) {
           /* The channel doesn't exist anymore, so get out of here. */
           goto exit;
+        }
 
         /* The record saved in the channel record always gets updated,
          * so we can use that. */
@@ -2891,6 +2881,15 @@ static int gotnotice(char *from, char *msg)
   return 0;
 }
 
+/* Got ACCOUNT message; only valid for account-notify capability */
+static int gotaccount(char *from, char *msg) {
+  char *nick = splitnick(&from);
+  fixcolon(msg);
+  /* nick!ident@host ACCOUNT xxx */
+  setaccount(nick, msg);
+  return 0;
+}
+
 static int parse_maxlist(const char *value)
 {
   int tmpsum = 0, addtosum;
@@ -3019,7 +3018,8 @@ static cmd_t irc_raw[] = {
   {"347",     "",   (IntFunc) got347,          "irc:347"},
   {"348",     "",   (IntFunc) got348,          "irc:348"},
   {"349",     "",   (IntFunc) got349,          "irc:349"},
-  {NULL,      NULL, NULL,                           NULL}
+  {"ACCOUNT", "",   (IntFunc) gotaccount,  "irc:account"},
+  {NULL,     NULL,  NULL,                           NULL}
 };
 
 static cmd_t irc_isupport_binds[] = {

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1311,9 +1311,10 @@ static int got354(char *from, char *msg)
 
   if (use_354) {
     newsplit(&msg);             /* Skip my nick - efficiently */
-    if (!strncmp(msg, "222", strlen("222"))) {
-      newsplit(&msg);           /* Skip our query-type magic number" */
+    if (strncmp(msg, "222", strlen("222"))) {
+      return 0;                 /* ignore request without our query type, could be different arguments */
     }
+    newsplit(&msg);           /* Skip our query-type magic number" */
     if (msg[0] && (strchr(CHANMETA, msg[0]) != NULL)) {
       chname = newsplit(&msg);  /* Grab the channel */
       chan = findchan(chname);  /* See if I'm on channel */

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -853,11 +853,11 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
       else
         chanflag = ' ';
       if (chan_issplit(m)) {
-        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- netsplit, %fs\n",
+        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c             <- netsplit, %fs\n",
               chanflag, maxnicklen, m->nick, maxhandlen, handle, maxnicklen,
               m->account, s, atrflag, difftime(now, m->split));
       } else if (!rfc_casecmp(m->nick, botname)) {
-        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c     <- it's me!\n", chanflag,
+        dprintf(idx, "%c%-*s %-*s %-*s %-6s %c             <- it's me!\n", chanflag,
               maxnicklen, m->nick, maxhandlen, handle, maxnicklen, m->account,
               s, atrflag);
       } else {

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1110,7 +1110,7 @@ static void tell_account_tracking_status(int idx, int details)
       if (tag && (!whox || !notify || !extjoin)) {
         dprintf(idx, "%s", "      - account-tag enabled    => Accounts will update whenever someone messages a channel or this bot\n");
       }
-      dprintf(idx, "%s", "      See doc/ACCOUNT for more details\n");
+      dprintf(idx, "%s", "      See doc/ACCOUNTS for more details\n");
     }
   }
 }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1452,6 +1452,7 @@ char *irc_start(Function *global_funcs)
   add_builtins(H_dcc, irc_dcc);
   add_builtins(H_msg, C_msg);
   add_builtins(H_raw, irc_raw);
+  add_builtins(H_rawt, irc_rawt);
   add_builtins(H_isupport, irc_isupport_binds);
   add_tcl_commands(tclchan_cmds);
   add_help_reference("irc.help");

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -48,6 +48,7 @@ static int check_tcl_pub(char *, char *, char *, char *);
 static int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *,
                                     char*);
 static int check_tcl_monitor(char *, int);
+static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account);
 static int me_op(struct chanset_t *);
 static int me_halfop(struct chanset_t *);
 static int me_voice(struct chanset_t *);

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -587,7 +587,7 @@ static int tcl_accounttracking STDVAR
     acctnotify = 1;
   }
   Tcl_SetResult(irp, use_354 && extjoin && acctnotify ? "1" : "0", NULL);
- return TCL_OK;
+  return TCL_OK;
 }
 
 static int tcl_getchanhost STDVAR

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -105,7 +105,7 @@ static char sslserver = 0;
 #endif
 
 static p_tcl_bind_list H_wall, H_raw, H_notc, H_msgm, H_msg, H_flud, H_ctcr,
-                       H_ctcp, H_out, H_rawt, H_account;
+                       H_ctcp, H_out, H_rawt;
 
 static void empty_msgq(void);
 static void next_server(int *, char *, unsigned int *, char *);
@@ -1279,17 +1279,6 @@ static int server_msg STDVAR
   return TCL_OK;
 }
 
-static int server_account STDVAR
-{
-  Function F = (Function) cd;
-
-  BADARGS(6, 6, " nick uhost hand chan account");
-
-  CHECKVALIDITY(server_account);
-  F(argv[1], argv[2], get_user_by_handle(userlist, argv[3]), argv[4], argv[5]);
-  return TCL_OK;
-}
-
 static int server_raw STDVAR
 {
   Function F = (Function) cd;
@@ -2139,7 +2128,6 @@ static char *server_close()
   isupport_fini();
   /* Restore original commands. */
   del_bind_table(H_wall);
-  del_bind_table(H_account);
   del_bind_table(H_raw);
   del_bind_table(H_rawt);
   del_bind_table(H_notc);
@@ -2246,7 +2234,7 @@ static Function server_table[] = {
   /* 40 - 43 */
   (Function) & H_out,           /* p_tcl_bind_list                      */
   (Function) & net_type_int,    /* int                                  */
-  (Function) & H_account,       /* p_tcl_bind)list                      */
+  (Function) NULL,              /* was H_account, now irc.mod           */
   (Function) & cap,             /* capability_t                         */
   /* 44 - 47 */
   (Function) & extended_join,   /* int                                  */
@@ -2255,7 +2243,7 @@ static Function server_table[] = {
   (Function) & isupport_get,    /*                                      */
   /* 48 - 52 */
   (Function) & isupport_parseint,/*                                     */
-  (Function) check_tcl_account,
+  (Function) NULL,               /* was check_tcl_account, now irc.mod  */
   (Function) & find_capability,
   (Function) encode_msgtags
 };
@@ -2358,7 +2346,6 @@ char *server_start(Function *global_funcs)
                TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                traced_nicklen, NULL);
   H_wall = add_bind_table("wall", HT_STACKABLE, server_2char);
-  H_account = add_bind_table("account", HT_STACKABLE, server_account);
   H_raw = add_bind_table("raw", HT_STACKABLE, server_raw);
   H_rawt = add_bind_table("rawt", HT_STACKABLE, server_rawt);
   H_notc = add_bind_table("notc", HT_STACKABLE, server_5char);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1661,6 +1661,7 @@ static tcl_ints my_tcl_ints[] = {
   {"message-tags",      &message_tags,              0},
   {"extended-join",     &extended_join,             0},
   {"account-notify",    &account_notify,            0},
+  {"account-tag",       &account_tag,               0},
   {NULL,                NULL,                       0}
 };
 

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -86,7 +86,7 @@
 /* 40 - 43 */
 #define H_out (*(p_tcl_bind_list *)(server_funcs[40]))
 #define net_type_int (*(int *)(server_funcs[41]))
-#define H_account (*(p_tcl_bind_list *)(server_funcs[42]))
+/* #define H_account unused */
 #define cap (*(capability_t **)(server_funcs[43]))
 /* 44 - 47 */
 #define extended_join (*(int *)(server_funcs[44]))
@@ -95,7 +95,7 @@
 #define isupport_get ((struct isupport *(*)(const char *, size_t))(server_funcs[47]))
 /* 48 - 51 */
 #define isupport_parseint ((int (*)(const char *, const char *, int, int, int, int, int *))(server_funcs[48]))
-#define check_tcl_account ((int (*)(char *,char *,char *,struct userrec *,char *,char *))server_funcs[49])
+/* #define check_tcl_account NULL */
 #define find_capability ((struct capability *(*)(char *))(server_funcs[50]))
 #define encode_msgtags ((char *(*)(Tcl_Obj *))(server_funcs[51]))
 #endif /* MAKING_SERVER */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -196,7 +196,7 @@ static int check_tcl_raw(char *from, char *code, char *msg)
   Tcl_SetVar(interp, "_raw2", code, 0);
   Tcl_SetVar(interp, "_raw3", msg, 0);
   x = check_tcl_bind(H_raw, code, 0, " $_raw1 $_raw2 $_raw3",
-                     MATCH_EXACT | BIND_STACKABLE | BIND_WANTRET);
+                     MATCH_MASK | BIND_STACKABLE | BIND_WANTRET);
 
   /* Return 1 if processed */
   return (x == BIND_EXEC_LOG);
@@ -212,7 +212,7 @@ static int check_tcl_rawt(char *from, char *code, char *msg, char *tagdict)
   Tcl_SetVar(interp, "_rawt3", msg, 0);
   Tcl_SetVar(interp, "_rawt4", tagdict, 0);
   x = check_tcl_bind(H_rawt, code, 0, " $_rawt1 $_rawt2 $_rawt3 $_rawt4",
-                    MATCH_EXACT | BIND_STACKABLE | BIND_WANTRET);
+                    MATCH_MASK | BIND_STACKABLE | BIND_WANTRET);
   return (x == BIND_EXEC_LOG);
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -40,7 +40,7 @@ static int multistatus = 0, count_ctcp = 0;
 static char altnick_char = 0;
 struct capability *cap;
 struct capability *find_capability(char *capname);
-int account_notify, extended_join;
+int account_notify = 1, extended_join = 1, account_tag = 0;
 Tcl_Obj *ncapeslist;
 
 /* We try to change to a preferred unique nick here. We always first try the
@@ -1841,6 +1841,9 @@ static int gotcap(char *from, char *msg) {
       if (!strcmp(current->name, "sasl") && (sasl) && !(current->enabled)) {
         add_req(current->name);
       } else if (!strcmp(current->name, "account-notify") && (account_notify)
+                && (!current->enabled)) {
+        add_req(current->name);
+      } else if (!strcmp(current->name, "account-tag") && (account_tag)
                 && (!current->enabled)) {
         add_req(current->name);
       } else if (!strcmp(current->name, "extended-join") && (extended_join) 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -259,22 +259,6 @@ static int check_tcl_wall(char *from, char *msg)
   return 1;
 }
 
-static int check_tcl_account(char *nick, char *uhost, char *mask,
-                            struct userrec *u, char *chan,  char *account)
-{
-  struct flag_record fr = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };
-  int x;
-
-  Tcl_SetVar(interp, "_acnt1", nick, 0);
-  Tcl_SetVar(interp, "_acnt2", uhost, 0);
-  Tcl_SetVar(interp, "_acnt3", u ? u->handle : "*", 0);
-  Tcl_SetVar(interp, "_acnt4", chan, 0);
-  Tcl_SetVar(interp, "_acnt5", account, 0);
-  x = check_tcl_bind(H_account, mask, &fr,
-       " $_acnt1 $_acnt2 $_acnt3 $_acnt4 $_acnt5", MATCH_MASK | BIND_STACKABLE);
-  return (x == BIND_EXEC_LOG);
-}
-
 static int check_tcl_flud(char *nick, char *uhost, struct userrec *u,
                           char *ftype, char *chname)
 {
@@ -1646,34 +1630,6 @@ static int handle_sasl_timeout()
   return sasl_error("timeout");
 }
 
-/* Got ACCOUNT message; only valid for account-notify capability */
-static int gotaccount(char *from, char *msg) {
-  struct chanset_t *chan;
-  struct userrec *u;
-  memberlist *m;
-  char *nick, *chname, mask[CHANNELLEN+UHOSTLEN+NICKMAX+2];
-
-  u = get_user_by_host(from);
-  nick = splitnick(&from);
-  for (chan = chanset; chan; chan = chan->next) {
-    chname = chan->dname;
-    if ((m = ismember(chan, nick))) {
-      strlcpy (m->account, msg[0] == '*' ? "" : msg, sizeof m->account);
-      snprintf(mask, sizeof mask, "%s %s", chname, from);
-      if (!strcasecmp(msg, "*")) {
-        msg[0] = '\0';
-        putlog(LOG_JOIN, chname, "%s!%s has logged out of their "
-                "account", nick, from);
-      } else {
-        putlog(LOG_JOIN, chname, "%s!%s has logged into account %s",
-                nick, from, msg);
-      }
-      check_tcl_account(nick, from, mask, u, chname, msg[0] == '*' ? "" : msg);
-    }
-  }
-  return 0;
-}
-
 /*
  * 465     ERR_YOUREBANNEDCREEP :You are banned from this server
  */
@@ -2085,7 +2041,6 @@ static cmd_t my_raw_binds[] = {
   {"KICK",         "",   (IntFunc) gotkick,         NULL},
   {"CAP",          "",   (IntFunc) gotcap,          NULL},
   {"AUTHENTICATE", "",   (IntFunc) gotauthenticate, NULL},
-  {"ACCOUNT",      "",   (IntFunc) gotaccount,      NULL},
   {"CHGHOST",      "",   (IntFunc) gotchghost,      NULL},
   {"SETNAME",      "",   (IntFunc) gotsetname,      NULL},
   {NULL,           NULL, NULL,                      NULL}


### PR DESCRIPTION
- Central setaccount() function to update account and call binds
- Normalized m->account values (empty string = unknown, "*" = not logged in, otherwise accountname)
- raw and rawt accept wildcards
- moved most of account functionality to irc.mod because it's only relevant in the context of channels
- improved .status reporting for account tracking
- request account-notify and extended-join by default