### PR TITLE
Autoscript

### DIFF
--- a/doc/html/using/autoscripts.html
+++ b/doc/html/using/autoscripts.html
@@ -1,0 +1,341 @@
+
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
+
+    <title>Eggdrop Autoscripts &#8212; Eggdrop 1.9.4 documentation</title>
+    <link rel="stylesheet" type="text/css" href="../_static/pygments.css" />
+    <link rel="stylesheet" type="text/css" href="../_static/eggdrop.css" />
+    <script data-url_root="../" id="documentation_options" src="../_static/documentation_options.js"></script>
+    <script src="../_static/doctools.js"></script>
+    <script src="../_static/sphinx_highlight.js"></script>
+    <link rel="search" title="Search" href="../search.html" />
+    <link rel="next" title="Users and Flags" href="users.html" />
+    <link rel="prev" title="The Party Line" href="partyline.html" /> 
+  </head><body>
+    <div class="header-wrapper" role="banner">
+      <div class="header">
+        <div class="headertitle"><a
+          href="../index.html">Eggdrop 1.9.4 documentation</a></div>
+        <div class="rel" role="navigation" aria-label="related navigation">
+          <a href="partyline.html" title="The Party Line"
+             accesskey="P">previous</a> |
+          <a href="users.html" title="Users and Flags"
+             accesskey="N">next</a>
+        </div>
+       </div>
+    </div>
+
+    <div class="content-wrapper">
+      <div class="content">
+        <div class="sidebar">
+          
+          <h3>Table of Contents</h3>
+          <p class="caption" role="heading"><span class="caption-text">Installing Eggdrop</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../install/readme.html">README</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../install/install.html">Installing Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../install/upgrading.html">Upgrading Eggdrop</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">Using Eggdrop</span></p>
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="features.html">Eggdrop Features</a></li>
+<li class="toctree-l1"><a class="reference internal" href="core.html">Eggdrop Core Settings</a></li>
+<li class="toctree-l1"><a class="reference internal" href="partyline.html">The Party Line</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">Eggdrop Autoscripts</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="#autoscripts-usage">Autoscripts usage</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#autoscripts-file-structure">Autoscripts File Structure</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#development-hints">Development hints</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#tcl-commands">Tcl Commands</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="users.html">Users and Flags</a></li>
+<li class="toctree-l1"><a class="reference internal" href="bans.html">Bans, Invites, and Exempts</a></li>
+<li class="toctree-l1"><a class="reference internal" href="botnet.html">Botnet Sharing and Linking</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ipv6.html">IPv6 support</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tls.html">TLS support</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ircv3.html">IRCv3 support</a></li>
+<li class="toctree-l1"><a class="reference internal" href="accounts.html">Account tracking in Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="pbkdf2info.html">Encryption/Hashing</a></li>
+<li class="toctree-l1"><a class="reference internal" href="twitchinfo.html">Twitch</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tricks.html">Advanced Tips</a></li>
+<li class="toctree-l1"><a class="reference internal" href="text-sub.html">Textfile Substitutions</a></li>
+<li class="toctree-l1"><a class="reference internal" href="tcl-commands.html">Eggdrop Tcl Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="twitch-tcl-commands.html">Eggdrop Twitch Tcl Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="patch.html">Patching Eggdrop</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">Tutorials</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/setup.html">Setting Up Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/firststeps.html">Common First Steps</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/tlssetup.html">Enabling TLS Security on Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tutorials/firstscript.html">Writing an Eggdrop Script</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">Eggdrop Modules</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../modules/index.html">Eggdrop Module Information</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../modules/included.html">Modules included with Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../modules/writing.html">Writing an Eggdrop Module</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">About Eggdrop</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="../about/about.html">About Eggdrop</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../about/legal.html">Boring legal stuff</a></li>
+</ul>
+
+          <div role="search">
+            <h3 style="margin-top: 1.5em;">Search</h3>
+            <form class="search" action="../search.html" method="get">
+                <input type="text" name="q" />
+                <input type="submit" value="Go" />
+            </form>
+          </div>
+
+        </div>
+        <div class="document">
+            
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+          <div class="body" role="main">
+            
+  <section id="eggdrop-autoscripts">
+<h1>Eggdrop Autoscripts<a class="headerlink" href="#eggdrop-autoscripts" title="Permalink to this heading">¶</a></h1>
+<p>Since it’s inception, users have needed to load a Tcl script into Eggdrop by downloading a Tcl file, editing the file to customize settings, and then sourceing that file in the config file. In v1.10, the Autoscripts system was added to make this process a little more user-friendly. The autoscripts system helps by:</p>
+<ul class="simple">
+<li><p>Centralizing commonly-used scripts in a single location</p></li>
+<li><p>Allowing scripts to be downloaded via the partyline</p></li>
+<li><p>Allowing script settings to be configured via the partyline</p></li>
+<li><p>Allowing user-written scripts to be managed by the autoscripts system</p></li>
+<li><p>Providing a documented API to write autoscripts-compatible scripts</p></li>
+</ul>
+<section id="autoscripts-usage">
+<h2>Autoscripts usage<a class="headerlink" href="#autoscripts-usage" title="Permalink to this heading">¶</a></h2>
+<p>To view available autoscript commands, type <code class="docutils literal notranslate"><span class="pre">.script</span></code> on the partyline. The following sub-commands are available for use with script:</p>
+<section id="remote">
+<h3>remote<a class="headerlink" href="#remote" title="Permalink to this heading">¶</a></h3>
+<p>This command will list scripts hosted on the Eggdrop website that are available to be downloaded and installed on your Eggdrop.</p>
+</section>
+<section id="fetch-script">
+<h3>fetch &lt;script&gt;<a class="headerlink" href="#fetch-script" title="Permalink to this heading">¶</a></h3>
+<p>This command will download the specified script from the Eggdrop website and place it into the autoscript/ directory.</p>
+</section>
+<section id="list">
+<h3>list<a class="headerlink" href="#list" title="Permalink to this heading">¶</a></h3>
+<p>This command will list scripts locallt present in the autoscripts/ directory, available to be configured and loaded.</p>
+</section>
+<section id="config-script">
+<h3>config &lt;script&gt;<a class="headerlink" href="#config-script" title="Permalink to this heading">¶</a></h3>
+<p>This command will list settings available for configuration for the provided script.</p>
+</section>
+<section id="set-script-setting">
+<h3>set &lt;script&gt; &lt;setting&gt;<a class="headerlink" href="#set-script-setting" title="Permalink to this heading">¶</a></h3>
+<p>This command will set <code class="docutils literal notranslate"><span class="pre">setting</span></code> for <code class="docutils literal notranslate"><span class="pre">script</span></code> to the provided value.</p>
+</section>
+<section id="load-script">
+<h3>load &lt;script&gt;<a class="headerlink" href="#load-script" title="Permalink to this heading">¶</a></h3>
+<p>This command will activate the script for use.</p>
+</section>
+<section id="unload-script">
+<h3>unload &lt;script&gt;<a class="headerlink" href="#unload-script" title="Permalink to this heading">¶</a></h3>
+<p>This command will prevent the script from being loaded the next time Eggdrop starts. To fully unload a script, Eggdrop must be restarted!</p>
+</section>
+<section id="clean-script">
+<h3>clean &lt;script&gt;<a class="headerlink" href="#clean-script" title="Permalink to this heading">¶</a></h3>
+<p>This command will delete the script from the filesystem. After running this command, you will have to re-download and re-configure the script if you wish to use it again.</p>
+</section>
+</section>
+<section id="autoscripts-file-structure">
+<h2>Autoscripts File Structure<a class="headerlink" href="#autoscripts-file-structure" title="Permalink to this heading">¶</a></h2>
+<p>An autoscripts package requires (minimum) two files: the Tcl script, and a json manifest file.</p>
+<section id="tcl-file">
+<h3>Tcl File<a class="headerlink" href="#tcl-file" title="Permalink to this heading">¶</a></h3>
+<p>Nothing new or novel here; this is where your Tcl code goes. The one change to this file is that any setting intended should now be located in the manifest.json file, not the Tcl script file. All variables will be added to the global namespace. For this reason, it is recommended that variables have unique names to avoid collisions. This is commonly done by prefixing the variable name with the script name or abbreviation. For example, a script called myscript.tcl might avoid using a variable calld <code class="docutils literal notranslate"><span class="pre">name</span></code> and instead use <code class="docutils literal notranslate"><span class="pre">myscript_name</span></code> or <code class="docutils literal notranslate"><span class="pre">ms_name</span></code>.</p>
+</section>
+<section id="manifest-json">
+<h3>Manifest.json<a class="headerlink" href="#manifest-json" title="Permalink to this heading">¶</a></h3>
+<p>Every autoscripts package must have a manifest.json file. This file contains metadata for the script such as version and description information, as well as the user-configurable settings for use with th script. A simple example of a manifest.json file is as follows:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">{</span>
+  <span class="s2">&quot;name&quot;</span><span class="p">:</span> <span class="s2">&quot;woobie&quot;</span><span class="p">,</span>
+  <span class="s2">&quot;version_major&quot;</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span>
+  <span class="s2">&quot;version_minor&quot;</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span>
+  <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;An example script to help developers write autoscript packages&quot;</span><span class="p">,</span>
+  <span class="s2">&quot;long_description&quot;</span><span class="p">:</span> <span class="s2">&quot;This is an example script to help understand the autoscript system. Yeah, it doesn&#39;t really do anything, but that&#39;s besides the point. It could, and that should be enough for anyone&quot;</span>
+  <span class="s2">&quot;config&quot;</span><span class="p">:</span> <span class="p">{</span>
+    <span class="s2">&quot;loaded&quot;</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span>
+    <span class="s2">&quot;udefflag&quot;</span><span class="p">:</span><span class="s2">&quot;myscript&quot;</span>
+    <span class="s2">&quot;requires&quot;</span><span class="p">:</span> <span class="n">null</span><span class="p">,</span>
+    <span class="s2">&quot;vars&quot;</span><span class="p">:</span> <span class="p">{</span>
+      <span class="s2">&quot;woobie_dict&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;A setting that accepts a dict as a value&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;value&quot;</span><span class="p">:</span> <span class="s2">&quot;{quiet q}&quot;</span>
+      <span class="p">},</span>
+      <span class="s2">&quot;woobie_setting&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;A normal setting to enable or disable something&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;value&quot;</span><span class="p">:</span> <span class="s2">&quot;1&quot;</span>
+      <span class="p">},</span>
+      <span class="s2">&quot;woobie_string&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;A setting taking a string, like a filename or something&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;value&quot;</span><span class="p">:</span> <span class="s2">&quot;woobie&quot;</span>
+      <span class="p">},</span>
+      <span class="s2">&quot;woobie(array)&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;A setting that is set as an array&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;value&quot;</span><span class="p">:</span><span class="s2">&quot;another string&quot;</span>
+      <span class="p">}</span>
+    <span class="p">}</span>
+  <span class="p">}</span>
+<span class="p">}</span>
+</pre></div>
+</div>
+<table class="docutils align-default">
+<tbody>
+<tr class="row-odd"><td><p>name</p></td>
+<td><p>The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)</p></td>
+</tr>
+<tr class="row-even"><td><p>version_major</p></td>
+<td><p>The major version integer (ie, 1 for 1.6)</p></td>
+</tr>
+<tr class="row-odd"><td><p>version_minor</p></td>
+<td><p>The minor version integer (ie, 6 for 1.6)</p></td>
+</tr>
+<tr class="row-even"><td><p>description</p></td>
+<td><p>A one-line summary of what the script does. This will be shown when available scripts are listed on the partyline via .script list.</p></td>
+</tr>
+<tr class="row-odd"><td><p>long_description</p></td>
+<td><p>A longer description of what the script does, similar to a README. This will be shown when a script is viewed via .script config.</p></td>
+</tr>
+<tr class="row-even"><td><p>config-loaded</p></td>
+<td><p>Whether this script is currently loaded or not. It should be default set to 0.</p></td>
+</tr>
+<tr class="row-odd"><td><p>config-udefflag</p></td>
+<td><p>Any user-defined channel settings used by the script. This is displayed when configuration settings are displayed to the user on the partyline.</p></td>
+</tr>
+<tr class="row-even"><td><p>config-requires</p></td>
+<td><p>Any Tcl package required for use by the script, such as tcllib or json.</p></td>
+</tr>
+<tr class="row-odd"><td><p>config-vars-&lt;varname&gt;</p></td>
+<td><p>A setting intended to be modified by the user. The ‘description’ field should describe what the setting does, and the ‘value’ field stores the current value. These settings are displayed when the configuration settings are displayed to the user on the partyline.</p></td>
+</tr>
+<tr class="row-even"><td><p>config-vars-&lt;varname&gt;-description</p></td>
+<td><p>A description of the setting, displayed in the configuration listing for the script.</p></td>
+</tr>
+<tr class="row-odd"><td><p>config-vars-&lt;varname&gt;-value</p></td>
+<td><p>The value the setting is set to</p></td>
+</tr>
+</tbody>
+</table>
+<dl class="field-list simple">
+<dt class="field-odd">name<span class="colon">:</span></dt>
+<dd class="field-odd"><p>The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)</p>
+</dd>
+<dt class="field-even">version_major<span class="colon">:</span></dt>
+<dd class="field-even"><p>The major version integer (ie, 1 for 1.6)</p>
+</dd>
+<dt class="field-odd">version_minor<span class="colon">:</span></dt>
+<dd class="field-odd"><p>The minor version integer (ie, 6 for 1.6)</p>
+</dd>
+<dt class="field-even">description<span class="colon">:</span></dt>
+<dd class="field-even"><p>A one-line summary of what the script does. This will be shown when available scripts are listed on the partyline via .script list.</p>
+</dd>
+<dt class="field-odd">long_description<span class="colon">:</span></dt>
+<dd class="field-odd"><p>A longer description of what the script does, similar to a README. This will be shown when a script is viewed via .script config.</p>
+</dd>
+<dt class="field-even">config-loaded<span class="colon">:</span></dt>
+<dd class="field-even"><p>Whether this script is currently loaded or not. It should be default set to 0.</p>
+</dd>
+<dt class="field-odd">config-udefflag<span class="colon">:</span></dt>
+<dd class="field-odd"><p>Any user-defined channel settings used by the script. This is displayed when configuration settings are displayed to the user on the partyline.</p>
+</dd>
+<dt class="field-even">config-requires<span class="colon">:</span></dt>
+<dd class="field-even"><p>Any Tcl package required for use by the script, such as tcllib or json.</p>
+</dd>
+<dt class="field-odd">config-vars-&lt;varname&gt;<span class="colon">:</span></dt>
+<dd class="field-odd"><p>A setting intended to be modified by the user. The ‘description’ field should describe what the setting does, and the ‘value’ field stores the current value. These settings are displayed when the configuration settings are displayed to the user on the partyline.</p>
+</dd>
+<dt class="field-even">config-vars-&lt;varname&gt;-description<span class="colon">:</span></dt>
+<dd class="field-even"><p>A description of the setting, displayed in the configuration listing for the script</p>
+</dd>
+<dt class="field-odd">config-vars-&lt;varname&gt;-value<span class="colon">:</span></dt>
+<dd class="field-odd"><p>The value thee setting is set to</p>
+</dd>
+</dl>
+</section>
+<section id="file-placement">
+<h3>File placement<a class="headerlink" href="#file-placement" title="Permalink to this heading">¶</a></h3>
+<p>Autoscript files are stored in the autoscript directory. The path structure is eggdrop/autoscript/&lt;scriptname&gt;/[script files]. If the autoscript <code class="docutils literal notranslate"><span class="pre">fetch</span></code> command is used, a .tgz file will be downloaded and extracted to the proper location automatically. If you wish to manually add a script, create a directory with the same name as the script, and then place the script and manifest files inside the directory. The directory name must exactly match the script name (without the .tcl extension)! If the Tcl script to be loaded is called <code class="docutils literal notranslate"><span class="pre">myscript_goodversion_specialfeature.tcl</span></code>, then the directory must also called <code class="docutils literal notranslate"><span class="pre">myscript_goodversion_specialfeature</span></code>.</p>
+</section>
+</section>
+<section id="development-hints">
+<h2>Development hints<a class="headerlink" href="#development-hints" title="Permalink to this heading">¶</a></h2>
+<ul class="simple">
+<li><p>An autoscript should not require a user to manually open the script in an editor for any reason. Design your script as such!</p></li>
+<li><p>Use <a class="reference external" href="https://docs.eggheads.org/using/tcl-commands.html#setudef-flag-int-str-name">user defined channel flags</a> to enable/disable a script for a particular channel, they’re easy!</p></li>
+<li><p>Variables used in autoscripts are placed into the global namespace. Make them unique to prevent collisions! We recommend prefixing the script name in front of a variable, such as myscript_setting or ms_setting.</p></li>
+</ul>
+</section>
+<section id="tcl-commands">
+<h2>Tcl Commands<a class="headerlink" href="#tcl-commands" title="Permalink to this heading">¶</a></h2>
+<p>The autoscripts Tcl script adds three new commands for use with Tcl scripts:</p>
+<section id="egg-loaded">
+<h3>egg_loaded<a class="headerlink" href="#egg-loaded" title="Permalink to this heading">¶</a></h3>
+<blockquote>
+<div><p>Description: lists all scripts currently loaded via the autoscripts system</p>
+<p>Returns: A Tcl list of script names currently loaded via autoscripts</p>
+</div></blockquote>
+</section>
+<section id="egg-unloaded">
+<h3>egg_unloaded<a class="headerlink" href="#egg-unloaded" title="Permalink to this heading">¶</a></h3>
+<blockquote>
+<div><p>Description: lists all scripts downloaded to the local machine via the autoscripts system but not currently loaded by Eggdrop</p>
+<p>Returns: A Tcl list of script names downloaded but not currently loaded via autoscripts</p>
+</div></blockquote>
+</section>
+<section id="egg-all">
+<h3>egg_all<a class="headerlink" href="#egg-all" title="Permalink to this heading">¶</a></h3>
+<blockquote>
+<div><p>Description: lists all script downloaded to the localm machine via the autoscripts system, regardless if they are running or not</p>
+<p>Returns: A Tcl list of all script namees download via autoscripts</p>
+</div></blockquote>
+</section>
+</section>
+</section>
+
+
+            <div class="clearer"></div>
+          </div>
+        </div>
+      </div>
+        </div>
+        <div class="clearer"></div>
+      </div>
+    </div>
+
+    <div class="footer-wrapper">
+      <div class="footer">
+        <div class="left">
+          <div role="navigation" aria-label="related navigaton">
+            <a href="partyline.html" title="The Party Line"
+              >previous</a> |
+            <a href="users.html" title="Users and Flags"
+              >next</a>
+          </div>
+          <div role="note" aria-label="source link">
+          </div>
+        </div>
+
+        <div class="right">
+          
+    <div class="footer" role="contentinfo">
+        &#169; Copyright 2022, Eggheads.
+      Last updated on Feb 05, 2023.
+      Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 6.1.3.
+    </div>
+        </div>
+        <div class="clearer"></div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/doc/sphinx_source/index.rst
+++ b/doc/sphinx_source/index.rst
@@ -55,6 +55,7 @@ The Eggheads development team can be found lurking on #eggdrop on the Libera net
     using/features
     using/core
     using/partyline
