### PR TITLE
Fix localtime() returning NULL

### DIFF
--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -21,6 +21,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <errno.h>
 #include "main.h"
 #include "modules.h"
 #include "tandem.h"
@@ -440,11 +441,16 @@ static int tcl_strftime STDVAR
   else
     t = now;
   tm1 = localtime(&t);
+  if (!tm1) {
+    Tcl_AppendResult(irp, "tcl_strftime(): localtime(): error = ",
+                     strerror(errno), NULL);
+    return TCL_ERROR;
+  }
   if (strftime(buf, sizeof(buf) - 1, argv[1], tm1)) {
     Tcl_AppendResult(irp, buf, NULL);
     return TCL_OK;
   }
-  Tcl_AppendResult(irp, " error with strftime", NULL);
+  Tcl_AppendResult(irp, "tcl_strftime(): strftime(): error", NULL);
   return TCL_ERROR;
 }
 


### PR DESCRIPTION
Found by: michaelortmann 
Patch by: michaelortmann

One-line summary:
handle localtime receiving/returning a NULL