### PR TITLE
Add CHGHOST bind

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3571,7 +3571,6 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Description: triggered when a server sends either an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
 
-
 ^^^^^^^^^^^^^
 Return Values
 ^^^^^^^^^^^^^

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3432,6 +3432,7 @@ The following is a list of bind types and how they work. Below each bind type is
           init-server       - called when we actually get on our IRC server
           disconnect-server - called when we disconnect from our IRC server
           fail-server       - called when an IRC server fails to respond 
+          hidden-host       - called when the bot's host is hidden by the server
 
   Note that Tcl scripts can trigger arbitrary events, including ones that are not pre-defined or used by Eggdrop.
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3570,7 +3570,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <old user@host> <handle> <channel> <new user@host>
 
-  Description: triggered when a server sends an IRCv3 spec CHGHOST message to change a user's hostmask. The new host is matched against mask in the form of "#channel nick!user\@host" and can contain wildcards. The specified proc will be called with the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
+  Description: triggered when a server sends an IRCv3 spec CHGHOST message to change a user's hostmask. The new host is matched against mask in the form of "#channel nick!user\@host" and can contain wildcards. The specified proc will be called with the nick of the user whose hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
 
 ^^^^^^^^^^^^^
 Return Values

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3569,7 +3569,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <old user@host> <handle> <channel> <new user@host>
 
-  Description: triggered when a server sends either an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
+  Description: triggered when a server sends an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
 
 ^^^^^^^^^^^^^
 Return Values

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3432,7 +3432,7 @@ The following is a list of bind types and how they work. Below each bind type is
           init-server       - called when we actually get on our IRC server
           disconnect-server - called when we disconnect from our IRC server
           fail-server       - called when an IRC server fails to respond 
-          hidden-host       - called when the bot's host is hidden by the server
+          hidden-host       - called after the bot's host is hidden by the server
 
   Note that Tcl scripts can trigger arbitrary events, including ones that are not pre-defined or used by Eggdrop.
 
@@ -3570,7 +3570,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <old user@host> <handle> <channel> <new user@host>
 
-  Description: triggered when a server sends an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
+  Description: triggered when a server sends an IRCv3 spec CHGHOST message to change a user's hostmask. The new host is matched against mask in the form of "#channel nick!user\@host" and can contain wildcards. The specified proc will be called with the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
 
 ^^^^^^^^^^^^^
 Return Values

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3569,7 +3569,7 @@ The following is a list of bind types and how they work. Below each bind type is
 
   procname <nick> <old user@host> <handle> <channel> <new user@host>
 
-  Description: triggered when a server sends either a 396 (Undernet +x) message OR an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
+  Description: triggered when a server sends either an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
 
 
 ^^^^^^^^^^^^^

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -3563,6 +3563,14 @@ The following is a list of bind types and how they work. Below each bind type is
 
   Module: irc
 
+(56) CHGHOST
+
+  bind chghost <flags> <mask> <proc>
+
+  procname <nick> <old user@host> <handle> <channel> <new user@host>
+
+  Description: triggered when a server sends either a 396 (Undernet +x) message OR an IRCv3 spec CHGHOST message to change a user's hostmask. The mask is matched against "#channel nick!user\@host" and can contain wildcards. The triggered proc will return the nick of the user who's hostmask changed; the hostmask the affected user had before the change, the handle of the affected user (or * if no handle is present), the channel the user was on when the bind triggered, and the new hostmask of the affected user. This bind will trigger once for each channel the user is on.
+
 
 ^^^^^^^^^^^^^
 Return Values

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1383,8 +1383,7 @@ static int got396(char *from, char *msg)
   if (match_my_nick(nick)) {  /* Double check this really is for me */
     strlcpy(userbuf, botuserhost, sizeof userbuf);
     ident = strtok(userbuf, "@");
-    snprintf(botuserhost, sizeof botuserhost, "%s@%s", ident, msg);
-    strlcpy(botuserhost, userbuf, sizeof botuserhost);
+    snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, msg);
   }
   return 0;
 }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1377,13 +1377,14 @@ static int gotchghost(char *from, char *msg){
  */
 static int got396(char *from, char *msg)
 {
-  char *nick, *ident, userbuf[UHOSTLEN];
+  char *nick, *ident, *uhost, userbuf[UHOSTLEN];
 
   nick = newsplit(&msg);
   if (match_my_nick(nick)) {  /* Double check this really is for me */
     strlcpy(userbuf, botuserhost, sizeof userbuf);
     ident = strtok(userbuf, "@");
-    snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, msg);
+    uhost = newsplit(&msg);
+    snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, uhost);
   }
   return 0;
 }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1352,7 +1352,7 @@ static int gotchghost(char *from, char *msg){
   ident = newsplit(&msg);  /* Get the ident */
   /* Update my own internal hostmask */
   if (match_my_nick(nick)) {
-    strlcpy(botuserhost, from, sizeof botuserhost);
+    snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, msg);
   }
   u = get_user_by_host(from);
   /* Run the bind for each channel the user is on */
