### PR TITLE
doc update regarding strftime + whitespace + capitalization

### DIFF
--- a/doc/sphinx_source/install/install.rst
+++ b/doc/sphinx_source/install/install.rst
@@ -37,7 +37,7 @@ Eggdrop uses the GNU autoconfigure scripts to make things easier.
      and will enlarge the binary a bit, but it's worth it if you want to
      support Eggdrop development.
 
-4. Eggdrop must be installed in a directory somewhere.  This is
+4. Eggdrop must be installed in a directory somewhere. This is
      accomplished by entering the UNIX command::
 
        make install

--- a/doc/sphinx_source/modules/mod/server.rst
+++ b/doc/sphinx_source/modules/mod/server.rst
@@ -103,8 +103,8 @@ There are also some variables you can set in your config file:
 
   set msg-rate 2
     Number of seconds to wait between transmitting queued lines to the
-    server. Lower this value at your own risk.  ircd is known to start
-    flood control at 512 bytes/2 seconds.
+    server. Lower this value at your own risk. ircd is known to start flood
+    control at 512 bytes/2 seconds.
 
   set ssl-verify-servers 0
     Control certificate verification for servers. You can set this by adding

--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -218,8 +218,7 @@ logfile <logflags> <channel> "logs/logfile"
     If keep-all-logs is 1, this setting will define the suffix of the
     logfiles. The default will result in a suffix like "04May2000". "%Y%m%d"
     will produce the often used yyyymmdd format. Read the strftime manpages
-    for more options. NOTE: On systems which don't support strftime, the
-    default format will always be used.
+    for more options.
 
 Console Settings
 ----------------

--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -193,7 +193,7 @@ logfile <logflags> <channel> "logs/logfile"
   set timestamp-format "[%H:%M:%S]"
     Set the following to the timestamp for the logfile entries. Popular times
     might be "[%H:%M]" (hour, min), or "[%H:%M:%S]" (hour, min, sec).
-    Read 'man strftime' for more formatting options.  Keep it below 32 chars.
+    Read 'man strftime' for more formatting options. Keep it below 32 chars.
 
   set keep-all-logs 0
     If you want to keep your logfiles forever, turn this setting on. All

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -1079,7 +1079,7 @@ isidentified <nickname> [channel]
 isaway <nickname> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: determine if a user is marked as 'away' on a server. IMPORTANT: this command is only "mostly" reliable on its own when the IRCv3 away-notify capability is available and negotiated with the IRC server (if you didn't add this to your config file, it likely isn't enabled- you can confirm using the ``cap`` Tcl command).  Additionally, there is no way for Eggdrop (or any client) to capture a user's away status when the user first joins a channel (they are assumed present by Eggdrop on join). To use this command without the away-notify capability negotiated, or to get a user's away status on join (via a JOIN bind), use ``refreshchan <channel> w`` on a channel the user is on, which will refresh the current away status stored by Eggdrop for all users on the channel.
+  Description: determine if a user is marked as 'away' on a server. IMPORTANT: this command is only "mostly" reliable on its own when the IRCv3 away-notify capability is available and negotiated with the IRC server (if you didn't add this to your config file, it likely isn't enabled- you can confirm using the ``cap`` Tcl command). Additionally, there is no way for Eggdrop (or any client) to capture a user's away status when the user first joins a channel (they are assumed present by Eggdrop on join). To use this command without the away-notify capability negotiated, or to get a user's away status on join (via a JOIN bind), use ``refreshchan <channel> w`` on a channel the user is on, which will refresh the current away status stored by Eggdrop for all users on the channel.
 
   Returns: 1 if Eggdrop is currently tracking someone by that nickname marked as 'away' (again, see disclaimer above) by an IRC server; 0 otherwise.
 
@@ -2688,7 +2688,7 @@ matchcidr <block> <address> <prefix>
 matchstr <pattern> <string>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: checks if pattern matches string. Only two wildcards are supported: '*' and '?'. Matching is case-insensitive. This command is intended as a simplified alternative to Tcl's string match.  
+  Description: checks if pattern matches string. Only two wildcards are supported: '*' and '?'. Matching is case-insensitive. This command is intended as a simplified alternative to Tcl's string match.
 
   Returns: 1 if the pattern matches the string, 0 if it doesn't.
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -200,8 +200,6 @@ set keep-all-logs 0
 # If keep-all-logs is 1, this setting will define the suffix of the logfiles.
 # The default will result in a suffix like "04May2000". "%Y%m%d" will produce
 # the often used yyyymmdd format. Read the strftime manpages for more options.
-# NOTE: On systems which don't support strftime, the default format will
-# be used _always_.
 set logfile-suffix ".%d%b%Y"
 
 # You can specify when Eggdrop should switch logfiles and start fresh. You

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -188,7 +188,7 @@ set log-time 1
 
 # Set the following to the timestamp for the logfile entries. Popular times
 # might be "[%H:%M]" (hour, min), or "[%H:%M:%S]" (hour, min, sec).
