### PR TITLE
Avoid freeaddrinfo(NULL) and enhance error logging

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -555,7 +555,7 @@ void *thread_dns_ipbyhost(void *arg)
       freeaddrinfo(res0);
   }
   else if (error == EAI_NONAME)
-    debug1("dns: thread_dns_ipbyhost(): getaddrinfo(): hostname '%s' not known", dtn->host);
+    debug1("dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s not known", dtn->host);
   else
     debug1("dns: thread_dns_ipbyhost(): getaddrinfo(): error = %s", gai_strerror(error));
   pthread_mutex_lock(&dtn->mutex);

--- a/src/dns.c
+++ b/src/dns.c
@@ -550,8 +550,8 @@ void *thread_dns_ipbyhost(void *arg)
       }
     }
 #endif
-    if (res0) /* The behavior of freeadrinfo(NULL) is left unspecified by RFC
-               * 3493 */
+    if (res0) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
+               * 2553 and 3493. Avoid to be compatible with all OSes. */
       freeaddrinfo(res0);
   }
   else if (i == EAI_NONAME)

--- a/src/dns.c
+++ b/src/dns.c
@@ -521,7 +521,7 @@ void *thread_dns_hostbyip(void *arg)
 void *thread_dns_ipbyhost(void *arg)
 {
   struct dns_thread_node *dtn = (struct dns_thread_node *) arg;
-  struct addrinfo *res0, *res;
+  struct addrinfo *res0 = NULL, *res;
   int i;
   sockname_t *addr = &dtn->addr;
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -555,7 +555,7 @@ void *thread_dns_ipbyhost(void *arg)
       freeaddrinfo(res0);
   }
   else if (i == EAI_NONAME)
-    debug0("dns: thread_dns_ipbyhost(): getaddrinfo(): hostname not known");
+    debug1("dns: thread_dns_ipbyhost(): getaddrinfo(): hostname '%s' not known", dtn->host);
   else
     debug1("dns: thread_dns_ipbyhost(): getaddrinfo(): error = %s", gai_strerror(i));
   pthread_mutex_lock(&dtn->mutex);

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1028,13 +1028,12 @@ static int tcl_connect STDVAR
 }
 
 static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *maskproc, char *flag) {
-  int i, idx = -1, port, realport, found=0, ipv4=1;
+  int i, idx = -1, port, realport, found=0, ipv4=1, error;
   char s[11], msg[256], newip[EGG_INET_ADDRSTRLEN];
   struct portmap *pmap = NULL, *pold = NULL;
   sockname_t name;
   struct in_addr ipaddr4;
   struct addrinfo hint, *ipaddr = NULL;
-  int ret;
 #ifdef IPV6
   struct in6_addr ipaddr6;
 #endif
@@ -1056,8 +1055,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     strlcpy(newip, ip, sizeof newip);
   }
   /* Return addrinfo struct ipaddr containing family... */
-  ret = getaddrinfo(newip, NULL, &hint, &ipaddr);
-  if (!ret) {
+  error = getaddrinfo(newip, NULL, &hint, &ipaddr);
+  if (!error) {
   /* Load network address to in(6)_addr struct for later byte comparisons */
     if (ipaddr->ai_family == AF_INET) {
       inet_pton(AF_INET, newip, &ipaddr4);
@@ -1072,12 +1071,12 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
                  * 2553 and 3493. Avoid to be compatible with all OSes. */
       freeaddrinfo(ipaddr);
   }
-  else if (ret == EAI_NONAME)
+  else if (error == EAI_NONAME)
     putlog(LOG_MISC, "*",
            "tcldcc: setlisten(): getaddrinfo(): hostname '%s' not known", newip);
   else
     putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
-           gai_strerror(ret));
+           gai_strerror(error));
   port = realport = atoi(portp);
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next) {
     if (pmap->realport == port) {

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1072,8 +1072,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
   else
     debug1("tcldcc: (): setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));
-  if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFC
-               * 3493 */
+  if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
+               * 2553 and 3493. Avoid to be compatible with all OSes. */
     freeaddrinfo(ipaddr);
   port = realport = atoi(portp);
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next) {

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1070,7 +1070,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
 #endif
   }
   else
-    debug1("tcldcc: (): setlisten(): getaddrinfo(): error = %s",
+    putlog(LOG_MISC, "*", "tcldcc: (): setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));
   if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
                * 2553 and 3493. Avoid to be compatible with all OSes. */

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1069,7 +1069,12 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     }
 #endif
   }
-  freeaddrinfo(ipaddr);
+  else
+    debug1("tcldcc: (): setlisten(): getaddrinfo(): error = %s",
+           gai_strerror(ret));
+  if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFC
+               * 3493 */
+    freeaddrinfo(ipaddr);
   port = realport = atoi(portp);
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next) {
     if (pmap->realport == port) {

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1071,7 +1071,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
   }
   else if (ret == EAI_NONAME)
     putlog(LOG_MISC, "*",
-           "tcldcc: setlisten(): getaddrinfo(): hostname not known");
+           "tcldcc: setlisten(): getaddrinfo(): hostname '%s' not known", newip);
   else
     putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1290,7 +1290,7 @@ static int tcl_listen STDVAR
       strlcpy(ip, argv[1], sizeof(ip));
       i++;
     } else {
-      Tcl_AppendResult(irp, "invalid ip address", NULL);
+      Tcl_AppendResult(irp, "invalid IP address argument", NULL);
       return TCL_ERROR;
     }
   }

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1070,7 +1070,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
 #endif
   }
   else
