### PR TITLE
Fix usage of language file for IRC_CHANGINGSERV

### DIFF
--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -1101,7 +1101,7 @@ static int msg_jump(char *nick, char *host, struct userrec *u, char *par)
       putlog(LOG_CMDS, "*", "(%s!%s) !%s! JUMP", nick, host, u->handle);
     dprintf(-serv, "NOTICE %s :%s\n", nick, IRC_JUMP);
     cycle_time = 0;
-    nuke_server("changing servers");
+    nuke_server(IRC_CHANGINGSERV);
   } else
     putlog(LOG_CMDS, "*", "(%s!%s) !%s! failed JUMP", nick, host, u->handle);
   return 1;

--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -137,7 +137,7 @@ server, but Eggdrop was not compiled with SSL libraries. Skipping...");
     putlog(LOG_CMDS, "*", "#%s# jump", dcc[idx].nick);
   dprintf(idx, "%s...\n", IRC_JUMP);
   cycle_time = 0;
-  nuke_server("changing servers");
+  nuke_server(IRC_CHANGINGSERV);
 }
 
 static void cmd_clearqueue(struct userrec *u, int idx, char *par)

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -379,7 +379,7 @@ static int tcl_jump STDVAR
   }
   cycle_time = 0;
 
-  nuke_server("changing servers\n");
+  nuke_server(IRC_CHANGINGSERV);
   return TCL_OK;
 }
 


### PR DESCRIPTION
Found by: primalz
Patch by: michaelortmann
Fixes: #1327

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`.jump` and `.tcl jump` still works