### PR TITLE
Update firststeps.rst

### DIFF
--- a/doc/sphinx_source/tutorials/firststeps.rst
+++ b/doc/sphinx_source/tutorials/firststeps.rst
@@ -118,13 +118,13 @@ Systemd Method (Newer Systems)
 
 To stop Eggdrop, use::
 
-    systemctl --usre stop <botname>.service
+    systemctl --user stop <botname>.service
 
 To prevent Eggdrop from automatically running after a system start, use::
 
     systemctl --user disable <botname>.service 
 
-To re-enable Eggdrop automatically starting after a system start, use::
+To re-enable Eggdrop automatically starting after a system start (default), use::
 
     systemctl --user enable <botname>.service
 


### PR DESCRIPTION
- Fixed a typo
- State that `starting eggdrop on system start` is the default

Found by: @PeGaSuS-Coder 
Patch by: @PeGaSuS-Coder 
Fixes: 

One-line summary:
Minor improvements

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
