### PR TITLE
Update bothost only on own chghost

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1320,7 +1320,9 @@ static int got396orchghost(char *nick, char *user, char *uhost)
     m = ismember(chan, nick);
     if (m) {
       snprintf(m->userhost, sizeof m->userhost, "%s@%s", user, uhost);
-      strcpy(botuserhost, m->userhost);
+      if (!rfc_casecmp(m->nick, botname)) {
+        strcpy(botuserhost, m->userhost);
+      }
     }
   }
   return 0;


### PR DESCRIPTION
Found by: Geo
Patch by: Geo

One-line summary:
Eggdrop incorrectly updated its own internally-tracked hostname with any host in a CHGHOST, whether it was intended for Eggdrop or not.

Test cases demonstrating functionality (if applicable):
```
[02:35:21] [@] :geo!foo@foo.bar.mooz CHGHOST foo foo.bar.moo

(gdb) p botuserhost
$2 = "Eggdrop@b0rg-6B5420BE.aol.com", '\000' <repeats 72 times>
```