+    using/autoscripts
     using/users
     using/bans
     using/botnet

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -45,9 +45,9 @@ clean <script>
 ^^^^^^^^^^^^^^
 This command will delete the script from the filesystem. After running this command, you will have to re-download and re-configure the script if you wish to use it again.
 
-update
-^^^^^^
-This command checks if there is a newer version of autoscript available.
+update [script]
+^^^^^^^^^^^^^^^
+If no script is specified, this command checks if there any downloaded script has a newer version available. If a script is specified, autoscript will fetch and install the updated script.
 
 
 Autoscripts File Structure
@@ -63,6 +63,7 @@ Manifest.json
 Every autoscripts package must have a manifest.json file. This file contains metadata for the script such as version and description information, as well as the user-configurable settings for use with th script. A simple example of a manifest.json file is as follows::
 
   {
+    "schema": 1,
     "name": "woobie",
     "version_major": 1,
     "version_minor": 0,
@@ -93,6 +94,8 @@ Every autoscripts package must have a manifest.json file. This file contains met
     }
   }
 
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| schema                            | The schema version of autoscript (currently 1)                                                                                                                                                                                                                         |
 +-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | name                              | The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)                                                                                                                                                                   |
 +-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -11,7 +11,7 @@ Since it's inception, users have needed to load a Tcl script into Eggdrop by dow
 
 Autoscripts usage
 -----------------
