### PR TITLE
Fix crash - load of null pointer

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1700,6 +1700,12 @@ char *traced_natip(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
   int r;
   struct in_addr ia;
 
+  /* Recover trace in case of unset. */
+  if (flags & TCL_TRACE_DESTROYED) {
+    Tcl_TraceVar2(irp, name1, name2, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_natip, cd);
+    return NULL;
+  }
+
   value = Tcl_GetVar2(irp, name1, name2, TCL_GLOBAL_ONLY);
   if (*value) {
     r = inet_pton(AF_INET, value, &ia);


### PR DESCRIPTION
Found by: 0_o I am EMPTY, mister EMPTY, ZarTek-Creole
Patch by: michaelortmann
Fixes: #1389

One-line summary:
Fix crash - load of null pointer

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
CFLAGS="-O1 -fsanitize=undefined" ./configure
[...]
$ cat scripts/crash.tcl 
namespace delete ::
$ ./eggdrop -t BotA.conf
[...]
.tcl source scripts/crash.tcl
[06:19:29] tcl: builtin dcc call: *dcc:tcl -HQ 1 source scripts/crash.tcl
[06:19:29] tcl: evaluate (.tcl): source scripts/crash.tcl
net.c:1704:7: runtime error: load of null pointer of type 'const char'
```