### PR TITLE
Fix matchattr without flags to always match again, e.g. - or -|-

### DIFF
--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -270,6 +270,7 @@ static int tcl_matchattr STDVAR
       if (!plus.global && !plus.udef_global && !plus.chan &&
           !plus.udef_chan && !plus.bot) {
         /* No flags (e.g. "-" or "+" or "-|-" matches anyone */
+        Tcl_AppendResult(irp, "1", NULL);
         return TCL_OK;
       }
     }

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -269,8 +269,8 @@ static int tcl_matchattr STDVAR
       nom = 1;
       if (!plus.global && !plus.udef_global && !plus.chan &&
           !plus.udef_chan && !plus.bot) {
-        Tcl_AppendResult(irp, "Unknown flag specified for matching", NULL);
-        return TCL_ERROR;
+        /* No flags (e.g. "-" or "+" or "-|-" matches anyone */
+        return TCL_OK;
       }
     }
     if (flagrec_eq(&plus, &user)) {


### PR DESCRIPTION
Fixes: #1267

The matchattr/bind flag string "-" or "-|-" is commonly used to match "anyone". It isn't a real match because there are no flags specified so there is nothing to match. - and | are just meta-characters that don't parse to modes that can match.

Found by: crazycatdevs
Patch by: thommey
