### PR TITLE
Fix openssl3 deprecation

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -228,27 +228,49 @@ int ssl_init()
 #endif
   /* Let advanced users specify dhparam */
   if (tls_dhparam[0]) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L /* 3.0.0 */
+    BIO *pbio = BIO_new_file(tls_dhparam, "r");
+    if (pbio) {
+      EVP_PKEY *param = PEM_read_bio_Parameters(pbio, NULL);
+      BIO_free(pbio);
+      if (param) {
+        if (SSL_CTX_set0_tmp_dh_pkey(ssl_ctx, param) == 1)
+          debug1("TLS: setting ssl dhparam %s successful", tls_dhparam);
+        else {
+          EVP_PKEY_free(param);
+          putlog(LOG_MISC, "*", "ERROR: TLS: SSL_CTX_set0_tmp_dh_pkey(%s): %s",
+                 tls_dhparam, ERR_error_string(ERR_get_error(), NULL));
+        }
+      }
+      else
+        putlog(LOG_MISC, "*", "ERROR: TLS: PEM_read_bio_Parameters(%s): %s",
+               tls_dhparam, ERR_error_string(ERR_get_error(), NULL));
+    }
+    else
+      putlog(LOG_MISC, "*", "ERROR: TLS: BIO_new_file(%s): %s", tls_dhparam,
+            ERR_error_string(ERR_get_error(), NULL));
+#else
     DH *dh;
     FILE *paramfile = fopen(tls_dhparam, "r");
     if (paramfile) {
       dh = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
       fclose(paramfile);
       if (dh) {
-        if (SSL_CTX_set_tmp_dh(ssl_ctx, dh) != 1) {
-          putlog(LOG_MISC, "*", "ERROR: TLS: unable to set tmp dh %s: %s",
+        if (SSL_CTX_set_tmp_dh(ssl_ctx, dh) == 1)
+          debug1("TLS: setting ssl dhparam %s successful", tls_dhparam);
+        else
+          putlog(LOG_MISC, "*", "ERROR: TLS: SSL_CTX_set_tmp_dh(%s): %s",
                  tls_dhparam, ERR_error_string(ERR_get_error(), NULL));
-        }
         DH_free(dh);
       }
-      else {
-        putlog(LOG_MISC, "*", "ERROR: TLS: unable to read DHparams %s: %s",
+      else
+        putlog(LOG_MISC, "*", "ERROR: TLS: PEM_read_DHparams(%s): %s",
                tls_dhparam, ERR_error_string(ERR_get_error(), NULL));
-      }
     }
-    else {
+    else
       putlog(LOG_MISC, "*", "ERROR: TLS: unable to open %s: %s",
              tls_dhparam, strerror(errno));
-    }
+#endif
   }
   /* Let advanced users specify the list of allowed ssl ciphers */
   if (tls_ciphers[0] && !SSL_CTX_set_cipher_list(ssl_ctx, tls_ciphers)) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1113

One-line summary:
Fix openssl3 deprecation

Additional description (if needed):
Fix the following openssl3 deprecation
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tls.c
tls.c: In function ‘ssl_init’:
tls.c:234:7: warning: ‘PEM_read_DHparams’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  234 |       dh = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
      |       ^~
In file included from /usr/include/openssl/ssl.h:36,
                 from eggdrop.h:266,
                 from main.h:89,
                 from tls.c:27:
/usr/include/openssl/pem.h:469:1: note: declared here
  469 | DECLARE_PEM_rw_attr(OSSL_DEPRECATEDIN_3_0, DHparams, DH)
      | ^~~~~~~~~~~~~~~~~~~
tls.c:241:9: warning: ‘DH_free’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  241 |         DH_free(dh);
      |         ^~~~~~~
In file included from /usr/include/openssl/dsa.h:51,
                 from /usr/include/openssl/x509.h:37,
                 from /usr/include/openssl/ssl.h:31:
/usr/include/openssl/dh.h:200:28: note: declared here
  200 | OSSL_DEPRECATEDIN_3_0 void DH_free(DH *dh);
      |                            ^~~~~~~
```

Test cases demonstrating functionality (if applicable):
Tested with OpenSSL 3.0.7, OpenSSL 1.1.1s and OpenSSL 3.6.1
Tested error cases by setting ssl-dhparam in eggdrop.conf to nonexistsing file and to a non-dhparam file