### PR TITLE
Update autobotchk

### DIFF
--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -308,7 +308,12 @@ if {$systemd} {
   puts "ERROR: Eggdrop did not start."
   puts $res
  } else {
-  puts "Success."
+  puts "Success. Enabling ${botnet-nick}.service..."
+  if {[catch {exec systemctl --user enable ${botnet-nick}.service} res]} {
+   puts "ERROR! $res"
+  } else {
+   puts $res
+  }
  }
  exit
 }

--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -276,7 +276,7 @@ if {$systemd} {
   exit
  }
  puts "Creating systemd directory..."
- catch {exec mkdir -p ~/.config/systemd/user} res
+ catch {file mkdir ~/.config/systemd/user} res
  if {[catch {open ~/.config/systemd/user/${botnet-nick}.service w} fd]} {
   puts "  *** ERROR: unable to open '${botnet-nick}.service' for writing"
   puts ""
@@ -308,12 +308,7 @@ if {$systemd} {
   puts "ERROR: Eggdrop did not start."
   puts $res
  } else {
-  puts "Success. Enabling ${botnet-nick}.service..."
-  if {[catch {exec systemctl --user enable ${botnet-nick}.service} res]} {
-   puts "ERROR! $res"
-  } else {
-   puts $res
-  }
+  puts "Success."
  }
  exit
 }


### PR DESCRIPTION
Let's enable the systemd unit so it actually restart the bot on crash/machine reboot.

Found by: PeGaSuS
Patch by: PeGaSuS
Fixes:

One-line summary:
Currently the user unit isn't enabled which will cause eggdrop to not restart on crash/machine reboot. This PR should fix it.


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
