### PR TITLE
Add ssl header version to .status

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -336,22 +336,22 @@ void tell_verbose_status(int idx)
   dprintf(idx, "%s %s (%s %s)\n", MISC_TCLVERSION,
           ((interp) && (Tcl_Eval(interp, "info patchlevel") == TCL_OK)) ?
           tcl_resultstring() : (Tcl_Eval(interp, "info tclversion") == TCL_OK) ?
-          tcl_resultstring() : "*unknown*", MISC_TCLHVERSION, TCL_PATCH_LEVEL);
+          tcl_resultstring() : "*unknown*", MISC_HEADERVERSION, TCL_PATCH_LEVEL);
 
   if (tcl_threaded())
     dprintf(idx, "Tcl is threaded.\n");
 #ifdef TLS
   dprintf(idx, "TLS support is enabled.\n"
   #if defined HAVE_EVP_PKEY_GET1_EC_KEY && defined HAVE_OPENSSL_MD5
-               "TLS library: %s\n",
+               "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n",
   #elif !defined HAVE_EVP_PKEY_GET1_EC_KEY && defined HAVE_OPENSSL_MD5
-               "TLS library: %s\n             (no elliptic curve support)\n",
+               "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no elliptic curve support)\n",
   #elif defined HAVE_EVP_PKEY_GET1_EC_KEY && !defined HAVE_OPENSSL_MD5
-               "TLS library: %s\n             (no MD5 support)\n",
+               "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no MD5 support)\n",
   #elif !defined HAVE_EVP_PKEY_GET1_EC_KEY && !defined HAVE_OPENSSL_MD5
-               "TLS library: %s\n             (no elliptic curve or MD5 support)\n",
+               "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no elliptic curve or MD5 support)\n",
   #endif
-          SSLeay_version(SSLEAY_VERSION));
+          SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);
 #else
   dprintf(idx, "TLS support is not available.\n");
 #endif

--- a/src/lang.h
+++ b/src/lang.h
@@ -122,7 +122,7 @@
 #define MISC_JUPED              get_language(0x542)
 #define MISC_NOFREESOCK         get_language(0x543)
 #define MISC_TCLVERSION         get_language(0x544)
-#define MISC_TCLHVERSION        get_language(0x545)
+#define MISC_HEADERVERSION      get_language(0x545)
 
 /* IRC */
 #define IRC_BANNED              get_language(0x600)


### PR DESCRIPTION
Found by: wheel
Patch by: michaelortmann
Fixes: #1322

One-line summary:
Add ssl header version to .status

Additional description (if needed):
This is not exactly, what #1322 asked for, so i would like to leave #1322 open.
But its a useful addition and could help debugging.

Test cases demonstrating functionality (if applicable):
```
$ LD_LIBRARY_PATH=/home/michael/opt/openssl-3.1.0-beta1/lib64 ./eggdrop -t BotA.conf
[...]
.status
[...]
TLS library: OpenSSL 3.1.0-beta1 21 Dec 2022 (header version OpenSSL 3.0.7 1 Nov 2022)
```