### PR TITLE
Fix strcpy-param-overlap

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -232,11 +232,7 @@ void splitcn(char *first, char *rest, char divider, size_t max)
   if (first != NULL)
     strlcpy(first, rest, max);
   if (first != rest)
-    /*    In most circumstances, strcpy with src and dst being the same buffer
-     *  can produce undefined results. We're safe here, as the src is
-     *  guaranteed to be at least 2 bytes higher in memory than dest. <Cybah>
-     */
-    strcpy(rest, p + 1);
+    memmove(rest, p + 1, strlen(p + 1) + 1);
 }
 
 char *splitnick(char **blah)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix strcpy-param-overlap

Additional description (if needed):
That source code comment was questionable. What if reverse, 64bit-word or AVX* strcpy() happens?
Additionally, if your distribution or you compile with CFLAGS `-fsanitize=address` it will abort-crash

Test cases demonstrating functionality (if applicable):
CFLAGS `-fsanitize=address`
```
.boot a@aa
[04:43:39] tcl: builtin dcc call: *dcc:boot -HQ 1 a@aa
=================================================================
==718769==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x6290000ad590,0x6290000ad593) and [0x6290000ad592, 0x6290000ad595) overlap
    #0 0x7f0769260007 in __interceptor_strcpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:423
    #1 0x558fa2af0681 in splitcn /home/michael/projects/eggdrop5/eggdrop/src/misc.c:239
[...]
SUMMARY: AddressSanitizer: strcpy-param-overlap /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:423 in __interceptor_strcpy
==718769==ABORTING
$
```