### PR TITLE
Crashfix: maskname() buffer size

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2605,30 +2605,21 @@ char *stripmasktype(int x)
 
 static char *stripmaskname(int x)
 {
-  static char s[161];
-  int i = 0;
+  static char s[128];
+  int i;
 
-  s[i] = 0;
-  if (x & STRIP_COLOR)
-    i += my_strcpy(s + i, "color, ");
-  if (x & STRIP_BOLD)
-    i += my_strcpy(s + i, "bold, ");
-  if (x & STRIP_REVERSE)
-    i += my_strcpy(s + i, "reverse, ");
-  if (x & STRIP_UNDERLINE)
-    i += my_strcpy(s + i, "underline, ");
-  if (x & STRIP_ANSI)
-    i += my_strcpy(s + i, "ansi, ");
-  if (x & STRIP_BELLS)
-    i += my_strcpy(s + i, "bells, ");
-  if (x & STRIP_ORDINARY)
-    i += my_strcpy(s + i, "ordinary, ");
-  if (x & STRIP_ITALICS)
-    i += my_strcpy(s + i, "italics, ");
-  if (!i)
-    strcpy(s, "none");
-  else
+  if ((i = snprintf(s, sizeof s, "%s%s%s%s%s%s%s%s",
+                    (x & STRIP_COLOR) ? "color, " : "",
+                    (x & STRIP_BOLD) ? "bold, " : "",
+                    (x & STRIP_REVERSE) ? "reverse, " : "",
+                    (x & STRIP_UNDERLINE) ? "underline, " : "",
+                    (x & STRIP_ANSI) ? "ansi, " : "",
+                    (x & STRIP_BELLS) ? "bells, " : "",
+                    (x & STRIP_ORDINARY) ? "ordinary, " : "",
+                    (x & STRIP_ITALICS) ? "italics, " : "")))
     s[i - 2] = 0;
+  else
+    strcpy(s, "none");
   return s;
 }
 

--- a/src/flags.c
+++ b/src/flags.c
@@ -206,7 +206,6 @@ char *maskname(int x)
   static char s[6+8+7+13+6+6+6+17+5+7+14+7+9+15+17+17+24+24+(8*9)+1]; /* Change this if you change the levels */
   int i = 0;
 
-  s[0] = 0;
   if (x & LOG_MSGS)
     i += my_strcpy(s, "msgs, "); /* 6 */
   if (x & LOG_PUBLIC)