-# Read `man strftime' for more formatting options.  Keep it below 32 chars.
+# Read `man strftime' for more formatting options. Keep it below 32 chars.
 set timestamp-format {[%H:%M:%S]}
 
 # If you want to keep your logfiles forever, turn this setting on. All
@@ -1182,8 +1182,8 @@ set extended-join 1
 #### End of CAP features ####
 
 # Number of seconds to wait between transmitting queued lines to the server.
-# Lower this value at your own risk.  ircd is known to start flood control
-# at 512 bytes/2 seconds.
+# Lower this value at your own risk. ircd is known to start flood control at
+# 512 bytes/2 seconds.
 set msg-rate 2
 
 # This setting makes the bot try to get his original nickname back if its

--- a/help/set/cmds1.help
+++ b/help/set/cmds1.help
@@ -191,7 +191,7 @@
 ###  %bset timestamp-format%b <format>
    Set the following to the timestamp for the logfile entries. Popular
    times might be "[%H:%M]" (hour,min), or "[%H:%M:%S]" (hour, min, sec).
-   Read `man strftime' for more formatting options.  Keep it below 32
+   Read `man strftime' for more formatting options. Keep it below 32
    chars.
 %{help=set max-logsize}%{+n}
 ###  %bset max-logsize%b <filesize>

--- a/help/set/cmds1.help
+++ b/help/set/cmds1.help
@@ -211,8 +211,7 @@
    If keep-all-logs is 1, this setting will define the suffix of the
    logfiles. The default will result in a suffix like "04May2000".
    "%Y%m%d" will produce the often used yyyymmdd format. Read the
-   strftime manpages for more options. NOTE: On systems which don't
-   support strftime, the default format will be used _always_.
+   strftime manpages for more options.
 %{help=set quiet-save}%{+n}
 ###  %bset quiet-save%b <0/1/2/3>
    "Writing user file..." and "Writing channel file..." messages won't

--- a/scripts/help/msg/userinfo.help
+++ b/scripts/help/msg/userinfo.help
@@ -1,9 +1,9 @@
 %{help=email}
 %b/MSG%b %B %bEMAIL%b <my email address>
-   This will set your email address.  It's shown when
-   someone does a WHOIS on you (see HELP WHOIS).  If
-   you don't specify a email address, the bot will show
-   you the email address it currently has set for you (if any).
+   This will set your email address. It's shown when someone
+   does a WHOIS on you (see HELP WHOIS). If you don't specify a
+   email address, the bot will show you the email address it
+   currently has set for you (if any).
 %b/MSG%b %B %bEMAIL%b none
    This clears your email address.
 %{help=url}
@@ -15,7 +15,7 @@
    This clears your url address.
 %{help=bf}
 %b/MSG%b %B %bBF%b <my boyfriend>
-   This will set your boyfriend. some scripts (such as seen)
+   This will set your boyfriend. Some scripts (such as seen)
    use this information. If you don't specify a boyfriend,
    the bot will show you the boyfriend it currently has set
    for you (if any).
@@ -23,7 +23,7 @@
    This clears your boyfriend.
 %{help=gf}
 %b/MSG%b %B %bGF%b <my girlfriend>
-   This will set your girlfriend. some scripts (such as seen)
+   This will set your girlfriend. Some scripts (such as seen)
    use this information. If you don't specify a girlfriend,
    the bot will show you the girlfriend it currently has set
    for you (if any).
@@ -31,14 +31,14 @@
    This clears your girlfriend.
 %{help=irl}
 %b/MSG%b %B %bIRL%b <my real name>
-   This will set your real name. just for the information
+   This will set your real name. Just for the information
    of others :). If you don't specify a real name, the bot will
    show you the real name it currently has set for you (if any).
 %b/MSG%b %B %bIRL%b none
    This clears your real name.
 %{help=dob}
 %b/MSG%b %B %bDOB%b <my date of birth>
-   This will set your date of birth. now now, be honest :)
+   This will set your date of birth. Now, be honest :)
    If you don't specify a date of birth, the bot will show
    you the date of birth it currently has set for you (if any).
 %b/MSG%b %B %bDOB%b none

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -395,7 +395,7 @@ targetcont:
             prefix, whoredirect, whotarget);
     return;
   }
-  /* Target not on this channel.   Check other channels */
+  /* Target not on this channel. Check other channels */
   chan = chanset;
   while (chan) {
     m = ismember(chan, whotarget);
@@ -442,7 +442,7 @@ targetcont:
       }
     }
   }
-  /* Target known, but nowhere to be seen.  Give last IRC and botnet time */
+  /* Target known, but nowhere to be seen. Give last IRC and botnet time */
   wordshift(word1, text);
   if (!strcasecmp(word1, "anywhere"))
     cr = NULL;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
doc update regarding strftime, see also commit c0e69988d6dd892e27b6b4a410f35d8d8156e3eb
and fix some whitespaces and capitalizations

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
