### PR TITLE
Update autobotchk

### DIFF
--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -276,7 +276,7 @@ if {$systemd} {
   exit
  }
  puts "Creating systemd directory..."
- catch {exec mkdir -p ~/.config/systemd/user} res
+ catch {file mkdir ~/.config/systemd/user } res
  if {[catch {open ~/.config/systemd/user/${botnet-nick}.service w} fd]} {
   puts "  *** ERROR: unable to open '${botnet-nick}.service' for writing"
   puts ""


### PR DESCRIPTION
** Tested on Ubuntu 22.04 **
Findings:
1) Apparently `tclsh` doesn't expand `~` to `$HOME (/home/$USER/)` when using `exec mkdir` and therefore the directories `.config/systemd/user` are never created.  
2) The command `catch {file mkdir ~/.config/systemd/user } res`  needs the extra space before the last `}` or the last directory (in this case `/user/`) is never created

Found by: PeGaSuS
Patch by: PeGaSuS
Fixes: 

One-line summary:
Fix creation off directories if they're inexistent.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