--- a/src/flags.c
+++ b/src/flags.c
@@ -203,62 +203,36 @@ char *masktype(int x)
 
 char *maskname(int x)
 {
-  static char s[6+8+7+13+6+6+6+17+5+7+14+7+9+15+17+17+24+24+(8*9)+1]; /* Change this if you change the levels */
-  int i = 0;
+  static char s[512];
+  int i;
 
-  if (x & LOG_MSGS)
-    i += my_strcpy(s, "msgs, "); /* 6 */
-  if (x & LOG_PUBLIC)
-    i += my_strcpy(s + i, "public, "); /* 8 */
-  if (x & LOG_JOIN)
-    i += my_strcpy(s + i, "joins, "); /* 7 */
-  if (x & LOG_MODES)
-    i += my_strcpy(s + i, "kicks/modes, "); /* 13 */
-  if (x & LOG_CMDS)
-    i += my_strcpy(s + i, "cmds, "); /* 6 */
-  if (x & LOG_MISC)
-    i += my_strcpy(s + i, "misc, "); /* 6 */
-  if (x & LOG_BOTS)
-    i += my_strcpy(s + i, "bots, "); /* 6 */
-  if (x & LOG_BOTMSG)
-    i += my_strcpy(s + i, "linked bot msgs, "); /* 17 */
-  if ((x & LOG_RAW) && raw_log)
-    i += my_strcpy(s + i, "raw, "); /* 5 */
-  if (x & LOG_FILES)
-    i += my_strcpy(s + i, "files, "); /* 7 */
-  if (x & LOG_SERV)
-    i += my_strcpy(s + i, "server input, "); /* 14 */
-  if (x & LOG_DEBUG)
-    i += my_strcpy(s + i, "debug, "); /* 7 */
-  if (x & LOG_WALL)
-    i += my_strcpy(s + i, "wallops, "); /* 9 */
-  if ((x & LOG_SRVOUT) && raw_log)
-    i += my_strcpy(s + i, "server output, "); /* 15 */
-  if ((x & LOG_BOTNETIN) && raw_log)
-    i += my_strcpy(s + i, "botnet incoming, "); /* 17 */
-  if ((x & LOG_BOTNETOUT) && raw_log)
-    i += my_strcpy(s + i, "botnet outgoing, "); /* 17 */
-  if ((x & LOG_BOTSHRIN) && raw_log)
-    i += my_strcpy(s + i, "incoming share traffic, "); /* 24 */
-  if ((x & LOG_BOTSHROUT) && raw_log)
-    i += my_strcpy(s + i, "outgoing share traffic, "); /* 24 */
-  if (x & LOG_LEV1)
-    i += my_strcpy(s + i, "level 1, "); /* 9 */
-  if (x & LOG_LEV2)
-    i += my_strcpy(s + i, "level 2, "); /* 9 */
-  if (x & LOG_LEV3)
-    i += my_strcpy(s + i, "level 3, "); /* 9 */
-  if (x & LOG_LEV4)
-    i += my_strcpy(s + i, "level 4, "); /* 9 */
-  if (x & LOG_LEV5)
-    i += my_strcpy(s + i, "level 5, "); /* 9 */
-  if (x & LOG_LEV6)
-    i += my_strcpy(s + i, "level 6, "); /* 9 */
-  if (x & LOG_LEV7)
-    i += my_strcpy(s + i, "level 7, "); /* 9 */
-  if (x & LOG_LEV8)
-    i += my_strcpy(s + i, "level 8, "); /* 9 */
-  if (i)
+  if ((i = snprintf(s, sizeof s, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+                    (x & LOG_MSGS)   ? "msgs, " : "",
+                    (x & LOG_PUBLIC) ? "public, " : "",
+                    (x & LOG_JOIN) ? "joins, " : "",
+                    (x & LOG_MODES) ? "kicks/modes, " : "",
+                    (x & LOG_CMDS) ? "cmds, " : "",
+                    (x & LOG_MISC) ? "misc, " : "",
+                    (x & LOG_BOTS) ? "bots, " : "",
+                    (x & LOG_BOTMSG) ? "linked bot msgs, " : "",
+                    ((x & LOG_RAW) && raw_log) ? "raw, " : "",
+                    (x & LOG_FILES) ? "files, " : "",
+                    (x & LOG_SERV) ? "server input, " : "",
+                    (x & LOG_DEBUG) ? "debug, " : "",
+                    (x & LOG_WALL) ? "wallops, " : "",
+                    ((x & LOG_SRVOUT) && raw_log) ? "server output, " : "",
+                    ((x & LOG_BOTNETIN) && raw_log) ? "botnet incoming, " : "",
+                    ((x & LOG_BOTNETOUT) && raw_log) ? "botnet outgoing, " : "",
+                    ((x & LOG_BOTSHRIN) && raw_log) ? "incoming share traffic, " : "",
+                    ((x & LOG_BOTSHROUT) && raw_log) ? "outgoing share traffic, " : "",
+                    (x & LOG_LEV1) ? "level 1, " : "",
+                    (x & LOG_LEV2) ? "level 2, " : "",
+                    (x & LOG_LEV3) ? "level 3, " : "",
+                    (x & LOG_LEV4) ? "level 4, " : "",
+                    (x & LOG_LEV5) ? "level 5, " : "",
+                    (x & LOG_LEV6) ? "level 6, " : "",
+                    (x & LOG_LEV7) ? "level 7, " : "",
+                    (x & LOG_LEV8) ? "level 8, " : "")))
     s[i - 2] = 0;
   else
     strcpy(s, "none");

--- a/src/flags.c
+++ b/src/flags.c
@@ -203,8 +203,8 @@ char *masktype(int x)
 
 char *maskname(int x)
 {
-  static char s[275]; /* Change this if you change the levels */
-  int i = 0;          /* 6+8+7+13+6+6+6+17+5+7+8+7+9+15+17+17+24+24+(8*9)+1 */
+  static char s[6+8+7+13+6+6+6+17+5+7+14+7+9+15+17+17+24+24+(8*9)+1]; /* Change this if you change the levels */
+  int i = 0;
 
   s[0] = 0;
   if (x & LOG_MSGS)
@@ -228,7 +228,7 @@ char *maskname(int x)
   if (x & LOG_FILES)
     i += my_strcpy(s + i, "files, "); /* 7 */
   if (x & LOG_SERV)
-    i += my_strcpy(s + i, "server input, "); /* 8 */
+    i += my_strcpy(s + i, "server input, "); /* 14 */
   if (x & LOG_DEBUG)
     i += my_strcpy(s + i, "debug, "); /* 7 */
   if (x & LOG_WALL)

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -989,7 +989,7 @@ char *channels_start(Function *global_funcs)
          "-autohalfop "
          "-nodesynch "
          "-static ");
-  module_register(MODULE_NAME, channels_table, 1, 3);
+  module_register(MODULE_NAME, channels_table, 1, 2);
   if (!module_depend(MODULE_NAME, "eggdrop", 108, 0)) {
     module_undepend(MODULE_NAME);
     return "This module requires Eggdrop 1.8.0 or later.";

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -989,7 +989,7 @@ char *channels_start(Function *global_funcs)
          "-autohalfop "
          "-nodesynch "
          "-static ");
-  module_register(MODULE_NAME, channels_table, 1, 2);
+  module_register(MODULE_NAME, channels_table, 1, 3);
   if (!module_depend(MODULE_NAME, "eggdrop", 108, 0)) {
     module_undepend(MODULE_NAME);
     return "This module requires Eggdrop 1.8.0 or later.";

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -620,61 +620,34 @@ static void channels_report(int idx, int details)
     dprintf(idx, "%s\n", s);
 
     if (details) {
-      s[0] = 0;
-      i = 0;
-
-      if (channel_enforcebans(chan))
-        i += my_strcpy(s + i, "enforcebans ");
-      if (channel_dynamicbans(chan))
-        i += my_strcpy(s + i, "dynamicbans ");
-      if (!channel_nouserbans(chan))
-        i += my_strcpy(s + i, "userbans ");
-      if (channel_autoop(chan))
-        i += my_strcpy(s + i, "autoop ");
-      if (channel_bitch(chan))
-        i += my_strcpy(s + i, "bitch ");
-      if (channel_greet(chan))
-        i += my_strcpy(s + i, "greet ");
-      if (channel_protectops(chan))
-        i += my_strcpy(s + i, "protectops ");
-      if (channel_protecthalfops(chan))
-        i += my_strcpy(s + i, "protecthalfops ");
-      if (channel_protectfriends(chan))
-        i += my_strcpy(s + i, "protectfriends ");
-      if (channel_dontkickops(chan))
-        i += my_strcpy(s + i, "dontkickops ");
-      if (channel_logstatus(chan))
-        i += my_strcpy(s + i, "statuslog ");
-      if (channel_revenge(chan))
-        i += my_strcpy(s + i, "revenge ");
-      if (channel_revenge(chan))
-        i += my_strcpy(s + i, "revengebot ");
-      if (channel_secret(chan))
-        i += my_strcpy(s + i, "secret ");
-      if (channel_shared(chan))
-        i += my_strcpy(s + i, "shared ");
-      if (!channel_static(chan))
-        i += my_strcpy(s + i, "dynamic ");
-      if (channel_autovoice(chan))
-        i += my_strcpy(s + i, "autovoice ");
-      if (channel_autohalfop(chan))
-        i += my_strcpy(s + i, "autohalfop ");
-      if (channel_cycle(chan))
-        i += my_strcpy(s + i, "cycle ");
-      if (channel_seen(chan))
-        i += my_strcpy(s + i, "seen ");
-      if (channel_dynamicexempts(chan))
-        i += my_strcpy(s + i, "dynamicexempts ");
-      if (!channel_nouserexempts(chan))
-        i += my_strcpy(s + i, "userexempts ");
-      if (channel_dynamicinvites(chan))
-        i += my_strcpy(s + i, "dynamicinvites ");
-      if (!channel_nouserinvites(chan))
-        i += my_strcpy(s + i, "userinvites ");
-      if (channel_inactive(chan))
-        i += my_strcpy(s + i, "inactive ");
-      if (channel_nodesynch(chan))
-        my_strcpy(s + i, "nodesynch ");
+      if ((i = snprintf(s, sizeof s, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+                        channel_enforcebans(chan) ? "enforcebans " : "",
+                        channel_dynamicbans(chan) ? "dynamicbans " : "",
+                        !channel_nouserbans(chan) ? "userbans " : "",
+                        channel_autoop(chan) ? "autoop " : "",
+                        channel_bitch(chan) ? "bitch " : "",
+                        channel_greet(chan) ? "greet " : "",
+                        channel_protectops(chan) ? "protectops " : "",
+                        channel_protecthalfops(chan) ? "protecthalfops " : "",
+                        channel_protectfriends(chan) ? "protectfriends " : "",
+                        channel_dontkickops(chan) ? "dontkickops " : "",
+                        channel_logstatus(chan) ? "statuslog " : "",
+                        channel_revenge(chan) ? "revenge " : "",
+                        channel_revengebot(chan) ? "revengebot " : "",
+                        channel_secret(chan) ? "secret " : "",
+                        channel_shared(chan) ? "shared " : "",
+                        !channel_static(chan) ? "dynamic " : "",
+                        channel_autovoice(chan) ? "autovoice " : "",
+                        channel_autohalfop(chan) ? "autohalfop " : "",
+                        channel_cycle(chan) ? "cycle " : "",
+                        channel_seen(chan) ? "seen " : "",
+                        channel_dynamicexempts(chan) ? "dynamicexempts " : "",
+                        !channel_nouserexempts(chan) ? "userexempts " : "",
+                        channel_dynamicinvites(chan) ? "dynamicinvites " : "",
+                        !channel_nouserinvites(chan) ? "userinvites " : "",
+                        channel_inactive(chan) ? "inactive " : "",
+                        channel_nodesynch(chan) ? "nodesynch " : "")))
+        s[i - 2] = 0;
 
       dprintf(idx, "      Options: %s\n", s);
 


### PR DESCRIPTION
Found by: jack3?
Patch by: michaelortmann
Fixes: #1434

One-line summary:
Fix maskname() buffer size

Additional description (if needed):
Bug since eggdrop 1.9.0rc1 https://github.com/eggheads/eggdrop/commit/842ef4454088224bc5e896f5d49e12e8e0138156

Test cases demonstrating functionality (if applicable):
```
.console #test *
[01:34:45] tcl: builtin dcc call: *dcc:console -HQ 1 #test *
[01:34:45] #-HQ# console #test *
=================================================================
==479219==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5616810a4333 at pc 0x561680c6de17 bp 0x7ffc36d10d00 sp 0x7ffc36d10cf0
WRITE of size 1 at 0x5616810a4333 thread T0
    #0 0x561680c6de16 in my_strcpy /home/michael/projects/eggdrop5/eggdrop/src/misc.c:188
    #1 0x561680c40fd1 in maskname /home/michael/projects/eggdrop5/eggdrop/src/flags.c:261
    #2 0x561680bd32ef in do_console /home/michael/projects/eggdrop5/eggdrop/src/cmds.c:751
    #3 0x561680bd466c in cmd_console /home/michael/projects/eggdrop5/eggdrop/src/cmds.c:782
    #4 0x561680cd0986 in builtin_dcc /home/michael/projects/eggdrop5/eggdrop/src/tclhash.c:678
    #5 0x561680ca5e05 in tcl_call_stringproc_cd /home/michael/projects/eggdrop5/eggdrop/src/tcl.c:334
    #6 0x7fdf4b47f61f in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x4061f)
    #7 0x7fdf4b481664 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42664)
    #8 0x7fdf4b481f26 in Tcl_EvalEx (/usr/lib/libtcl8.6.so+0x42f26)
    #9 0x7fdf4b481f49 in Tcl_Eval (/usr/lib/libtcl8.6.so+0x42f49)
    #10 0x7fdf4b48256f in Tcl_VarEvalVA (/usr/lib/libtcl8.6.so+0x4356f)
    #11 0x7fdf4b48264d in Tcl_VarEval (/usr/lib/libtcl8.6.so+0x4364d)
    #12 0x561680cd127b in trigger_bind /home/michael/projects/eggdrop5/eggdrop/src/tclhash.c:742
    #13 0x561680cd2896 in check_tcl_bind /home/michael/projects/eggdrop5/eggdrop/src/tclhash.c:942
    #14 0x561680cd310b in check_tcl_dcc /home/michael/projects/eggdrop5/eggdrop/src/tclhash.c:974
    #15 0x561680c0ce17 in dcc_chat /home/michael/projects/eggdrop5/eggdrop/src/dcc.c:1068
    #16 0x561680c63da6 in mainloop main.c:857
    #17 0x561680c67f89 in main main.c:1274
    #18 0x7fdf4a43c78f  (/usr/lib/libc.so.6+0x2378f)
    #19 0x7fdf4a43c849 in __libc_start_main (/usr/lib/libc.so.6+0x23849)
    #20 0x561680b71414 in _start (/home/michael/eggdrop/eggdrop-1.9.5+0x275414)

0x5616810a4333 is located 0 bytes to the right of global variable 's' defined in 'flags.c:206:15' (0x5616810a4220) of size 275
SUMMARY: AddressSanitizer: global-buffer-overflow /home/michael/projects/eggdrop5/eggdrop/src/misc.c:188 in my_strcpy
Shadow bytes around the buggy address:
  0x0ac35020c810: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c820: f9 f9 f9 f9 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9
  0x0ac35020c830: 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 03
  0x0ac35020c840: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c850: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0ac35020c860: 00 00 00 00 00 00[03]f9 f9 f9 f9 f9 00 00 00 00
  0x0ac35020c870: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c890: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c8a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac35020c8b0: f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==479219==ABORTING
```