### PR TITLE
Fix crash - add missing Tcl_UntraceVar(keep-nick)

### DIFF
--- a/src/mod/twitch.mod/twitch.c
+++ b/src/mod/twitch.mod/twitch.c
@@ -843,6 +843,7 @@ static char *twitch_close()
   del_bind_table(H_rmst);
   del_bind_table(H_usst);
   del_bind_table(H_usrntc);
+  Tcl_UntraceVar(interp, "keep-nick", TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_keepnick, NULL);
   module_undepend(MODULE_NAME);
   return NULL;
 }


### PR DESCRIPTION
Found by: Lord255
Patch by: michaelortmann
Fixes: #1380

One-line summary:
Fix crash - add missing Tcl_UntraceVar(keep-nick)

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Without this patch, eggdrop will crash, when twitch module is reloaded, like:
```
.unload twitch
.load twitch
```