### PR TITLE
Fix crash - add tcl service mode hook stub / enhance doc

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,6 +19,8 @@ Eggdrop uses the GNU autoconfigure scripts to make things easier.
         correctly compile Eggdrop. It will also try to find Tcl, which
         is required to compile.
 
+        For macOS tcl and openssl see doc/COMPILE-GUIDE.
+
 2.  
 
     Type either 'make config' or 'make iconfig' to determine which
@@ -154,5 +156,5 @@ the README file. If not, then READ IT!&@#%@!
 
 Have fun with Eggdrop!
 
-  Copyright (C) 1997 Robey Pointer Copyright (C) 1999 - 2022 Eggheads
-  Development Team
+  Copyright (C) 1997 Robey Pointer
+  Copyright (C) 1999 - 2022 Eggheads Development Team

--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -1,5 +1,5 @@
 Eggdrop Compile Guide and FAQ
-Last revised: June 9, 2020
+Last revised: November 17, 2022
     _____________________________________________________________________
 
                         Eggdrop Compile Guide and FAQ
@@ -20,7 +20,7 @@ Last revised: June 9, 2020
       A. Standard compile process (Linux, FreeBSD, NetBSD, OpenBSD, etc)
       B. HP-UX B.11.*
       C. Ultrix
-      D. Mac OS X
+      D. macOS (previously OS X and originally Mac OS X)
       E. AIX
       F. IRIX
       G. Solaris / SunOS
@@ -187,7 +187,7 @@ Last revised: June 9, 2020
                gmake install DEST=/home/user/otherdir
 
 
-    D. Mac OS X
+    D. macOS
       Follow the standard compile process in Section A. To compile dynamically
       (with module support), use 'make eggdrop' instead of 'make'.
 
@@ -210,7 +210,7 @@ Last revised: June 9, 2020
       If you notice a module that requires these changes, it would probably be
       a good idea to let the module's developer know, so it can be fixed.
 
-      Note that on Mac OS X, the DYLD_LIBRARY_PATH environment variable should
+      Note that on macOS, the DYLD_LIBRARY_PATH environment variable should
       be used instead of LD_LIBRARY_PATH.
 
       Install OpenSSL using homebrew:
@@ -221,7 +221,7 @@ Last revised: June 9, 2020
 
       Tell configure where to find tcl and openssl:
 
-        ./configure --with-tcl=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh --with-sslinc=/usr/local/opt/openssl/include --with-ssllib=/usr/local/opt/openssl/lib
+        ./configure --with-tcl=/System/Volumes/Data/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh -with-sslinc=/usr/local/Cellar/openssl@3/3.0.7/include --with-ssllib=/usr/local/Cellar/openssl@3/3.0.7/lib
 
     E. AIX
       Follow the standard compile process in Section A. To compile dynamically
@@ -581,4 +581,4 @@ Last revised: June 9, 2020
     _____________________________________________________________________
 
    Copyright (C) 1997 Robey Pointer
-   Copyright (C) 1999 - 2021 Eggheads Development Team
+   Copyright (C) 1999 - 2022 Eggheads Development Team

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -596,8 +596,9 @@ void tickle_AlertNotifier(ClientData cd)
 
 void tickle_ServiceModeHook(int mode)
 {
-  if (mode != TCL_SERVICE_ALL)
-    putlog(LOG_MISC, "*", "stub tickle_ServiceModeHook");
+  if (mode != TCL_SERVICE_ALL) {
+    fatal("Tcl_ServiceModeHook called with unsupported mode", 0);
+  }
 }
 
 int tclthreadmainloop(int zero)

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -594,6 +594,11 @@ void tickle_AlertNotifier(ClientData cd)
     putlog(LOG_MISC, "*", "stub tickle_AlertNotifier");
 }
 
+void tickle_ServiceModeHook(int mode)
+{
+  putlog(LOG_MISC, "*", "stub tickle_ServiceModeHook");
+}
+
 int tclthreadmainloop(int zero)
 {
   int i;
@@ -661,6 +666,7 @@ void init_tcl(int argc, char **argv)
   notifierprocs.waitForEventProc = tickle_WaitForEvent;
   notifierprocs.finalizeNotifierProc = tickle_FinalizeNotifier;
   notifierprocs.alertNotifierProc = tickle_AlertNotifier;
+  notifierprocs.serviceModeHookProc = tickle_ServiceModeHook;
 
   Tcl_SetNotifier(&notifierprocs);
 #endif /* REPLACE_NOTIFIER */

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -596,7 +596,8 @@ void tickle_AlertNotifier(ClientData cd)
 
 void tickle_ServiceModeHook(int mode)
 {
-  putlog(LOG_MISC, "*", "stub tickle_ServiceModeHook");
+  if (mode != TCL_SERVICE_ALL)
+    putlog(LOG_MISC, "*", "stub tickle_ServiceModeHook");
 }
 
 int tclthreadmainloop(int zero)

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -590,8 +590,9 @@ ClientData tickle_InitNotifier()
 
 void tickle_AlertNotifier(ClientData cd)
 {
-  if (cd)
-    putlog(LOG_MISC, "*", "stub tickle_AlertNotifier");
+  if (cd) {
+    fatal("Error calling Tcl_AlertNotifier", 0);
+  }
 }
 
 void tickle_ServiceModeHook(int mode)


### PR DESCRIPTION
Found by: MacinMan
Patch by: michaelortmann
Fixes: #1351 and #1352

One-line summary:
Fix crash - add tcl service mode hook stub / enhance doc

Additional description (if needed):
This fix is similar to #1115

Test cases demonstrating functionality (if applicable):
Test under macOS Big Sur 11.7.1.
With default tcl 8.5.9 (MacOSX sdk) under macOS eggdrop has got no problem:
`./configure --with-tcl=/System/Volumes/Data/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh`
With user compiled tcl 8.6.12:
`./configure --with-tcl=/Users/michael/opt/tcl8.6.12/lib/tclConfig.sh`
**Before:**
```
michael@macos eggdrop % ./eggdrop -t BotA.conf 

Eggdrop v1.9.4+alpha (C) 1997 Robey Pointer (C) 2010-2022 Eggheads
Tcl_ServiceModeHook: Notifier not initialized
zsh: abort      ./eggdrop -t BotA.conf
```
**After:**
No problem.