### PR TITLE
Fix more openssl3 deprecation

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1621,11 +1621,12 @@ AC_DEFUN([EGG_TLS_DETECT],
     if test -z "$SSL_LIBS"; then
       AC_CHECK_LIB(crypto, X509_digest, , [havessllib="no"], [-lssl])
       AC_CHECK_LIB(ssl, SSL_accept, , [havessllib="no"], [-lcrypto])
-      AC_CHECK_FUNCS([EVP_md5 EVP_sha1 a2i_IPADDRESS], , [[
+      AC_CHECK_FUNCS([EVP_sha1 a2i_IPADDRESS], , [[
         havessllib="no"
         break
       ]])
     fi
+    AC_CHECK_FUNCS([EVP_md5])
     AC_CHECK_FUNC(OPENSSL_buf2hexstr, ,
       AC_CHECK_FUNC(hex_to_string,
           AC_DEFINE([OPENSSL_buf2hexstr], [hex_to_string], [Define this to hex_to_string when using OpenSSL < 1.1.0])

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -329,7 +329,7 @@ static void dcc_bot_digest(int idx, char *challenge, char *password)
   unsigned char digest[16];
   int i;
 
-#ifdef HAVE_EVP_MD5
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && defined(HAVE_EVP_MD5) 
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   const EVP_MD *md = EVP_md5();
   unsigned int md_len;
@@ -602,7 +602,7 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
     return 1;
   snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
            (unsigned long) dcc[idx].timeval);
-#ifdef HAVE_EVP_MD5
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && defined(HAVE_EVP_MD5)
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   const EVP_MD *md = EVP_md5();
   unsigned int md_len;

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -329,7 +329,7 @@ static void dcc_bot_digest(int idx, char *challenge, char *password)
   unsigned char digest[16];
   int i;
 
-#ifdef TLS
+#ifdef HAVE_EVP_MD5
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   const EVP_MD *md = EVP_md5();
   unsigned int md_len;
@@ -602,7 +602,7 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
     return 1;
   snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
            (unsigned long) dcc[idx].timeval);
-#ifdef TLS
+#ifdef HAVE_EVP_MD5
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   const EVP_MD *md = EVP_md5();
   unsigned int md_len;

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -325,15 +325,26 @@ static void cont_link(int idx, char *buf, int i)
  */
 static void dcc_bot_digest(int idx, char *challenge, char *password)
 {
-  MD5_CTX md5context;
   char digest_string[33];       /* 32 for digest in hex + null */
   unsigned char digest[16];
   int i;
 
+#ifdef TLS
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_md5();
+  unsigned int md_len;
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, challenge, strlen(challenge));
+  EVP_DigestUpdate(mdctx, password, strlen(password));
+  EVP_DigestFinal_ex(mdctx, digest, &md_len);
+  EVP_MD_CTX_free(mdctx);
+#else
+  MD5_CTX md5context;
   MD5_Init(&md5context);
   MD5_Update(&md5context, (unsigned char *) challenge, strlen(challenge));
   MD5_Update(&md5context, (unsigned char *) password, strlen(password));
   MD5_Final(digest, &md5context);
+#endif
 
   for (i = 0; i < 16; i++)
     sprintf(digest_string + (i * 2), "%.2x", digest[i]);
@@ -582,7 +593,6 @@ struct dcc_table DCC_FORK_BOT = {
  */
 static int dcc_bot_check_digest(int idx, char *remote_digest)
 {
-  MD5_CTX md5context;
   char digest_string[33];       /* 32 for digest in hex + null */
   unsigned char digest[16];
   int i, ret;
@@ -590,22 +600,32 @@ static int dcc_bot_check_digest(int idx, char *remote_digest)
 
   if (!password)
     return 1;
-
+  snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
+           (unsigned long) dcc[idx].timeval);
+#ifdef TLS
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_md5();
+  unsigned int md_len;
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, digest_string, strlen(digest_string));
+  EVP_DigestUpdate(mdctx, botnetnick, strlen(botnetnick));
+  EVP_DigestUpdate(mdctx, ">", 1);
+  EVP_DigestUpdate(mdctx, password, strlen(password));
+  EVP_DigestFinal_ex(mdctx, digest, &md_len);
+  EVP_MD_CTX_free(mdctx);
+#else
+  MD5_CTX md5context;
   MD5_Init(&md5context);
-
-  egg_snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
-               (unsigned long) dcc[idx].timeval);
   MD5_Update(&md5context, (unsigned char *) digest_string,
              strlen(digest_string));
   MD5_Update(&md5context, (unsigned char *) botnetnick, strlen(botnetnick));
   MD5_Update(&md5context, (unsigned char *) ">", 1);
   MD5_Update(&md5context, (unsigned char *) password, strlen(password));
-
   MD5_Final(digest, &md5context);
+#endif
 
   for (i = 0; i < 16; i++)
     sprintf(digest_string + (i * 2), "%.2x", digest[i]);
-
   ret = strcmp(digest_string, remote_digest);
   explicit_bzero(digest_string, sizeof digest_string);
   explicit_bzero(digest, sizeof digest);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -777,7 +777,6 @@ resetPath:
   add_tcl_commands(tcluser_cmds);
   add_tcl_commands(tcldcc_cmds);
   add_tcl_commands(tclmisc_cmds);
-  add_tcl_objcommands(tclmisc_objcmds);
   add_tcl_commands(tcldns_cmds);
 #ifdef TLS
   add_tcl_commands(tcltls_cmds);

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -707,7 +707,7 @@ static int tcl_md5 STDVAR
 
   BADARGS(2, 2, " string");
 
-#ifdef HAVE_EVP_MD5
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && defined(HAVE_EVP_MD5)
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   const EVP_MD *md = EVP_md5();
   unsigned int md_len;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -699,26 +699,29 @@ static int tcl_stripcodes STDVAR
   return TCL_OK;
 }
 
-static int tcl_md5(cd, irp, objc, objv)
-ClientData cd;
-Tcl_Interp *irp;
-int objc;
-Tcl_Obj *CONST objv[];
+static int tcl_md5 STDVAR
 {
-  MD5_CTX md5context;
-  char digest_string[33], *string;
+  char digest_string[33];
   unsigned char digest[16];
-  int i, len;
+  int i;
 
-  if (objc != 2) {
-    Tcl_WrongNumArgs(irp, 1, objv, "string");
-    return TCL_ERROR;
-  }
-  string = Tcl_GetStringFromObj(objv[1], &len);
+  BADARGS(2, 2, " string");
 
+#ifdef HAVE_EVP_MD5
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_md5();
+  unsigned int md_len;
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, argv[1], strlen(argv[1]));
+  EVP_DigestFinal_ex(mdctx, digest, &md_len);
+  EVP_MD_CTX_free(mdctx);
+#else
+  MD5_CTX md5context;
   MD5_Init(&md5context);
-  MD5_Update(&md5context, (unsigned char *) string, len);
+  MD5_Update(&md5context, (unsigned char *) argv[1], strlen(argv[1]));
   MD5_Final(digest, &md5context);
+#endif
+
   for (i = 0; i < 16; i++)
     sprintf(digest_string + (i * 2), "%.2x", digest[i]);
   Tcl_AppendResult(irp, digest_string, NULL);
@@ -757,11 +760,6 @@ static int tcl_matchstr STDVAR
     Tcl_AppendResult(irp, "0", NULL);
   return TCL_OK;
 }
-
-tcl_cmds tclmisc_objcmds[] = {
-  {"md5", tcl_md5},
-  {NULL,     NULL}
-};
 
 static int tcl_status STDVAR
 {
@@ -854,5 +852,6 @@ tcl_cmds tclmisc_cmds[] = {
   {"matchstr",         tcl_matchstr},
   {"status",             tcl_status},
   {"rfcequal",         tcl_rfcequal},
+  {"md5",                   tcl_md5},
   {NULL,                       NULL}
 };


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix more openssl3 deprecation
**Please run `misc/runautotools`**

Additional description (if needed):
Fix the following openssl3 deprecations:
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c dcc.c
dcc.c: In function ‘dcc_bot_digest’:
dcc.c:333:3: warning: ‘MD5_Init’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  333 |   MD5_Init(&md5context);
      |   ^~~~~~~~
In file included from md5/md5.h:32,
                 from dcc.c:32:
/usr/include/openssl/md5.h:49:27: note: declared here
   49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
      |                           ^~~~~~~~
dcc.c:334:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  334 |   MD5_Update(&md5context, (unsigned char *) challenge, strlen(challenge));
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:335:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  335 |   MD5_Update(&md5context, (unsigned char *) password, strlen(password));
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:336:3: warning: ‘MD5_Final’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  336 |   MD5_Final(digest, &md5context);
      |   ^~~~~~~~~
/usr/include/openssl/md5.h:51:27: note: declared here
   51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
      |                           ^~~~~~~~~
dcc.c: In function ‘dcc_bot_check_digest’:
dcc.c:594:3: warning: ‘MD5_Init’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  594 |   MD5_Init(&md5context);
      |   ^~~~~~~~
/usr/include/openssl/md5.h:49:27: note: declared here
   49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
      |                           ^~~~~~~~
dcc.c:598:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  598 |   MD5_Update(&md5context, (unsigned char *) digest_string,
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:600:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  600 |   MD5_Update(&md5context, (unsigned char *) botnetnick, strlen(botnetnick));
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:601:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  601 |   MD5_Update(&md5context, (unsigned char *) ">", 1);
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:602:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  602 |   MD5_Update(&md5context, (unsigned char *) password, strlen(password));
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
dcc.c:604:3: warning: ‘MD5_Final’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  604 |   MD5_Final(digest, &md5context);
      |   ^~~~~~~~~
/usr/include/openssl/md5.h:51:27: note: declared here
   51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
      |                           ^~~~~~~~~
```
[...]
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tclmisc.c
tclmisc.c: In function ‘tcl_md5’:
tclmisc.c:719:3: warning: ‘MD5_Init’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  719 |   MD5_Init(&md5context);
      |   ^~~~~~~~
In file included from md5/md5.h:32,
                 from tclmisc.c:27:
/usr/include/openssl/md5.h:49:27: note: declared here
   49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
      |                           ^~~~~~~~
tclmisc.c:720:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  720 |   MD5_Update(&md5context, (unsigned char *) string, len);
      |   ^~~~~~~~~~
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
tclmisc.c:721:3: warning: ‘MD5_Final’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  721 |   MD5_Final(digest, &md5context);
      |   ^~~~~~~~~
/usr/include/openssl/md5.h:51:27: note: declared here
   51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
      |                           ^~~~~~~~~
```

Test cases demonstrating functionality (if applicable):
**Link-Test with OpenSSL 3.0.7:**
```
.link BotA 
[04:13:06] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[04:13:06] #-HQ# link BotA
[04:13:06] Linking to BotA at 127.0.0.1:3333 ...
[04:13:06] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3333 ssl 0
[04:13:06] Received challenge from BotA... sending response ...
[04:13:06] Linked to BotA.
```
**Link-Test with `./configure --disable-tls`**
```
.link BotA
[04:14:36] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[04:14:36] #-HQ# link BotA
[04:14:36] Linking to BotA at 127.0.0.1:3333 ...
[04:14:36] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3333
[04:14:36] Received challenge from BotA... sending response ...
[04:14:36] Linked to BotA.
```
**tcl_md5-Test with OpenSSL 3.0.7:**
```
.tcl md5 test
[04:55:17] tcl: builtin dcc call: *dcc:tcl -HQ 1 md5 test
[04:55:17] tcl: evaluate (.tcl): md5 test
Tcl: 098f6bcd4621d373cade4e832627b4f6
```
**tcl_md5-Test with `./configure --disable-tls`**
```
.tcl md5 test
[04:56:57] tcl: builtin dcc call: *dcc:tcl -HQ 1 md5 test
[04:56:57] tcl: evaluate (.tcl): md5 test
Tcl: 098f6bcd4621d373cade4e832627b4f6
```
Same tests with OpenSSL 0.9.8zc and OpenSSL 1.1.1s were successful