### PR TITLE
Workaround for usage of Emoji with default TCL_UTF_MAX==3

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -654,6 +654,9 @@ int init_threaddata(int mainthread)
 #ifdef TCL_WORKAROUND_UNICODESUP
 
 /* Based on https://github.com/skeeto/branchless-utf8 which is released into the public domain */
+/* 0 means not utf-8, so the length is still 1 but we can distinguish that case,
+ * that's why len = len + !len is used, to convert 0 to 1 and leave the rest as-is
+ */
 static const char utf8lengths[] = {
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
   0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -96,6 +96,17 @@ int handlen = HANDLEN;
 
 extern Tcl_VarTraceProc traced_myiphostname, traced_natip, traced_remove_pass;
 
+/* Unicode workaround for Tcl versions that only support BMP characters (3 byte utf-8) */
+#if TCL_MAJOR_VERSION == 8 && TCL_MINOR_VERSION >= 5 && TCL_MINOR_VERSION <= 6 && TCL_UTF_MAX < 4
+#  define TCL_WORKAROUND_UNICODESUP 1
+struct tcl_unicodesup_info {
+  const char *subcmd;
+  Tcl_Obj *cmd;
+};
+#endif
+
+
+
 int expmem_tcl()
 {
   return strtot;
@@ -639,6 +650,264 @@ int init_threaddata(int mainthread)
   return 0;
 }
 
+/* workaround for Tcl that does not support unicode outside BMP (3 byte utf-8 characters) */
+#ifdef TCL_WORKAROUND_UNICODESUP
+
+/* Based on https://github.com/skeeto/branchless-utf8 which is released into the public domain */
+static const char utf8lengths[] = {
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
+};
+
+/* quick check if tricks are needed, only if 4-byte utf-8 characters are used */
+int needs_unicodesup(const char *str)
+{
+  while (*str) {
+    int len = utf8lengths[((unsigned char)str[0]) >> 3] + !utf8lengths[((unsigned char)str[0]) >> 3];
+
+    if (len == 4) {
+      return 1;
+    }
+    while (len--) {
+      if (*str++ == '\0') {
+        break;
+      }
+    }
+  }
+  return 0;
+}
+
+/* return a new Tcl_StringObj with 4-byte utf-8 characters replaced by surrogate pairs
+ * - decode 4-byte utf-8 into unicode codepoint c
+ * - calculate high and low surrogate unicode codepoints high/low
+ * - encode high/low as 3-byte utf-8 strings
+ * the length of the result could be len/4*6 bytes long, so
+ * to avoid frequent reallocation/string appending, a temporary buffer is used
+ * for long strings (>512 characters, which does not apply to IRC lines) and assembled to a Tcl_DString
+ * for short strings the 512 character buffer is enough
+ */
+Tcl_Obj *egg_string_unicodesup_surrogate(const char *oldstr, int len)
+{
+  int stridx = 0, bufidx = 0;
+  char buf[512];
+  Tcl_DString ds;
+  Tcl_Obj *result;
+
+  /* chunked */
+  if (len > sizeof buf) {
+    Tcl_DStringInit(&ds);
+  }
+
+  while (stridx < len) {
+    int charlen = utf8lengths[((unsigned char)oldstr[stridx]) >> 3] + !utf8lengths[((unsigned char)oldstr[stridx])>> 3];
+
+    if (charlen == 4 && stridx + 4 <= len) {
+      uint32_t c;
+      uint16_t high, low;
+
+      /* decode 4-byte utf-8 into unicode codepoint */
+      c  = (uint32_t)(oldstr[stridx++] & 0x07) << 18;
+      c |= (uint32_t)(oldstr[stridx++] & 0x3f) << 12;
+      c |= (uint32_t)(oldstr[stridx++] & 0x3f) <<  6;
+      c |= (uint32_t)(oldstr[stridx++] & 0x3f) <<  0;
+
+      /* calculate high and low surrogate unicode codepoints */
+      c -= 0x10000;
+      high = 0xD800 + ((c & 0xffc00) >> 10);
+      low = 0xDC00 + (c & 0x3ff);
+
+      /* encode high surrogate as utf-8 */
+      buf[bufidx++] = 0xe0 | ((high >> 12) & 0xf);
+      buf[bufidx++] = 0x80 | ((high >> 6) & 0x3f);
+      buf[bufidx++] = 0x80 | ((high >> 0) & 0x3f);
+
+      /* encode low surrogate as utf-8 */
+      buf[bufidx++] = 0xe0 | ((low >> 12) & 0xf);
+      buf[bufidx++] = 0x80 | ((low >> 6) & 0x3f);
+      buf[bufidx++] = 0x80 | ((low >> 0) & 0x3f);
+    } else {
+      /* copy everything else verbatim */
+      while (charlen-- && stridx < len) {
+        buf[bufidx++] = oldstr[stridx++];
+      }
+    }
+    if (len > sizeof buf && bufidx > sizeof buf - 6) {
+      Tcl_DStringAppend(&ds, buf, bufidx);
+      bufidx = 0;
+    }
+  }
+  if (len > sizeof buf && bufidx) {
+    Tcl_DStringAppend(&ds, buf, bufidx);
+    result = Tcl_NewStringObj(Tcl_DStringValue(&ds), Tcl_DStringLength(&ds));
+    Tcl_DStringFree(&ds);
+  } else {
+    result = Tcl_NewStringObj(buf, bufidx);
+  }
+  return result;
+}
+
+/* decode 2 utf-8 sequences that are 3 bytes long and check if they are surrogate pairs */
+int decode_surrogates(const char *str, uint32_t *high, uint32_t *low)
+{
+  *high  = (*str++ & 0xf) << 12;
+  *high |= (*str++ & 0x3f) << 6; 
+  *high |= (*str++ & 0x3f) << 0;
+  if (*high < 0xD800 || *high > 0xDBFF) {
+    return 0;
+  }
+  *low  = (*str++ & 0xf) << 12;
+  *low |= (*str++ & 0x3f) << 6; 
+  *low |= (*str++ & 0x3f) << 0;
+  if (*low < 0xDC00 || *low > 0xDFFF) {
+    return 0;
+  }
+  return 1;
+}
+
+/* returns a new Tcl_StringObj by replacing surrogate pairs back into 4-byte utf-8 sequences
+ * - for every 3-byte utf-8 sequence, check if it's a surrogate pair
+ * - decode into high/low codepoints
+ * - calculate original codepoint and write back a 4-byte utf-8 sequence instead of 3-byte surrogate pairs
+ * the length of the result is guaranteed to be equal or shorter than the original, so malloc(len) is sufficient space
+ */
+Tcl_Obj *egg_string_unicodesup_desurrogate(const char *oldstr, int len)
+{
+  int stridx = 0, bufidx = 0;
+  char *buf = nmalloc(len);
+
+  while (stridx < len) {
+    uint32_t low, high;
+    int charlen = utf8lengths[((unsigned char)oldstr[stridx]) >> 3] + !utf8lengths[((unsigned char)oldstr[stridx]) >> 3];
+
+    if (charlen == 3 && stridx + 6 <= len && utf8lengths[((unsigned char)oldstr[stridx + 3]) >> 3] == 3 && decode_surrogates(oldstr + stridx, &high, &low)) {
+      uint32_t c = 0x10000 + (high - 0xD800) * 0x400 + (low - 0xDC00);
+
+      buf[bufidx++] = 0xF0 | ((c >> 18) & 0x07);
+      buf[bufidx++] = 0x80 | ((c >> 12) & 0x3f);
+      buf[bufidx++] = 0x80 | ((c >>  6) & 0x3f);
+      buf[bufidx++] = 0x80 | ((c >>  0) & 0x3f);
+
+      stridx += 6;
+    } else {
+      while (charlen-- && stridx < len) {
+        buf[bufidx++] = oldstr[stridx++];
+      }
+    }
+  }
+  return Tcl_NewStringObj(buf, bufidx);
+}
+
+/* C function called for ::egg_tcl_tolower/toupper/totitle
+ * context (original Tcl function and which conversion to do) is in cd
+ */
+int egg_string_unicodesup(void *cd, Tcl_Interp *interp, int objc, Tcl_Obj *const orig_objv[])
+{
+  struct tcl_unicodesup_info *info = cd;
+  Tcl_Obj **new_objv;
+  int i;
+  int ret;
+
+  /* impossible? */
+  if (objc == 0) {
+    return Tcl_EvalObjv(interp, objc, orig_objv, 0);
+  }
+  /* new arguments to original Tcl string tolower/toupper/totitle */
+  new_objv = nmalloc(objc * sizeof *new_objv);
+
+  for (i = 0; i < objc; i++) {
+    if (i == 0) {
+      /* overwrite command objv[0] with original Tcl command instead of this function */
+      new_objv[i] = info->cmd;
+    } else if (i == 1 && needs_unicodesup(Tcl_GetString(orig_objv[1]))) {
+      int len;
+      const char *oldstr = Tcl_GetStringFromObj(orig_objv[1], &len);
+
+      /* overwrite string argument by replacing 4-byet utf-8 sequences with surrogate pairs */
+      new_objv[1] = egg_string_unicodesup_surrogate(oldstr, len);
+    } else {
+      /* copy other arguments, e.g. string tolower test 1 2 */
+      new_objv[i] = orig_objv[i];
+    }
+    /* ref count of new objects must be increased before eval and decreased after, orig_objv is read-only */
+    Tcl_IncrRefCount(new_objv[i]);
+  }
+
+  /* call original Tcl function */
+  ret = Tcl_EvalObjv(interp, objc, new_objv, 0);
+
+  /* decrease ref count of new arguments */
+  for (i = 0; i < objc; i++) {
+    Tcl_DecrRefCount(new_objv[i]);
+  }
+  nfree(new_objv);
+  /* overwrite Tcl's result by replacing surrogates back to 4-byte utf-8 sequences*/
+  if (ret == TCL_OK) {
+    int len;
+    Tcl_Obj *resultobj = Tcl_GetObjResult(interp);
+    const char *str = Tcl_GetStringFromObj(resultobj, &len);
+
+    Tcl_SetObjResult(interp, egg_string_unicodesup_desurrogate(str, len));
+  }
+  return ret;
+}
+
+/* register a single workaround command, making the namespace ensemble string <subcmd> call ::egg_string_<subcmd> instead
+ * original command names are ::tcl::string::<subcmd>
+ */
+void init_unicodesup_cmd(Tcl_Obj *ensdict, const char *subcmd, int index)
+{
+  Tcl_Obj *orig_cmd;
+  static struct tcl_unicodesup_info info[3];
+  char buf[64];
+
+  if (Tcl_DictObjGet(interp, ensdict, Tcl_NewStringObj(subcmd, -1), &orig_cmd) != TCL_OK || !orig_cmd) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup could not find string %s subcommand", subcmd);
+    return;
+  }
+
+  info[index].subcmd = subcmd;
+  info[index].cmd = orig_cmd;
+  Tcl_IncrRefCount(orig_cmd);
+
+  snprintf(buf, sizeof buf, "::egg_string_%s", subcmd);
+  Tcl_CreateObjCommand(interp, buf, egg_string_unicodesup, &info[index], NULL);
+
+  if (Tcl_DictObjPut(interp, ensdict, Tcl_NewStringObj(subcmd, -1), Tcl_NewStringObj(buf, -1)) != TCL_OK) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup could not set dictionary redirect");
+    return;
+  }
+}
+
+/* register all workaround functions */
+void init_unicodesup(void)
+{
+  Tcl_Obj *ensdict;
+  Tcl_Command enscmd = Tcl_FindEnsemble(interp, Tcl_NewStringObj("string", -1), 0);
+
+  if (!enscmd) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup could not find string command");
+    return;
+  }
+  if (!Tcl_IsEnsemble(enscmd)) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup is not a namespace ensemble");
+    return;
+  }
+  if (Tcl_GetEnsembleMappingDict(interp, enscmd, &ensdict) != TCL_OK || !ensdict) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup could not get namespace ensemble dictionary");
+    return;
+  }
+
+  init_unicodesup_cmd(ensdict, "tolower", 0);
+  init_unicodesup_cmd(ensdict, "toupper", 1);
+  init_unicodesup_cmd(ensdict, "totitle", 2);
+
+  if (Tcl_SetEnsembleMappingDict(interp, enscmd, ensdict) != TCL_OK) {
+    putlog(LOG_MISC, "*", "ERROR: Tcl non-BMP unicodesup could not set namespace ensemble dictionary");
+    return;
+  }
+}
+#endif /* TCL_WORKAROUND_UNICODESUP */
+
 /* Not going through Tcl's crazy main() system (what on earth was he
  * smoking?!) so we gotta initialize the Tcl interpreter
  */