-To view available autoscript commands, type `.script` on the partyline. The following sub-commands are available for use with script:
+To view available autoscript commands, type ``.script`` on the partyline. The following sub-commands are available for use with script:
 
 remote
 ^^^^^^
@@ -31,7 +31,7 @@ This command will list settings available for configuration for the provided scr
 
 set <script> <setting>
 ^^^^^^^^^^^^^^^^^^^^^^
-This command will set `setting` for `script` to the provided value.
+This command will set ``setting`` for ``script`` to the provided value.
 
 load <script>
 ^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ An autoscripts package requires (minimum) two files: the Tcl script, and a json 
 
 Tcl File
 ^^^^^^^^
-Nothing new or novel here; this is where your Tcl code goes. The one change to this file is that any setting intended should now be located in the manifest.json file, not the Tcl script file. All variables will be added to the global namespace. For this reason, it is recommended that variables have unique names to avoid collisions. This is commonly done by prefixing the variable name with the script name or abbreviation. For example, a script called myscript.tcl might avoid using a variable calld `name` and instead use `myscript_name` or `ms_name`.
+Nothing new or novel here; this is where your Tcl code goes. The one change to this file is that any setting intended should now be located in the manifest.json file, not the Tcl script file. All variables will be added to the global namespace. For this reason, it is recommended that variables have unique names to avoid collisions. This is commonly done by prefixing the variable name with the script name or abbreviation. For example, a script called myscript.tcl might avoid using a variable calld ``name`` and instead use ``myscript_name`` or ``ms_name``.
 
 Manifest.json
 ^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ Every autoscripts package must have a manifest.json file. This file contains met
     "config": {
       "loaded": 0,
       "udefflag":"myscript"
-      "requires": null,
+      "requires": "tls",
       "vars": {
         "woobie_dict": {
           "description": "A setting that accepts a dict as a value",
@@ -89,27 +89,39 @@ Every autoscripts package must have a manifest.json file. This file contains met
     }
   }
 
-:name: The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)
-:version_major: The major version integer (ie, 1 for 1.6)
-:version_minor: The minor version integer (ie, 6 for 1.6)
-:description: A one-line summary of what the script does. This will be shown when available scripts are listed on the partyline via .script list.
-:long_description: A longer description of what the script does, similar to a README. This will be shown when a script is viewed via .script config.
-:config-loaded: Whether this script is currently loaded or not. It should be default set to 0.
-:config-udefflag: Any user-defined channel settings used by the script. This is displayed when configuration settings are displayed to the user on the partyline.
-:config-requires: Any Tcl package required for use by the script, such as tcllib or json.
-:config-vars-<varname>: A setting intended to be modified by the user. The 'description' field should describe what the setting does, and the 'value' field stores the current value. These settings are displayed when the configuration settings are displayed to the user on the partyline.
-:config-vars-<varname>-description: A description of the setting, displayed in the configuration listing for the script
-:config-vars-<varname>-value: The value thee setting is set to
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| name                              | The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)                                                                                                                                                                   |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| version_major                     | The major version integer (ie, 1 for 1.6)                                                                                                                                                                                                                              |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| version_minor                     | The minor version integer (ie, 6 for 1.6)                                                                                                                                                                                                                              |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| description                       | A one-line summary of what the script does. This will be shown when available scripts are listed on the partyline via .script list.                                                                                                                                    |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| long_description                  | A longer description of what the script does, similar to a README. This will be shown when a script is viewed via .script config.                                                                                                                                      |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-loaded                     | Whether this script is currently loaded or not. It should be default set to 0.                                                                                                                                                                                         |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-udefflag                   | Any user-defined channel settings used by the script. This is displayed when configuration settings are displayed to the user on the partyline.                                                                                                                        |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-requires                   | Any Tcl package required for use by the script, such as tls, http, json, etc.                                                                                                                                                                                          |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-vars-<varname>             | A setting intended to be modified by the user. The 'description' field should describe what the setting does, and the 'value' field stores the current value. These settings are displayed when the configuration settings are displayed to the user on the partyline. |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-vars-<varname>-description | A description of the setting, displayed in the configuration listing for the script.                                                                                                                                                                                   |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| config-vars-<varname>-value       | The value the setting is set to                                                                                                                                                                                                                                        |
++-----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 File placement
 ^^^^^^^^^^^^^^
-Autoscript files are stored in the autoscript directory. The path structure is eggdrop/autoscript/<scriptname>/[script files]. If the autoscript `fetch` command is used, a .tgz file will be downloaded and extracted to the proper location automatically. If you wish to manually add a script, create a directory with the same name as the script, and then place the script and manifest files inside the directory. The directory name must exactly match the script name (without the .tcl extension)! If the Tcl script to be loaded is called `myscript_goodversion_specialfeature.tcl`, then the directory must also called `myscript_goodversion_specialfeature`.
+Autoscript files are stored in the autoscript directory. The path structure is eggdrop/autoscript/<scriptname>/[script files]. If the autoscript ``fetch`` command is used, a .tgz file will be downloaded and extracted to the proper location automatically. If you wish to manually add a script, create a directory with the same name as the script, and then place the script and manifest files inside the directory. The directory name must exactly match the script name (without the .tcl extension)! If the Tcl script to be loaded is called ``myscript_goodversion_specialfeature.tcl``, then the directory must also called ``myscript_goodversion_specialfeature``.
 
 Development hints
 -----------------
 
 * An autoscript should not require a user to manually open the script in an editor for any reason. Design your script as such!
