### PR TITLE
(RFC / WIP) utf8

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -340,6 +340,7 @@ void tell_verbose_status(int idx)
 
   if (tcl_threaded())
     dprintf(idx, "Tcl is threaded.\n");
+  dprintf(idx, "Tcl TCL_UTF_MAX: %i\n", TCL_UTF_MAX);
 #ifdef TLS
   dprintf(idx, "TLS support is enabled.\n"
   #if defined HAVE_EVP_PKEY_GET1_EC_KEY && defined HAVE_OPENSSL_MD5


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1326

One-line summary:
Add `TCL_UTF_MAX` to `.status`

Additional description (if needed):
Currently this PR is for wild experimentation

We could check if `TCL_UTF_MAX` is 3 (and tcl version) in .status and tell like `Tcl TCL_UTF_MAX: 3 (if your eggdrop/tcl-script crashes on utf8mb4, consider recompiling tcl with TCL_UTF_MAX set to 4 or use TCL 8.7+ where the bug may have been fixed`

Test cases demonstrating functionality (if applicable):
```
.status:
[...]
Tcl library: /usr/lib/tcl8.6
Tcl version: 8.6.12 (header version 8.6.12)
Tcl is threaded.
Tcl TCL_UTF_MAX: 3
[...]
```