### PR TITLE
Warn, if pbkdf2 took longer than 100ms

### DIFF
--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -74,7 +74,7 @@ static char *pbkdf2_hash(const char *pass, const char *digest_name,
   unsigned char *buf;
   struct rusage ru1, ru2;
   double utime, stime;
-  /* log only once as long as rounds aint changed */
+  /* log only once as long as rounds are not changed */
   static int rounds_last, responsiveness;
 
   digest = EVP_get_digestbyname(digest_name);
@@ -128,7 +128,7 @@ static char *pbkdf2_hash(const char *pass, const char *digest_name,
       responsiveness = 0;
     }
     if (((utime + stime) > 100.0) && !responsiveness) {
-      putlog(LOG_MISC, "*", "PBKDF2 warning: pbkdf2 method %s rounds %i took more than 100ms (user %.3fms sys %.3fms). Consider lowering pbkdf2-rounds for eggdrops responsiveness.",
+      putlog(LOG_MISC, "*", "PBKDF2 warning: pbkdf2 method %s rounds %i took more than 100ms (user %.3fms sys %.3fms). Consider lowering pbkdf2-rounds for eggdrop's responsiveness.",
              digest_name, rounds, utime, stime);
       responsiveness = 1;
     }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Warn, if pbkdf2 took longer than 100ms. Tell user to consider lowering pbkdf2-rounds

Additional description (if needed):
Eggdrop should be responsive. That means, functions should not block for longer than 100ms. But if the user desides to ignore this, warn only once as long as pbkdf2-rounds setting aint changed.

Test cases demonstrating functionality (if applicable):
```
.console -d
[...]
.set pbkdf2-rounds 300000
[01:55:15] #-HQ# set pbkdf2-rounds 300000
Ok, set.
.chpass testuser 123456
[01:55:22] #-HQ# chpass testuser [something]
Changed password.
.chpass testuser 123456
[01:55:23] #-HQ# chpass testuser [something]
Changed password.
.set pbkdf2-rounds 600000
[01:55:27] #-HQ# set pbkdf2-rounds 600000
Ok, set.
.chpass testuser 123456
[01:55:31] PBKDF2 warning: pbkdf2 method SHA256 rounds 600000 took more than 100ms (user 123.591ms sys 0.000ms). Consider lowering pbkdf2-rounds for eggdrops responsiveness.
[01:55:31] #-HQ# chpass testuser [something]
Changed password.
.chpass testuser 123456
[01:55:32] #-HQ# chpass testuser [something]
Changed password.
```