### PR TITLE
-days is useless in makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -313,10 +313,10 @@ sslstart:
 	fi
 
 sslcert: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
+	openssl req -new -x509 -nodes -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
 
 sslsilent: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
+	openssl req -new -x509 -nodes -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
 	    -subj "/O=Eggheads/OU=Eggdrop/CN=Self-generated Eggdrop Certificate"
 
 install: ainstall


### PR DESCRIPTION
Certificate duration should not be hard-coded in makefile.in because it overrides the value in [ssl.conf](https://github.com/eggheads/eggdrop/blob/develop/ssl.conf#L13) Following the observation of the outcome #1308

Found by: [ZarTek-Creole](https://github.com/eggheads/eggdrop/commits?author=ZarTek-Creole)
Patch by: [ZarTek-Creole](https://github.com/eggheads/eggdrop/commits?author=ZarTek-Creole)
Fixes: 
Prevent makefile from overriding ssl.conf information