@@ -1361,7 +1361,7 @@ static int gotchghost(char *from, char *msg){
     m = ismember(chan, nick);
     if (m) {
       snprintf(m->userhost, sizeof m->userhost, "%s@%s", ident, msg);
-      snprintf(mask, sizeof mask, "%s %s", chname, from);
+      snprintf(mask, sizeof mask, "%s %s!%s@%s", chname, nick, ident, msg);
       check_tcl_chghost(nick, from, mask, u, chname, ident, msg);
       get_user_flagrec(m->user ? m->user : get_user_by_host(s1), &fr,
                        chan->dname);
@@ -1384,8 +1384,10 @@ static int got396(char *from, char *msg)
     strlcpy(userbuf, botuserhost, sizeof userbuf);
     ident = strtok(userbuf, "@");
     uhost = newsplit(&msg);
-    snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, uhost);
-    check_tcl_event("hidden-host");
+    if (ident) {
+      snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, uhost);
+      check_tcl_event("hidden-host");
+    }
   }
   return 0;
 }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1383,7 +1383,7 @@ static int got396(char *from, char *msg)
   if (match_my_nick(nick)) {  /* Double check this really is for me */
     strlcpy(userbuf, botuserhost, sizeof userbuf);
     ident = strtok(userbuf, "@");
-    egg_snprintf(botuserhost, sizeof botuserhost, "%s@%s", ident, msg);
+    snprintf(botuserhost, sizeof botuserhost, "%s@%s", ident, msg);
     strlcpy(botuserhost, userbuf, sizeof botuserhost);
   }
   return 0;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1385,6 +1385,7 @@ static int got396(char *from, char *msg)
     ident = strtok(userbuf, "@");
     uhost = newsplit(&msg);
     snprintf(botuserhost, UHOSTMAX, "%s@%s", ident, uhost);
+    check_tcl_event("hidden-host");
   }
   return 0;
 }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -784,7 +784,7 @@ static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec 
   int x;
 
   get_user_flagrec(u, &fr, NULL);
-  simple_sprintf(usermask, "%s!%s@%s", nick, ident, host);
+  snprintf(usermask, "%s!%s@%s", nick, ident, host);
 
   Tcl_SetVar(interp, "_chghost1", nick, 0);
   Tcl_SetVar(interp, "_chghost2", from, 0);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -784,7 +784,7 @@ static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec 
   int x;
 
   get_user_flagrec(u, &fr, NULL);
-  snprintf(usermask, "%s!%s@%s", nick, ident, host);
+  snprintf(usermask, sizeof usermask, "%s!%s@%s", nick, ident, host);
 
   Tcl_SetVar(interp, "_chghost1", nick, 0);
   Tcl_SetVar(interp, "_chghost2", from, 0);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -793,7 +793,7 @@ static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec 
   Tcl_SetVar(interp, "_chghost5", usermask, 0);
   x = check_tcl_bind(H_chghost, mask, &fr,
                 " $_chghost1 $_chghost2 $_chghost3 $_chghost4 $_chghost5",
-                MATCH_MASK | BIND_STACKABLE);
+                MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
   return (x == BIND_EXEC_LOG);
 }
 

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -33,7 +33,7 @@
 
 static p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
 static p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt, H_ircaway;
-static p_tcl_bind_list H_monitor, H_account;
+static p_tcl_bind_list H_monitor, H_account, H_chghost;
 
 static Function *global = NULL, *channels_funcs = NULL, *server_funcs = NULL;
 
@@ -776,6 +776,27 @@ static int invite_4char STDVAR
   return TCL_OK;
 }
 
+static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec *u,
+                             char *chan, char *ident, char * host)
+{
+  struct flag_record fr = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };
+  char usermask[UHOSTMAX];
+  int x;
+
+  get_user_flagrec(u, &fr, NULL);
+  simple_sprintf(usermask, "%s!%s@%s", nick, ident, host);
+
+  Tcl_SetVar(interp, "_chghost1", nick, 0);
+  Tcl_SetVar(interp, "_chghost2", from, 0);
+  Tcl_SetVar(interp, "_chghost3", u ? u->handle : "*", 0);
+  Tcl_SetVar(interp, "_chghost4", chan, 0);
+  Tcl_SetVar(interp, "_chghost5", usermask, 0);
+  x = check_tcl_bind(H_chghost, mask, &fr,
+                " $_chghost1 $_chghost2 $_chghost3 $_chghost4 $_chghost5",
+                MATCH_MASK | BIND_STACKABLE);
+  return (x == BIND_EXEC_LOG);
+}
+
 static int check_tcl_ircaway(char *nick, char *from, char *mask,
             struct userrec *u, char *chan, char *msg)
 {
@@ -1340,6 +1361,7 @@ static char *irc_close()
   del_bind_table(H_ircaway);
   del_bind_table(H_monitor);
   del_bind_table(H_account);
+  del_bind_table(H_chghost);
   rem_tcl_strings(mystrings);
   rem_tcl_ints(myints);
   rem_builtins(H_dcc, irc_dcc);
@@ -1402,7 +1424,8 @@ static Function irc_table[] = {
   (Function) & twitch,          /* int                          */
   /* 28 - 31 */
   (Function) & H_ircaway,       /* p_tcl_bind_list              */
-  (Function) & H_monitor        /* p_tcl_bind_list              */
+  (Function) & H_monitor,       /* p_tcl_bind_list              */
+  (Function) & H_chghost        /* p_tcl_bind_list              */
 };
 
 char *irc_start(Function *global_funcs)
@@ -1472,6 +1495,7 @@ char *irc_start(Function *global_funcs)
   H_ircaway = add_bind_table("ircaway", HT_STACKABLE, channels_5char);
   H_monitor = add_bind_table("monitor", HT_STACKABLE, monitor_2char);
   H_account = add_bind_table("account", HT_STACKABLE, channels_5char);
+  H_chghost = add_bind_table("chghost", HT_STACKABLE, channels_5char);
   do_nettype();
   return NULL;
 }

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -49,6 +49,7 @@ static int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *,
                                     char*);
 static int check_tcl_monitor(char *, int);
 static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account);
