### PR TITLE
Fix typo: dependancy -> dependency

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -921,7 +921,7 @@ static void mainloop(int toplevel)
       while (f) {
         f = 0;
         for (p = module_list; p != NULL; p = p->next) {
-          dependancy *d = dependancy_list;
+          dependency *d = dependency_list;
           int ok = 1;
 
           while (ok && d) {

--- a/src/modules.h
+++ b/src/modules.h
@@ -63,13 +63,13 @@ extern struct hook_entry {
 
 #endif
 
-typedef struct _dependancy {
+typedef struct _dependency {
   struct _module_entry *needed;
   struct _module_entry *needing;
-  struct _dependancy *next;
+  struct _dependency *next;
   int major;
   int minor;
-} dependancy;
-extern dependancy *dependancy_list;
+} dependency;
+extern dependency *dependency_list;
 
 #endif /* _EGG_MODULE_H */

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -589,7 +589,7 @@ static int tcl_modules STDVAR
   int i;
   char *p, s[24], s2[24];
   EGG_CONST char *list[100], *list2[2];
-  dependancy *dep;
+  dependency *dep;
   module_entry *current;
 
   BADARGS(1, 1, "");
@@ -599,7 +599,7 @@ static int tcl_modules STDVAR
     egg_snprintf(s, sizeof s, "%d.%d", current->major, current->minor);
     list[1] = s;
     i = 2;
-    for (dep = dependancy_list; dep && (i < 100); dep = dep->next) {
+    for (dep = dependency_list; dep && (i < 100); dep = dep->next) {
       if (dep->needing == current) {
         list2[0] = dep->needed->name;
         egg_snprintf(s2, sizeof s2, "%d.%d", dep->major, dep->minor);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix long standing typo

Additional description (if needed):
Yes, we can rename variables

Test cases demonstrating functionality (if applicable):