-    putlog(LOG_MISC, "*", "tcldcc: (): setlisten(): getaddrinfo(): error = %s",
+    putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));
   if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
                * 2553 and 3493. Avoid to be compatible with all OSes. */

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1069,6 +1069,9 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     }
 #endif
   }
+  else if (ret == EAI_NONAME)
+    putlog(LOG_MISC, "*",
+           "tcldcc: setlisten(): getaddrinfo(): hostname not known");
   else
     putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1068,6 +1068,9 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       ipv4 = 0;
     }
 #endif
+    if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
+                 * 2553 and 3493. Avoid to be compatible with all OSes. */
+      freeaddrinfo(ipaddr);
   }
   else if (ret == EAI_NONAME)
     putlog(LOG_MISC, "*",
@@ -1075,9 +1078,6 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
   else
     putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
            gai_strerror(ret));
-  if (ipaddr) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
-               * 2553 and 3493. Avoid to be compatible with all OSes. */
-    freeaddrinfo(ipaddr);
   port = realport = atoi(portp);
   for (pmap = root; pmap; pold = pmap, pmap = pmap->next) {
     if (pmap->realport == port) {

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1072,8 +1072,9 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       freeaddrinfo(ipaddr);
   }
   else if (error == EAI_NONAME)
+    /* currently setlisten() handles only ip not hostname */
     putlog(LOG_MISC, "*",
-           "tcldcc: setlisten(): getaddrinfo(): hostname '%s' not known", newip);
+           "tcldcc: setlisten(): getaddrinfo(): ip %s not known", newip);
   else
     putlog(LOG_MISC, "*", "tcldcc: setlisten(): getaddrinfo(): error = %s",
            gai_strerror(error));


### PR DESCRIPTION
Found by: Release_
Patch by: michaelortmann
Fixes: #1329

One-line summary:
Avoid `freeaddrinfo(NULL)` and enhance error logging

Additional description (if needed):
The behavior of `freeadrinfo(NULL)` is left unspecified by RFC 3493
Some Operating Systems like FreeBSD handle this for compatibility / portability but others like OpenBSD do not (as reported in #1329), so let eggdrop avoid calling `freeadrinfo(NULL)`.
Log `gai_strerror()` for every single case of error of `getaddrinfo()` and `getnameinfo()`

Test cases demonstrating functionality (if applicable):
```
$ uname -a
OpenBSD openbsd71.home.arpa 7.1 GENERIC.MP#3 amd64
```
Config file:
```
set listen-addr test.com
listen 3333 all
```
Before:
```
* Last context: tclhash.c/247 []
* Please REPORT this BUG!
* Check doc/BUG-REPORT on how to do so.
* Wrote DEBUG
* SEGMENT VIOLATION -- CRASHING!
Segmentation fault (core dumped) 
```
After:
```
tcldcc: setlisten(): getaddrinfo(): hostname 'test.com' not known
Tcl error in file 'BotA.conf':
Couldn't listen on port '3333' on the given address: Cannot assign requested address. Please check that the port is not already in use
    while executing
"listen 3333 all"
    (file "BotA.conf" line 1668)
* CONFIG FILE NOT LOADED (NOT FOUND, OR ERROR)
```