### PR TITLE
Increase nouserfile output from 178 to 256

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -484,9 +484,9 @@ void chanprog()
 
   if (!readuserfile(userfile, &userlist)) {
     if (!make_userfile) {
-      char tmp[178];
+      char tmp[256];
 
-      egg_snprintf(tmp, sizeof tmp, MISC_NOUSERFILE, configfile);
+      snprintf(tmp, sizeof tmp, MISC_NOUSERFILE, configfile);
       fatal(tmp, 0);
     }
     printf("\n\n%s\n", MISC_NOUSERFILE2);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Increase nouserfile output from 178 to 256

Additional description (if needed):
MISC_NOUSERFILE len can at least be 78 chars:
```
language/core.portuguese.lang:0x535,FICHEIRO DE UTILIZADOR NÃO ENCONTRADO! (tenta './eggdrop -m %s' para criar um)\n

$ echo "FICHEIRO DE UTILIZADOR NÃO ENCONTRADO! (tenta './eggdrop -m ' para criar um)"|wc -c
78
```
configfile len can at least be 121 chars:
`src/main.c:char configfile[121] = "eggdrop.conf";  /* Default config file name */`
(78 + 121) > 178

Test cases demonstrating functionality (if applicable):
