### PR TITLE
Fix typo: telneting -> telnetting

### DIFF
--- a/doc/Changes0.9
+++ b/doc/Changes0.9
@@ -271,7 +271,7 @@ Eggdrop Changes (since version 0.8)
   - Revenge routine wasn't checking attributes correctly (fixed)
     Found by: imoq
 
-  - Handle could be too long when telneting in (fixed)
+  - Handle could be too long when telnetting in (fixed)
 
   - Tcl 'botname' wasn't getting set until it joined a channel (fixed)
     Found by: seljo

--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -297,7 +297,7 @@ should read doc/BOTNET before modifying these settings.
 
   listen <port> <mode>
     This opens a telnet port by which you and other bots can interact with
-    the Eggdrop by telneting in.
+    the Eggdrop by telnetting in.
 
     There are more options for the listen command in doc/tcl-commands.doc.
     Note that if you are running more than one bot on the same machine, you
@@ -369,7 +369,7 @@ should read doc/BOTNET before modifying these settings.
     instead.
 
   set use-telnet-banner 0
-    If you want Eggdrop to display a banner when telneting in, set this
+    If you want Eggdrop to display a banner when telnetting in, set this
     setting to 1. The telnet banner is set by 'set telnet-banner'.
 
   set connect-timeout 15
@@ -590,7 +590,7 @@ support.
 
   set ssl-verify-clients 0
     Control certificate verification for SSL listening ports. This includes
-    leaf bots connecting, users telneting in and /ctcp bot chat.
+    leaf bots connecting, users telnetting in and /ctcp bot chat.
 
 Modules
 -------

--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -206,7 +206,7 @@ set help-path "help/"
 #set botnet-nick "LlamaBot"
 
 # This opens a telnet port by which you and other bots can interact with the
-# Eggdrop by telneting in. There are more options for the listen command in
+# Eggdrop by telnetting in. There are more options for the listen command in
 # doc/tcl-commands.doc. Note that if you are running more than one bot on the
 # same machine, you will want to space the telnet ports at LEAST 5 apart,
 # although 10 is even better.
@@ -289,7 +289,7 @@ set ssl-capath "/etc/ssl/"
 #set ssl-verify-bots 0
 
 ## Control certificate verification for SSL listening ports. This includes
-## leaf bots connecting, users telneting in and /ctcp bot chat.
+## leaf bots connecting, users telnetting in and /ctcp bot chat.
 #set ssl-verify-clients 0
 
 

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -279,7 +279,7 @@ set userfile-perm 0600
 #set botnet-nick "LlamaBot"
 
 # This opens a telnet port by which you and other bots can interact with the
-# Eggdrop by telneting in. There are more options for the listen command in
+# Eggdrop by telnetting in. There are more options for the listen command in
 # doc/tcl-commands.doc. Note that if you are running more than one bot on the
 # same machine, you will want to space the telnet ports at LEAST 5 apart,
 # although 10 is even better.
@@ -356,7 +356,7 @@ set stealth-telnets 0
 #set stealth-prompt "login: "
 set stealth-prompt "\n\nNickname.\n"
 
-# If you want Eggdrop to display a banner when telneting in, set this setting
+# If you want Eggdrop to display a banner when telnetting in, set this setting
 # to 1. The telnet banner is set by 'set telnet-banner'.
 set use-telnet-banner 0
 
@@ -497,7 +497,7 @@ set ssl-capath "/etc/ssl/"
 #set ssl-verify-bots 0
 
 # Control certificate verification for SSL listening ports. This includes
-# leaf bots connecting, users telneting in and /ctcp bot chat.
+# leaf bots connecting, users telnetting in and /ctcp bot chat.
 #set ssl-verify-clients 0
 
 

--- a/help/set/cmds1.help
+++ b/help/set/cmds1.help
@@ -167,7 +167,7 @@
    the traditional Eggdrop banner.
 %{help=set use-telnet-banner}%{+n}
 ###  %bset use-telnet-banner%b <0/1>
-   If you want Eggdrop to display a banner when telneting in, set
+   If you want Eggdrop to display a banner when telnetting in, set
    this setting to 1. The telnet banner is set by 'set telnet-banner'.
 %{help=set handlen}%{+n}
 ###  %bset handlen%b
@@ -341,7 +341,7 @@ See also: set ssl-verify-clients
 %{help=set ssl-verify-clients}%{+n}
 ###  %bset ssl-verify-clients%b <#>
    Control certificate verification for SSL listening ports. This includes
-   leaf bots connecting to us, users telneting in and /ctcp bot chat.
+   leaf bots connecting to us, users telnetting in and /ctcp bot chat.
    You can set this by adding together the numbers for all exceptions you
    want to enable. By default certificate verification is disabled and all
    certificates are assumed to be valid.


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix typo: telneting -> telnetting

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