+static int check_tcl_chghost(char *, char *, char *, struct userrec *, char *, char *, char *);
 static int me_op(struct chanset_t *);
 static int me_halfop(struct chanset_t *);
 static int me_voice(struct chanset_t *);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -46,7 +46,7 @@ static int flud_ctcp_thr;       /* ctcp flood threshold */
 static int flud_ctcp_time;      /* ctcp flood time */
 static char initserver[121];    /* what, if anything, to send to the
                                  * server on connection */
-static char botuserhost[121];   /* bot's user@host (refreshed whenever the
+static char botuserhost[UHOSTMAX];/* bot's user@host (refreshed whenever the
                                  * bot joins a channel) */
                                 /* may not be correct user@host BUT it's
                                  * how the server sees it */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -105,7 +105,7 @@ static char sslserver = 0;
 #endif
 
 static p_tcl_bind_list H_wall, H_raw, H_notc, H_msgm, H_msg, H_flud, H_ctcr,
-                       H_ctcp, H_out, H_rawt;
+                       H_ctcp, H_out, H_rawt, H_chghost;
 
 static void empty_msgq(void);
 static void next_server(int *, char *, unsigned int *, char *);
@@ -2138,6 +2138,7 @@ static char *server_close()
   del_bind_table(H_ctcr);
   del_bind_table(H_ctcp);
   del_bind_table(H_out);
+  del_bind_table(H_chghost);
   rem_tcl_coups(my_tcl_coups);
   rem_tcl_strings(my_tcl_strings);
   rem_tcl_ints(my_tcl_ints);
@@ -2356,6 +2357,7 @@ char *server_start(Function *global_funcs)
   H_ctcr = add_bind_table("ctcr", HT_STACKABLE, server_6char);
   H_ctcp = add_bind_table("ctcp", HT_STACKABLE, server_6char);
   H_out = add_bind_table("out", HT_STACKABLE, server_out);
+  H_chghost = add_bind_table("chghost", HT_STACKABLE, server_5char);
   isupport_init();
   add_builtins(H_raw, my_raw_binds);
   add_builtins(H_rawt, my_rawt_binds);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -105,7 +105,7 @@ static char sslserver = 0;
 #endif
 
 static p_tcl_bind_list H_wall, H_raw, H_notc, H_msgm, H_msg, H_flud, H_ctcr,
-                       H_ctcp, H_out, H_rawt, H_chghost;
+                       H_ctcp, H_out, H_rawt;
 
 static void empty_msgq(void);
 static void next_server(int *, char *, unsigned int *, char *);
@@ -2138,7 +2138,6 @@ static char *server_close()
   del_bind_table(H_ctcr);
   del_bind_table(H_ctcp);
   del_bind_table(H_out);
-  del_bind_table(H_chghost);
   rem_tcl_coups(my_tcl_coups);
   rem_tcl_strings(my_tcl_strings);
   rem_tcl_ints(my_tcl_ints);
@@ -2357,7 +2356,6 @@ char *server_start(Function *global_funcs)
   H_ctcr = add_bind_table("ctcr", HT_STACKABLE, server_6char);
   H_ctcp = add_bind_table("ctcp", HT_STACKABLE, server_6char);
   H_out = add_bind_table("out", HT_STACKABLE, server_out);
-  H_chghost = add_bind_table("chghost", HT_STACKABLE, server_5char);
   isupport_init();
   add_builtins(H_raw, my_raw_binds);
   add_builtins(H_rawt, my_rawt_binds);

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -192,7 +192,7 @@ static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec 
                              char *chan, char *ident, char * host)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };
-  char usermask[USERHOSTMAX];
+  char usermask[UHOSTMAX];
   int x;
 
   get_user_flagrec(u, &fr, NULL);


### PR DESCRIPTION
Found by: thommey
Patch by: Geo
Fixes: #1371 

Questions for discussion:
- Should this trigger on chghost only, or chghost AND 396 (Undernet +x)?
- For the proc, should the last 'arg' value be returned in nick!ident@host or just ident@host ? ident and host are the only two values that will change AND nick is provided earlier, but I think the userbase is used to getting a full hostmask back