### PR TITLE
Fix sasl authenticate log

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1520,7 +1520,7 @@ static int tryauthenticate(char *from, char *msg)
     ret = ECDSA_sign(0, dst, olen, sig, &siglen, eckey);
     EC_KEY_free(eckey);
     if (!ret) {
-      printf("SASL: AUTHENTICATE: ECDSA_sign() SSL error = %s\n",
+      putlog(LOG_SERV, "*", "SASL: AUTHENTICATE: ECDSA_sign() SSL error = %s\n",
              ERR_error_string(ERR_get_error(), 0));
       nfree(sig);
       return 1;
@@ -1536,8 +1536,8 @@ static int tryauthenticate(char *from, char *msg)
     dprintf(DP_MODE, "AUTHENTICATE %s\n", dst);
 #endif /* HAVE_EVP_PKEY_GET1_EC_KEY */
 #else /* TLS */
-    dprintf(LOG_DEBUG, "*", "SASL: Received EC message, but no TLS EC libs "
-                "present. Try PLAIN method");
+    putlog(LOG_SERV, "*", "SASL: Received EC message, but no TLS EC libs "
+           "present. Try PLAIN method");
     return 1;
 #endif /* TLS */
   }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix sasl authenticate log

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
Test with `./configure --disable-tls`
Before:
```
$ make
[...]
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
In file included from .././server.mod/server.c:144:
.././server.mod/servmsg.c: In function ‘tryauthenticate’:
.././server.mod/servmsg.c:1539:24: warning: too many arguments for format [-Wformat-extra-args]
 1539 |     dprintf(LOG_DEBUG, "*", "SASL: Received EC message, but no TLS EC libs "
      |                        ^~~
gcc   -shared -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -o ../../../server.so ../server.o -L/usr/lib -ltcl8.6  -lz -lpthread -lm  -lresolv  && touch ../../../server.so
```
After:
no compiler warning anymore