@@ -769,6 +1038,9 @@ resetPath:
   }
   Tcl_PkgProvide(interp, "eggdrop", pver);
 
+#ifdef TCL_WORKAROUND_UNICODESUP
+  init_unicodesup();
+#endif
   /* Initialize binds and traces */
   init_bind();
   init_traces();


### PR DESCRIPTION
Ugly workaround that does not break current usage of emoji in the Tcl API. Our usage of the Tcl API is not correct because Eggdrop is encoding agnostic, and processes byte arrays only. Those however get passed to Tcl as strings, when they are not. The real solution is fairly complex (decode all bytes into strings with the proper encoding guess from/to the Tcl API).

If users are unable to recompile Tcl with increased TCL_UTF_MAX and are stuck with 8.6 stable (8.7 is not released as stable at the time of this PR), this should be a suitable, albeit ugly and complex, workaround that keeps emoji support alive.

We do not wish to break the currently working emoji usage however, which mostly works in the current state, except for a crash if passed to [string tolower/toupper/totitle], other problematic call sites aren't known.

So we overwrite Tcl's string tolower/toupper/totitle with our own version that:
- detects utf-8 sequences that are 4 bytes
- converts them into utf-8 encoded surrogate pairs before Tcl's string functions are called
- those remain untouched by case changes in Tcl
- convert the surrogate pairs back in the result to the original utf-8 4-byte code sequences

Side effect is that we also convert surrogate pairs if they were sent as such, which should not have a negative impact on existing scripts.

Single-byte encodings being valid 4-byte emoji sequences or 6-byte surrogate pairs is hopefully highly unlikely.

Found by: Empus
Patch by: thommey
Fixes: #1163 