### PR TITLE
Make init_threaddata() return void

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -778,7 +778,7 @@ void check_static(char *, char *(*)());
 
 #include "mod/static.h"
 #endif
-int init_threaddata(int);
+void init_threaddata(int);
 int init_mem();
 int init_userent();
 int init_misc();

--- a/src/proto.h
+++ b/src/proto.h
@@ -302,7 +302,7 @@ void safe_write(int, const void *, size_t);
 
 /* tcl.c */
 struct threaddata *threaddata(void);
-int init_threaddata(int);
+void init_threaddata(int);
 void protect_tcl(void);
 void unprotect_tcl(void);
 void do_tcl(char *, char *);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -620,7 +620,7 @@ struct threaddata *threaddata()
 
 #endif /* REPLACE_NOTIFIER */
 
-int init_threaddata(int mainthread)
+void init_threaddata(int mainthread)
 {
   struct threaddata *td = threaddata();
 /* Nested evaluation (vwait/update) of the event loop only
@@ -636,7 +636,6 @@ int init_threaddata(int mainthread)
   td->blocktime.tv_usec = 0;
   td->MAXSOCKS = 0;
   increase_socks_max();
-  return 0;
 }
 
 /* Not going through Tcl's crazy main() system (what on earth was he


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
init_threaddata() returned always and only 0, so lets simplify/make this function void

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
compile, run, ok.