### PR TITLE
Update help file, remove surplus empty line

### DIFF
--- a/src/mod/ctcp.mod/help/set/ctcp.help
+++ b/src/mod/ctcp.mod/help/set/ctcp.help
@@ -3,7 +3,7 @@
    Specifies the response the bot gives to a CTCP FINGER request.
 
    For example:
-      .set ctcp-finger "Robey (robey@wc130), idle 0 seconds"
+      .set ctcp-finger "(lamer@lamest.lame.org) Idle 0 seconds"
 
 See also: set ctcp-version, set ctcp-userinfo
 %{help=set ctcp-userinfo}%{+n}
@@ -16,11 +16,7 @@ See also: set ctcp-version, set ctcp-finger
    Specifies the response to send to a CTCP VERSION request.
 
    For example:
-      .set ctcp-version "Irssi 0.8.9"
-
-   Or
-      .set ctcp-version "xchat 2.0.7 Linux 2.6.5-1.358smp [i686/2.60GHz/SMP]"
-
+      .set ctcp-version "irssi v1.4.3 - running on Linux x86_64"
 
 See also: set ctcp-finger, set ctcp-userinfo
 %{help=set ctcp-mode}%{+n}

--- a/src/mod/irc.mod/help/irc.help
+++ b/src/mod/irc.mod/help/irc.help
@@ -113,7 +113,6 @@ See also: kickban, console
    channel the bot monitors. Appending a prefix of - or @ to a nickname
    changes the banmask used:
 
-
      For example, with a hostmask of nick!ident@host.name.domain:
 
         Command         Banmask


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Update help file, remove surplus empty line

Additional description (if needed):
The ctcp string was taken from original irssi client :)

Test cases demonstrating functionality (if applicable):