-* Use `user defined channel flags <https://docs.eggheads.org/using/tcl-commands.html#setudef-flag-int-str-name>` to enable/disable a script for a particular channel, they're easy!
+* Use `user defined channel flags <https://docs.eggheads.org/using/tcl-commands.html#setudef-flag-int-str-name>`_ to enable/disable a script for a particular channel, they're easy!
 * Variables used in autoscripts are placed into the global namespace. Make them unique to prevent collisions! We recommend prefixing the script name in front of a variable, such as myscript_setting or ms_setting.
 
 Tcl Commands
@@ -117,7 +129,6 @@ Tcl Commands
 
 The autoscripts Tcl script adds three new commands for use with Tcl scripts:
 
-^^^^^^^^^^
 egg_loaded
 ^^^^^^^^^^
 
@@ -125,7 +136,6 @@ egg_loaded
 
   Returns: A Tcl list of script names currently loaded via autoscripts
 
-^^^^^^^^^^^^
 egg_unloaded
 ^^^^^^^^^^^^
 
@@ -133,7 +143,6 @@ egg_unloaded
 
   Returns: A Tcl list of script names downloaded but not currently loaded via autoscripts
 
-^^^^^^^
 egg_all
 ^^^^^^^
 

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -45,6 +45,10 @@ clean <script>
 ^^^^^^^^^^^^^^
 This command will delete the script from the filesystem. After running this command, you will have to re-download and re-configure the script if you wish to use it again.
 
+update
+^^^^^^
+This command checks if there is a newer version of autoscript available.
+
 
 Autoscripts File Structure
 --------------------------

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -1,0 +1,113 @@
+Eggdrop Autoscripts
+===================
+
+Since it's inception, users have needed to load a Tcl script into Eggdrop by downloading a Tcl file, editing the file to customize settings, and then sourceing that file in the config file. In v1.10, the Autoscripts system was added to make this process a little more user-friendly. The autoscripts system helps by:
+
+* Centralizing commonly-used scripts in a single location
+* Allowing scripts to be downloaded via the partyline
+* Allowing script settings to be configured via the partyline
+* Allowing user-written scripts to be managed by the autoscripts system
+* Providing a documented API to write autoscripts-compatible scripts
+
+Autoscripts usage
+-----------------
+To view available autoscript commands, type `.script` on the partyline. The following sub-commands are available for use with script:
+
+remote
+^^^^^^
+This command will list scripts hosted on the Eggdrop website that are available to be downloaded and installed on your Eggdrop.
+
+fetch <script>
+^^^^^^^^^^^^^^
+This command will download the specified script from the Eggdrop website and place it into the autoscript/ directory.
+
+list
+^^^^
+This command will list scripts locallt present in the autoscripts/ directory, available to be configured and loaded.
+
+config <script>
+^^^^^^^^^^^^^^^
+This command will list settings available for configuration for the provided script.
+
+set <script> <setting>
+^^^^^^^^^^^^^^^^^^^^^^
+This command will set `setting` for `script` to the provided value.
+
+load <script>
+^^^^^^^^^^^^^
+This command will activate the script for use.
+
+unload <script>
+^^^^^^^^^^^^^^^
+This command will prevent the script from being loaded the next time Eggdrop starts. To fully unload a script, Eggdrop must be restarted!
+
+clean <script>
+^^^^^^^^^^^^^^
+This command will delete the script from the filesystem. After running this command, you will have to re-download and re-configure the script if you wish to use it again.
+
+
+Autoscripts File Structure
+--------------------------
+An autoscripts package requires (minimum) two files: the Tcl script, and a json manifest file. 
+
+Tcl File
+^^^^^^^^
+Nothing new or novel here; this is where your Tcl code goes. The one change to this file is that any setting intended should now be located in the manifest.json file, not the Tcl script file. All variables will be added to the global namespace. For this reason, it is recommended that variables have unique names to avoid collisions. This is commonly done by prefixing the variable name with the script name or abbreviation. For example, a script called myscript.tcl might avoid using a variable calld `name` and instead use `myscript_name` or `ms_name`.
+
+Manifest.json
+^^^^^^^^^^^^^
+Every autoscripts package must have a manifest.json file. This file contains metadata for the script such as version and description information, as well as the user-configurable settings for use with th script. A simple example of a manifest.json file is as follows::
+
+  {
+    "name": "woobie",
+    "version_major": 1,
+    "version_minor": 0,
+    "description": "An example script to help developers write autoscript packages",
+    "long_description": "This is an example script to help understand the autoscript system. Yeah, it doesn't really do anything, but that's besides the point. It could, and that should be enough for anyone"
+    "config": {
+      "loaded": 0,
+      "udefflag":"myscript"
+      "requires": null,
+      "vars": {
+        "woobie_dict": {
+          "description": "A setting that accepts a dict as a value",
+          "value": "{quiet q}"
+        },
+        "woobie_setting": {
+          "description": "A normal setting to enable or disable something",
+          "value": "1"
+        },
+        "woobie_string": {
+          "description": "A setting taking a string, like a filename or something",
+          "value": "woobie"
+        },
+        "woobie(array)": {
+          "description": "A setting that is set as an array",
+          "value":"another string"
+        }
+      }
+    }
+  }
+
+:name: The name of the script. Must match the script name (if the script is foo.tcl, then this must be foo)
+:version_major: The major version integer (ie, 1 for 1.6)
+:version_minor: The minor version integer (ie, 6 for 1.6)
+:description: A one-line summary of what the script does. This will be shown when available scripts are listed on the partyline via .script list.
+:long_description: A longer description of what the script does, similar to a README. This will be shown when a script is viewed via .script config.
+:config-loaded: Whether this script is currently loaded or not. It should be default set to 0.
+:config-udefflag: Any user-defined channel settings used by the script. This is displayed when configuration settings are displayed to the user on the partyline.
+:config-requires: Any Tcl package required for use by the script, such as tcllib or json.
+:config-vars-<varname>: A setting intended to be modified by the user. The 'description' field should describe what the setting does, and the 'value' field stores the current value. These settings are displayed when the configuration settings are displayed to the user on the partyline.
+:config-vars-<varname>-description: A description of the setting, displayed in the configuration listing for the script
+:config-vars-<varname>-value: The value thee setting is set to
+
+File placement
+^^^^^^^^^^^^^^
+Autoscript files are stored in the autoscript directory. The path structure is eggdrop/autoscript/<scriptname>/[script files]. If the autoscript `fetch` command is used, a .tgz file will be downloaded and extracted to the proper location automatically. If you wish to manually add a script, create a directory with the same name as the script, and then place the script and manifest files inside the directory. The directory name must exactly match the script name (without the .tcl extension)! If the Tcl script to be loaded is called `myscript_goodversion_specialfeature.tcl`, then the directory must also called `myscript_goodversion_specialfeature`.
+
+Development hints
+-----------------
+
+* An autoscript should not require a user to manually open the script in an editor for any reason. Design your script as such!
+* Use `user defined channel flags <https://docs.eggheads.org/using/tcl-commands.html#setudef-flag-int-str-name>` to enable/disable a script for a particular channel, they're easy!
+* Variables used in autoscripts are placed into the global namespace. Make them unique to prevent collisions! We recommend prefixing the script name in front of a variable, such as myscript_setting or ms_setting.

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -111,3 +111,32 @@ Development hints
 * An autoscript should not require a user to manually open the script in an editor for any reason. Design your script as such!
 * Use `user defined channel flags <https://docs.eggheads.org/using/tcl-commands.html#setudef-flag-int-str-name>` to enable/disable a script for a particular channel, they're easy!
 * Variables used in autoscripts are placed into the global namespace. Make them unique to prevent collisions! We recommend prefixing the script name in front of a variable, such as myscript_setting or ms_setting.
+
+Tcl Commands
+------------
+
+The autoscripts Tcl script adds three new commands for use with Tcl scripts:
+
+^^^^^^^^^^
+egg_loaded
+^^^^^^^^^^
+
+  Description: lists all scripts currently loaded via the autoscripts system
+
+  Returns: A Tcl list of script names currently loaded via autoscripts
+
+^^^^^^^^^^^^
+egg_unloaded
+^^^^^^^^^^^^
+
+  Description: lists all scripts downloaded to the local machine via the autoscripts system but not currently loaded by Eggdrop
+
+  Returns: A Tcl list of script names downloaded but not currently loaded via autoscripts
+
+^^^^^^^
+egg_all
+^^^^^^^
+
+  Description: lists all script downloaded to the localm machine via the autoscripts system, regardless if they are running or not
+
+  Returns: A Tcl list of all script namees download via autoscripts

