### PR TITLE
Increase .tcl logfile output from 151 to 256

### DIFF
--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -73,7 +73,7 @@ int expmem_tclmisc()
 static int tcl_logfile STDVAR
 {
   int i;
-  char s[151];
+  char s[256];
 
   BADARGS(1, 4, " ?logModes channel logFile?");
 
@@ -81,7 +81,7 @@ static int tcl_logfile STDVAR
     /* They just want a list of the logfiles and modes */
     for (i = 0; i < max_logs; i++)
       if (logs[i].filename != NULL) {
-        egg_snprintf(s, sizeof s, "%s %s %s", masktype(logs[i].mask),
+        snprintf(s, sizeof s, "%s %s %s", masktype(logs[i].mask),
                  logs[i].chname, logs[i].filename);
         Tcl_AppendElement(interp, s);
       }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Increase .tcl logfile output from 151 to 256

Additional description (if needed):
151 looks too small

Test cases demonstrating functionality (if applicable):
BotA.conf:
`logfile mco * "logs/BotAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjjkkkkkkkkkk.log"`
Before:
```
.tcl logfile
Tcl: {mco * logs/BotAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggggggghhhhhhhhhhiiiiiiii}
```
After:
```
.tcl logfile
`Tcl: {mco * logs/BotAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjjkkkkkkkkkk.log}`
```