--- a/doc/sphinx_source/using/autoscripts.rst
+++ b/doc/sphinx_source/using/autoscripts.rst
@@ -11,7 +11,7 @@ Since it's inception, users have needed to load a Tcl script into Eggdrop by dow
 
 Autoscripts usage
 -----------------
-To view available autoscript commands, type ``.script`` on the partyline. The following sub-commands are available for use with script:
+To view available autoscript commands, type ``.autoscript`` on the partyline. This will open up a special Eggdrop console that doesn't require you to prefix commands with a '.' . The following sub-commands are available for use with script:
 
 remote
 ^^^^^^
@@ -31,11 +31,11 @@ This command will list settings available for configuration for the provided scr
 
 set <script> <setting>
 ^^^^^^^^^^^^^^^^^^^^^^
-This command will set ``setting`` for ``script`` to the provided value.
+This command will set ``setting`` for ``script`` to the provided value. To activate this change, use the ``load`` command.
 
 load <script>
 ^^^^^^^^^^^^^
-This command will activate the script for use.
+This command will activate the script for use. You can also use this command to reload a script after modifying a script variable.
 
 unload <script>
 ^^^^^^^^^^^^^^^

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -373,6 +373,13 @@ unbind msg - addhost *msg:addhost
 ## Set here the filename where private notes between users are stored.
 set notefile "LamestBot.notes"
 
+##### AUTOSCRIPTS #####
+
+# Load this script to enable the autoscripts functionality for Eggdrop.
+# Autoscripts are scripts that can be downloaded, installed and configured via
+# the partyline. For more information, read doc/AUTOSCRIPTS
+source scripts/autoscripts.tcl
+
 ##### SCRIPTS #####
 
 ## This is a good place to load scripts to use with your bot.

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1682,6 +1682,13 @@ loadmodule uptime
 # Set the ident port to use for ident-method 1.
 #set ident-port 113
 
+##### AUTOSCRIPTS #####
+
+# Load this script to enable the autoscripts functionality for Eggdrop.
+# Autoscripts are scripts that can be downloaded, installed and configured via
+# the partyline. For more information, read doc/AUTOSCRIPTS
+source scripts/autoscripts.tcl
+
 ##### SCRIPTS #####
 
 # This is a good place to load scripts to use with your bot.

--- a/misc/generatedocs
+++ b/misc/generatedocs
@@ -144,6 +144,7 @@ mv tmpdocs/tricks.txt $BASEDIR/../doc/TRICKS
 mv tmpdocs/twitchinfo.txt $BASEDIR/../doc/TWITCH
 mv tmpdocs/users.txt $BASEDIR/../doc/USERS
 mv tmpdocs/accounts.txt $BASEDIR/../doc/ACCOUNTS
+mv tmpdocs/autoscripts.txt $BASEDIR/../doc/AUTOSCRIPTS
 rm -rf tmpdocs
 rm -rf $BASEDIR/../doc/html/_sources
 rm -rf $BASEDIR/../doc/doctrees/

--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -14,7 +14,7 @@ DOCS = CONTENTS
 
 SCRIPTS = action.fix.tcl alltools.tcl compat.tcl dccwhois.tcl getops.tcl \
 klined.tcl notes2.tcl ques5.tcl sentinel.tcl userinfo.tcl cmd_resolve.tcl \
-quotepong.tcl
+quotepong.tcl autoscripts.tcl
 
 EXESCRIPTS = autobotchk botchk weed
 

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -89,26 +89,28 @@ proc loadscripts {} {
 proc parse_egg {hand idx text} {
 	set args [split $text]
 	set args [lassign $args subcmd arg1 arg2]
-	if {$subcmd in {list remote}} {
+	if {$subcmd in {remote}} {
 		egg_$subcmd $idx
 	} elseif {$subcmd in {config fetch clean}} {
 		if {$arg1 eq ""} {
-			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
+		  putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
 		} else {
-			egg_$subcmd $idx $arg1
+		  egg_$subcmd $idx $arg1
 		}
 	} elseif {$subcmd in {load unload}} {
 		if {$arg1 eq ""} {
-			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
+		  putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
 		} else {
-			egg_load $idx $arg1 [expr {$subcmd eq "load"}]
+		  egg_load $idx $arg1 [expr {$subcmd eq "load"}]
 		}
 	} elseif {$subcmd in {set}} {
 		if {![llength $args]} {
-			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName settingName newSettingValue"
+		  putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName settingName newSettingValue"
 		} else {
-			egg_$subcmd $idx $arg1 $arg2 [join $args]
+		  egg_$subcmd $idx $arg1 $arg2 [join $args]
 		}
+    } elseif {$subcmd in {loaded unloaded all}} {
+       egg_$subcmd
 	} else {
 		putdcc $idx "Missing or unknown subcommand, must be $::lastbind set, config, load, unload, remote, fetch, clean"
 	}
@@ -225,6 +227,41 @@ proc egg_remote {idx} {
   putdcc $idx "\n"
   putdcc $idx "* Type '.egg fetch <scriptname>' to download a script"
 }
+
+# Helper command for scripts- return a Tcl list of scripts that are loaded
+proc egg_loaded {} {
+  global jsondict
+  list scriptlist
+  foreach scriptentry $jsondict {
+    if {[dict get $scriptentry config loaded]} {
+      lappend scriptlist [dict get $scriptentry name]
+    }
+  }
+  return $scriptlist
+}
+
+# Helper command for scripts- return a Tcl list of scripts that are loaded
+proc egg_unloaded {} {
+  global jsondict
+  list scriptlist
+  foreach scriptentry $jsondict {
+    if {![dict get $scriptentry config loaded]} {
+      lappend scriptlist [dict get $scriptentry name]
+    }
+  }
+  return $scriptlist
+}
+
+# Helper command for scripts- return a Tcl list of scripts that are loaded
+proc egg_all {} {
+  global jsondict
+  list scriptlist
+  foreach scriptentry $jsondict {
+    lappend scriptlist [dict get $scriptentry name]
+  }
+  return $scriptlist
+}
+
 
 # Download a script from the eggheads repository
 proc egg_fetch {idx script} {

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -37,7 +37,7 @@ proc console {hand idx arg} {
 proc readjsonfile {} {
   global jsondict
   global eggdir
-  set jsonstring "\["
+  set jsonlist {}
 ### How to get filepath properly
   foreach dirname [glob -nocomplain -type d -directory $eggdir *] {
     if {![file exists $dirname/manifest.json]} {
@@ -45,16 +45,11 @@ proc readjsonfile {} {
       putlog "$dirname missing manifest.json, deleting"
     } else {
       set fs [open $dirname/manifest.json r]
-      if {[string length $jsonstring] > 1} {
-        append jsonstring ","
-      }
-      set filestring [read $fs]
-      append jsonstring $filestring
+      lappend jsonlist [read $fs]
       close $fs
     }
   }
-  append jsonstring "\]"
-  set jsondict [json::json2dict $jsonstring]
+  set jsondict [json::json2dict "\[[join $jsonlist {,}]\]"]
 }
 
 # Write a script's JSON content to file
@@ -478,4 +473,4 @@ proc compile_json {spec data} {
 if {![file exists autoscripts]} {file mkdir autoscripts}
 readjsonfile
 loadscripts
-putlog "Loading foo.tcl"
+putlog "Loading autoscripts.tcl"

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -88,7 +88,7 @@ proc loadscripts {} {
 proc parse_egg {hand idx text} {
 	set args [split $text]
 	set args [lassign $args subcmd arg1 arg2]
-	if {$subcmd in {remote}} {
+	if {$subcmd in {remote help}} {
 		egg_$subcmd $idx
 	} elseif {$subcmd in {config fetch clean}} {
 		if {$arg1 eq ""} {
@@ -108,10 +108,11 @@ proc parse_egg {hand idx text} {
 		} else {
 		  egg_$subcmd $idx $arg1 $arg2 [join $args]
 		}
-    } elseif {$subcmd in {loaded unloaded all}} {
+    } elseif {$subcmd in {loaded unloaded all help}} {
        egg_$subcmd
 	} else {
-		putdcc $idx "Missing or unknown subcommand, must be $::lastbind set, config, load, unload, remote, fetch, clean"
+		putdcc $idx "Missing or unknown subcommand"
+        egg_help $idx
 	}
 }
 
@@ -307,6 +308,21 @@ proc egg_clean {idx script} {
   } else {
     putdcc $idx "* $script not found"
   }
+}
+
+proc egg_help {idx} {
+  putidx $idx "* The following commands are available for use with $::lastbind:"
+  putidx $idx "    remote, fetch, list, config, set, load, unload, clean"
+  putidx $idx ""
+  putidx $idx "* remote:               : List scripts available for download"
+  putidx $idx "* fetch <script>:       : Download the script"
+  putidx $idx "* list                  : List all scripts present on the local system available for use"
+  putidx $idx "* config <script>       : View configuration options for a script"
+  putidx $idx "* set <script> <setting>: Set the value for a script setting"
+  putidx $idx "* load <script>         : Load a script, and enable a script to be loaded when Eggdrop starts"
+  putidx $idx "* unload <script>       : Prevent a script from running when Eggdrop starts"
+  putidx $idx "                          (Must restart Eggdrop to remove stop a currently running script!)"
+  putidx $idx "* clean <script>        : Permanently remove a script and any associated settings or files"
 }
 
 # Yikes.

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -1,0 +1,353 @@
+package require json
+package require json::write
+package require http
+package require tls
+
+
+bind dcc * egg parse_egg
+bind dcc * scripts parse_egg
+
+set eggdir "autoscripts"
+
+set jsondict [dict create]
+
+#Read all JSON script files
+proc readjsonfile {} {
+  global jsondict
+  global eggdir
+  set jsonstring "\["
+### How to get filepath properly
+  foreach dirname [glob -nocomplain -type d -directory $eggdir *] {
+putlog "doing $dirname"
+    if {![file exists $dirname/manifest.json]} {
+      file delete -force $dirname
+      putlog "$dirname missing manifest.json, deleting"
+    } else {
+      set fs [open $dirname/manifest.json r]
+      if {[string length $jsonstring] > 1} {
+        append jsonstring ","
+      }
+      set filestring [read $fs]
+      append jsonstring $filestring
+      close $fs
+    }
+  }
+  append jsonstring "\]"
+  set jsondict [json::json2dict $jsonstring]
+}
+
+# Write a script's JSON content to file
+proc write_json {script jstring} {
+  global eggdir
+  set fs [open $eggdir/${script}/manifest.json w]
+  puts $fs $jstring
+  close $fs
+}
+
+# Send an HTTP request. Type 0 for text, 1 for binary
+proc send_http {url type} {
+  global eggdir
+  http::register https 443 [list ::tls::socket -autoservername true]
+  set req [http::config -useragent "eggdrop"]
+  if {$type} {
+    set fs [open $eggdir/[lindex [split $url /] end] w]
+    catch {set req [http::geturl $url -binary 1 -channel $fs]} error
+    close $fs
+  } else {
+    catch {set req [http::geturl $url -timeout 10000]} error
+  }
+  set status [http::status $req]
+  if {$status != "ok"} {
+    putlog "HTTP request error: $error"
+    return
+  }
+  set data [http::data $req]
+  ::http::cleanup $req
+  return $data
+}
+
+# Read all manifest files
+proc loadscripts {} {
+  global jsondict
+  global eggdir
+  foreach scriptentry $jsondict {
+    if [dict get $scriptentry config loaded] {
+      if {[dict exists $scriptentry config vars]} {
+        foreach configvar [dict keys [dict get $scriptentry config vars] *] {
+          uplevel #0 set $configvar [dict get $scriptentry config vars $configvar value]
+        }
+      }
+      if {[catch {uplevel #0 source $eggdir/[dict get $scriptentry name]/[dict get $scriptentry name].tcl} err]} {
+        putlog "Error loading [dict get $scriptentry]: $err"
+        return
+      }
+    }
+  }
+}
+
+# Initial function called by .egg command, sends to proper proc based on args
+proc parse_egg {hand idx text} {
+	set args [split $text]
+	set args [lassign $args subcmd arg1 arg2]
+	if {$subcmd in {list remote}} {
+		egg_$subcmd $idx
+	} elseif {$subcmd in {config fetch clean}} {
+		if {$arg1 eq ""} {
+			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
+		} else {
+			egg_$subcmd $idx $arg1
+		}
+	} elseif {$subcmd in {load unload}} {
+		if {$arg1 eq ""} {
+			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName"
+		} else {
+			egg_load $idx $arg1 [expr {$subcmd eq "load"}]
+		}
+	} elseif {$subcmd in {set}} {
+		if {![llength $args]} {
+			putdcc $idx "Missing parameter, must be $::lastbind $subcmd scriptName settingName newSettingValue"
+		} else {
+			egg_$subcmd $idx $arg1 $arg2 [join $args]
+		}
+	} else {
+		putdcc $idx "Missing or unknown subcommand, must be $::lastbind set, config, load, unload, remote, fetch, clean"
+	}
+}
+
+# List scripts that are locally present in .egg
+proc egg_list {idx} {
+  global jsondict
+  readjsonfile
+  putdcc $idx "\nThe following scripts are available for configuration:"
+  putdcc $idx "------------------------------------------------------"
+  foreach script $jsondict {
+    set loaded [expr {[dict get $script config loaded] == 1 ? "\[X\]" : "\[ \]"}]
+    putdcc $idx "* $loaded [dict get $script name] (v[dict get $script version_major].[dict get $script version_minor]) - [dict get $script description]"
+    if {[dict exists $script config requires] && [string length [dict get $script config requires]]} {
+      foreach pkg [dict get $script config requires] {
+        if {[catch {[package require [dict get $script $pkg]]}]} {
+          putdcc $idx "      ( ^ Must install Tcl $pkg package before loading)"
+        }
+      }
+    }
+  }
+}
+
+# Load or unload a script and update JSON field
+proc egg_load {idx script loadme} {
+  global jsondict
+  global eggdir
+  set found 0
+  readjsonfile
+  foreach scriptentry $jsondict {
+    if [string match $script [dict get $scriptentry name]] {
+      set found 1
+      if {$loadme} {
+        if {[dict exists $scriptentry config vars]} {
+          foreach configvar [dict keys [dict get $scriptentry config vars] *] {
+            uplevel #0 set $configvar [dict get $scriptentry config vars $configvar value]
+          }
+        }
+        if {[catch {uplevel #0 source $eggdir/${script}/${script}.tcl} err]} {
+          putdcc $idx "Error loading ${script}: $err"
+          return
+        }
+        dict set scriptentry config loaded 1
+        putdcc $idx "* Loaded $script."
+      } else {
+        dict set scriptentry config loaded 0
+        putdcc $idx "* Removed $script from being loaded. Restart Eggdrop to complete."
+      }
+      write_json $script [compile_json {dict config {dict vars {dict * dict}}} $scriptentry]
+      readjsonfile
+      break
+    }
+  }
+  if {!$found} {
+    putdcc $idx "* $script not found."
+  }
+}
+
+# List variables available for a script
+proc egg_config {idx script} {
+  global jsondict
+  foreach scriptentry $jsondict {
+    if {[string match $script [dict get $scriptentry name]]} {
+      if {[dict exists $scriptentry long_description]} {
+        putdcc $idx "\n* [dict get $scriptentry long_description]\n\n"
+      }
+      if {![dict exists $scriptentry config vars]} {
+        putdcc $idx "* No variables are available to configure for $script"
+      } else {
+        putdcc $idx "* The following config options are available for $script:"
+        putdcc $idx "---------------------------------------------------------"
+        foreach configvar [dict keys [dict get $scriptentry config vars] *] {
+          putdcc $idx "* $configvar - [dict get $scriptentry config vars $configvar description] (current value: [dict get $scriptentry config vars $configvar value])"
+        }
+        if {[dict exists $scriptentry config udefflag]} {
+          putdcc $idx ""
+          putdcc $idx "* Enable for a channel via .chanset <channel> +[dict get $scriptentry config udefflag]"
+        }
+      }
+    }
+  }
+}
+
+# Set a variable for a script
+proc egg_set {idx script setting value} {
+  global jsondict
+  foreach scriptentry $jsondict {
+    if {[string match $script [dict get $scriptentry name]]} {
+      if [dict exists $scriptentry config vars $setting] {
+        dict set scriptentry config vars $setting value $value
+        write_json $script [compile_json {dict config {dict vars {dict * dict}}} $scriptentry]
+        putdcc $idx "* ${script}: Variable \"$setting\" set to \"${value}\""
+        readjsonfile        
+      }
+    }
+  }
+}
+
+# Pull down remote Tcl file listing
+# For future eggheads- 100 is the maximum WP supports without doing pagination
+proc egg_remote {idx} {
+  set jsondata [send_http "https://www.eggheads.org/wp-json/wp/v2/media?mime_type=application\/x-gzip&orderby=slug&per_page=100&order=asc" 0]
+  set datadict [json::json2dict $jsondata]
+  putdcc $idx "* Retrieving script list, please wait..."
+  putdcc $idx "Scripts available for download:"
+  putdcc $idx "-------------------------------"
+  foreach scriptentry $datadict {
+    putdcc $idx "* [dict get $scriptentry slug] ([lindex [regexp -inline {\n.*<p>([^<>]*)</p>} [dict get $scriptentry description rendered]] 1])"
+  }
+  putdcc $idx "\n"
+  putdcc $idx "* Type '.egg fetch <scriptname>' to download a script"
+}
+
+# Download a script from the eggheads repository
+proc egg_fetch {idx script} {
+  global eggdir
+  try {
+    set results [exec which tar]
+    set status 0
+  } trap CHILDSTATUS {results options} {
+    if {lindex [dict get $options -errorcode] 2} {
+      putdcc $idx "* ERROR: This feature is not available (tar not detected on this system, cannot extract a downloaded file)."
+      return
+    }
+  }
+  if {[file isdirectory $eggdir/$script]} {
+    putdcc $idx "* Script directory already exists. Not downloading again!"
+    return
+  }
+### CHECK IF IT IS ON SITE FIRST
+  putdcc $idx "* Downloading, please wait..."
+  set jsondata [send_http "https://www.eggheads.org/wp-json/wp/v2/media?mime_type=application\/x-gzip" 0]
+  set datadict [json::json2dict $jsondata]
+  foreach scriptentry $datadict {
+    if {[string match $script [dict get $scriptentry slug]]} {
+      send_http [dict get $scriptentry source_url] 1
+      file mkdir $eggdir/[dict get $scriptentry slug]
+      exec tar -zxf $eggdir/[dict get $scriptentry slug].tgz -C $eggdir/[dict get $scriptentry slug]
+      file delete $eggdir/[dict get $scriptentry slug].tgz
+      putdcc $idx "* [dict get $scriptentry slug] downloaded."
+      putdcc $idx "* Use '.egg load [dict get $scriptentry slug]' to load and '.egg config [dict get $scriptentry slug]' to configure."
+      readjsonfile
+    }
+  }
+}
+
+proc egg_clean {idx script} {
+  global eggdir
+  if {[file isdirectory $eggdir/$script]} {
+    file delete -force $eggdir/$script
+    putdcc $idx "* $script deleted"
+  } else {
+    putdcc %idx "* $script not found"
+  }
+}
+
+# Yikes.
+proc compile_json {spec data} {
+	while [llength $spec] {
+		set type [lindex $spec 0]
+		set spec [lrange $spec 1 end]
+
+		switch -- $type {
+			dict {
+				lappend spec * unknown
+
+				set json {}
+				foreach {key val} $data {
+					foreach {keymatch valtype} $spec {
+						if {[string match $keymatch $key]} {
+							if {$key in {name displayname}} { set valtype string }
+							lappend json [subst {"$key":[compile_json $valtype $val]}]
+							break
+						}
+					}
+				}
+				return "{[join $json ,]}"
+			}
+			list {
+				if {![llength $spec]} {
+					set spec unknown
+				} else {
+					set spec [lindex $spec 0]
+				}
+				set json {}
+				foreach {val} $data {
+					lappend json [compile_json $spec $val]
+				}
+				return "\[[join $json ,]\]"
+			}
+			number {
+				if {$data eq "" || $data eq "null"} {
+					return null
+				} else {
+					return $data
+				}
+			}
+			string {
+				if {$data eq "" || $data eq "null"} {
+					return null
+				} else {
+					set new ""
+					for {set i 0} {$i < [string length $data]} {incr i} {
+						set c [string index $data $i]
+						set cc [scan $c %c]
+						if {$cc < 0x7e && $c ne "\\" && $cc >= 0x20 && $c ne "\""} {
+							append new $c
+						} else {
+							append new "\\u[format %04x $cc]"
+						}
+					}
+					return "\"$new\""
+				}
+			}
+			unknown {
+				if {$data eq "" || $data eq "null"} {
+					return null
+				} elseif {[string is double -strict $data] && ![string equal -nocase $data infinity] && ![string equal -nocase $data nan] && ![string equal -nocase $data -infinity]} {
+					return $data
+				} else {
+					set new ""
+					for {set i 0} {$i < [string length $data]} {incr i} {
+						set c [string index $data $i]
+						set cc [scan $c %c]
+						if {$cc < 0x7e && $c ne "\\" && $cc >= 0x20 && $c ne "\""} {
+							append new $c
+						} else {
+							append new "\\u[format %04x $cc]"
+						}
+					}
+					return "\"$new\""
+				}
+			}
+		}
+	}
+}
+
+if {![file exists autoscripts]} {file mkdir autoscripts}
+readjsonfile
+loadscripts
+putlog "Loading foo.tcl"

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -134,6 +134,7 @@ proc egg_list {idx} {
 }
 
 # Load or unload a script and update JSON field
+# loadme is 0 to unload a script, 1 to load a script
 proc egg_load {idx script loadme} {
   global jsondict
   global eggdir
@@ -157,6 +158,7 @@ proc egg_load {idx script loadme} {
       } else {
         dict set scriptentry config loaded 0
         putdcc $idx "* Removed $script from being loaded. Restart Eggdrop to complete."
+        set found 1
       }
       write_json $script [compile_json {dict config {dict vars {dict * dict}}} $scriptentry]
       readjsonfile
@@ -166,6 +168,7 @@ proc egg_load {idx script loadme} {
   if {!$found} {
     putdcc $idx "* $script not found."
   }
+  return $found
 }
 
 # List variables available for a script
@@ -258,11 +261,15 @@ proc egg_fetch {idx script} {
 
 proc egg_clean {idx script} {
   global eggdir
+  if {![egg_load $idx $script 0]} {
+    putdcc $idx "* Cannot remove $script"
+    return
+  }
   if {[file isdirectory $eggdir/$script]} {
     file delete -force $eggdir/$script
     putdcc $idx "* $script deleted"
   } else {
-    putdcc %idx "* $script not found"
+    putdcc $idx "* $script not found"
   }
 }
 

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -295,20 +295,26 @@ proc egg_update {idx} {
   global version
   global asminor
   global asmajor
+  set found 0
 
   readjsonfile
   set jsondata [send_http "https://www.eggheads.org/wp-json/wp/v2/media?mime_type=application\/x-gzip&orderby=slug&per_page=100&order=asc" 0]
+  set jsondata [send_http "https://www.eggheads.org/wp-content/uploads/2023/05/asman.json" 0]
   set datadict [json::json2dict $jsondata]
   foreach localscript $jsondict {
     foreach remotescript $datadict {
-      if {[string equal -nocase [dict get $remotescript slug] [dict get $localscript name]]} {
-        if { ([dict get $remotescript version_minor] > [dict get $localscript version_minor] &&
-              [dict get $remotescript version_major] >= [dict get $localscript version_major]) ||
-             ([dict get $remotescript version_major] > [dict get $localscript version_major]) } {
+      if {[string equal -nocase [dict get $remotescript name] [dict get $localscript name]]} {
+        if { ([dict get $remotescript minor] > [dict get $localscript version_minor] &&
+              [dict get $remotescript major] >= [dict get $localscript version_major]) ||
+             ([dict get $remotescript major] > [dict get $localscript version_major]) } {
           putdcc $idx "* [dict get $localscript name] has an update available."
+          set found 1
         }
       }
     }
+  }
+  if {!$found} {
+    putdcc $idx "* No updates available."
   }
 }
 
@@ -365,6 +371,7 @@ proc egg_fetch {idx script} {
   }
   if {[file isdirectory $eggdir/$script]} {
     putdcc $idx "* Script directory already exists. Not downloading again!"
+    putdcc $idx "* Use \"update $script\" if you're trying to update the script"
     putidx $idx "$cmdtxt"
     return
   }

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -19,7 +19,7 @@ proc console {hand idx arg} {
   set asidx $idx
   setchan $idx 469
   echo $idx 0
-  bind CHAT * * parse_egg
+  bind FILT * * parse_egg
   bind evnt * prerehash {egg_done $asidx}
   putdcc $idx "   _         _                      _       _  "
   putdcc $idx "  /_\\  _   _| |_ ___  ___  ___ _ __(_)_ __ | |_ "
@@ -106,16 +106,11 @@ proc loadscripts {} {
 }
 
 # Initial function called from autoscript console, sends to proper proc based on args
-proc parse_egg {hand chan text} {
+proc parse_egg {idx text} {
     global echostatus
     global oldchan
     global asidx
 
-    # Check if this is the user who triggered the console
-    if {[hand2idx $hand] != $asidx} {
-      return 0
-    }
-    set idx $asidx
 	set args [split $text]
 	set args [lassign $args subcmd arg1 arg2]
 
@@ -147,7 +142,7 @@ proc parse_egg {hand chan text} {
 		putdcc $idx "Missing or unknown subcommand"
         egg_help $idx
 	}
-    return 1
+    return
 }
 
 # List scripts that are locally present in .egg
@@ -368,7 +363,7 @@ proc egg_done {idx arg} {
   global oldchan
   global echostatus
   putdcc $idx "Returning to partyline..."
-  unbind CHAT * * parse_egg
+  unbind FILT * * parse_egg
   unbind EVNT * prerehash {egg_done $asidx}
   echo $idx $echostatus
   setchan $idx $oldchan

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -43,9 +43,14 @@ proc readjsonfile {} {
       putlog "$dirname missing manifest.json, deleting"
     } else {
       set fs [open $dirname/manifest.json r]
-      lappend jsonlist [read $fs]
+      set contents [read $fs]
+      set jcontents [json::json2dict $contents]
+      if {![string equal [dict get $jcontents schema] "1"]} {
+        putlog "$dirname contains invalid manifest.json format, skipping..."
+        continue
+      }
+      lappend jsonlist $contents
       close $fs
-  putlog "arg is $arg"
     }
   }
   set jsondict [json::json2dict "\[[join $jsonlist {,}]\]"]
@@ -100,7 +105,7 @@ proc loadscripts {} {
   }
 }
 
-# Initial function called by .egg command, sends to proper proc based on args
+# Initial function called from autoscript console, sends to proper proc based on args
 proc parse_egg {hand chan text} {
     global echostatus
     global oldchan

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -246,6 +246,7 @@ proc egg_set {idx script setting value} {
         dict set scriptentry config vars $setting value $value
         write_json $script [compile_json {dict config {dict vars {dict * dict}}} $scriptentry]
         putdcc $idx "* ${script}: Variable \"$setting\" set to \"${value}\""
+        putdcc $idx "* Use \"load $script\" to enable this change"
         putidx $idx "$cmdtxt"
         readjsonfile        
       }

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -10,7 +10,7 @@ set jsondict [dict create]
 set asmajor 1
 set asminor 0
 
-bind DCC * autoscript console
+bind DCC n autoscript console
 
 proc console {hand idx arg} {
   global echostatus
@@ -21,8 +21,8 @@ proc console {hand idx arg} {
   set asidx $idx
   setchan $idx 469
   echo $idx 0
-  bind FILT * * parse_egg
-  bind evnt * prerehash {egg_done $asidx}
+  bind FILT n * parse_egg
+  bind evnt n prerehash {egg_done $asidx}
   putdcc $idx "   _         _                      _       _  "
   putdcc $idx "  /_\\  _   _| |_ ___  ___  ___ _ __(_)_ __ | |_ "
   putdcc $idx " //_\\\\| | | | __/ _ \\/ __|/ __| '__| | '_ \\| __|"
@@ -430,8 +430,8 @@ proc egg_done {idx arg} {
   global oldchan
   global echostatus
   putdcc $idx "Returning to partyline..."
-  unbind FILT * * parse_egg
-  unbind EVNT * prerehash {egg_done $asidx}
+  unbind FILT n * parse_egg
+  unbind EVNT n prerehash {egg_done $asidx}
   echo $idx $echostatus
   setchan $idx $oldchan
 }

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -9,8 +9,6 @@ set cmdtxt "\nEnter your command (done to exit):"
 set jsondict [dict create]
 
 bind DCC * autoscript console
-bind dcc * egg parse_egg
-bind dcc * scripts
 
 proc console {hand idx arg} {
   global echostatus
@@ -47,6 +45,7 @@ proc readjsonfile {} {
       set fs [open $dirname/manifest.json r]
       lappend jsonlist [read $fs]
       close $fs
+  putlog "arg is $arg"
     }
   }
   set jsondict [json::json2dict "\[[join $jsonlist {,}]\]"]
@@ -143,7 +142,7 @@ proc parse_egg {hand chan text} {
 		putdcc $idx "Missing or unknown subcommand"
         egg_help $idx
 	}
-  return 1
+    return 1
 }
 
 # List scripts that are locally present in .egg
@@ -267,7 +266,7 @@ proc egg_remote {idx} {
     putdcc $idx "* [dict get $scriptentry slug] ([lindex [regexp -inline {\n.*<p>([^<>]*)</p>} [dict get $scriptentry description rendered]] 1])"
   }
   putdcc $idx "\n"
-  putdcc $idx "* Type '.egg fetch <scriptname>' to download a script"
+  putdcc $idx "* Type 'fetch <scriptname>' to download a script"
   putidx $idx "$cmdtxt"
 }
 
@@ -336,7 +335,7 @@ proc egg_fetch {idx script} {
       exec tar -zxf $eggdir/[dict get $scriptentry slug].tgz -C $eggdir/[dict get $scriptentry slug]
       file delete $eggdir/[dict get $scriptentry slug].tgz
       putdcc $idx "* [dict get $scriptentry slug] downloaded."
-      putdcc $idx "* Use '.egg load [dict get $scriptentry slug]' to load and '.egg config [dict get $scriptentry slug]' to configure."
+      putdcc $idx "* Use 'load [dict get $scriptentry slug]' to load and 'config [dict get $scriptentry slug]' to configure."
       putidx $idx "$cmdtxt"
       readjsonfile
     }

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -88,7 +88,7 @@ proc loadscripts {} {
 proc parse_egg {hand idx text} {
 	set args [split $text]
 	set args [lassign $args subcmd arg1 arg2]
-	if {$subcmd in {remote help}} {
+	if {$subcmd in {remote list help}} {
 		egg_$subcmd $idx
 	} elseif {$subcmd in {config fetch clean}} {
 		if {$arg1 eq ""} {
@@ -176,8 +176,10 @@ proc egg_load {idx script loadme} {
 # List variables available for a script
 proc egg_config {idx script} {
   global jsondict
+  set found 0
   foreach scriptentry $jsondict {
     if {[string match $script [dict get $scriptentry name]]} {
+      set found 1
       if {[dict exists $scriptentry long_description]} {
         putdcc $idx "\n* [dict get $scriptentry long_description]\n\n"
       }
@@ -195,6 +197,9 @@ proc egg_config {idx script} {
         }
       }
     }
+  }
+  if {!$found} {
+    putdcc $idx "Script $script not found."
   }
 }
 

--- a/scripts/autoscripts.tcl
+++ b/scripts/autoscripts.tcl
@@ -18,7 +18,6 @@ proc readjsonfile {} {
   set jsonstring "\["
 ### How to get filepath properly
   foreach dirname [glob -nocomplain -type d -directory $eggdir *] {
-putlog "doing $dirname"
     if {![file exists $dirname/manifest.json]} {
       file delete -force $dirname
       putlog "$dirname missing manifest.json, deleting"

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -1025,7 +1025,7 @@ void check_tcl_chatactbcst(const char *from, int chan, const char *text,
   Tcl_SetVar(interp, "_cab2", (char *) s, 0);
   Tcl_SetVar(interp, "_cab3", (char *) text, 0);
   check_tcl_bind(tl, text, 0, " $_cab1 $_cab2 $_cab3",
-                 MATCH_MASK | BIND_STACKABLE | BIND_WANTRET);
+                 MATCH_MASK | BIND_STACKABLE);
 }
 
 void check_tcl_nkch(const char *ohand, const char *nhand)

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -1025,7 +1025,7 @@ void check_tcl_chatactbcst(const char *from, int chan, const char *text,
   Tcl_SetVar(interp, "_cab2", (char *) s, 0);
   Tcl_SetVar(interp, "_cab3", (char *) text, 0);
   check_tcl_bind(tl, text, 0, " $_cab1 $_cab2 $_cab3",
-                 MATCH_MASK | BIND_STACKABLE);
+                 MATCH_MASK | BIND_STACKABLE | BIND_WANTRET);
 }
 
 void check_tcl_nkch(const char *ohand, const char *nhand)


### PR DESCRIPTION
One-line summary: Add autoscripts feature

Additional description (if needed):
The autoscripts system will allow Eggdrop to download, install, and configure scripts via the partyline. Since it's inception, users have needed to load a Tcl script into Eggdrop by downloading a Tcl file, editing the file to customize settings, and then sourcing that file in the config file. The autoscripts system helps by:

-   Centralizing commonly-used scripts in a single location
-   Allowing scripts to be downloaded via the partyline
-   Allowing script settings to be configured via the partyline
-   Allowing user-written scripts to be managed by the autoscripts system
-   Providing a documented API to write autoscripts-compatible scripts

To take advantage of this, scripts will have to be modified to adhere to a published API and be accompanied by a manifest.json file. Eggheads will host commonly used scripts so that users can download known "good" scripts. Additionally, the API will allow scripts to  be packaged and distributed outside of being downloaded from eggheads.

And obviously the traditional 'source' method of loading scripts is not going away!