### PR TITLE
Fix the bot reporting about bot-/user-only ports

### DIFF
--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -430,5 +430,5 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0xe33,Mistede telnet forbindelse fra %s mens der blev tjekket for dubletter
 0xe34,TIMEOUT ident forbindelse
 0xe35,Please remove the #comment from your listen setting and try again
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,This port is for bots only
+0xe37,This port is for users only (no bots)

--- a/language/core.danish.lang
+++ b/language/core.danish.lang
@@ -430,3 +430,5 @@ Telnet botten og skriv 'NEW' som dit nick.\n
 0xe33,Mistede telnet forbindelse fra %s mens der blev tjekket for dubletter
 0xe34,TIMEOUT ident forbindelse
 0xe35,Please remove the #comment from your listen setting and try again
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -430,5 +430,5 @@ Telnet to the bot and enter 'NEW' as your handle.
 0xe33,Lost telnet connection from %s while checking for duplicate
 0xe34,TIMEOUT ident connection
 0xe35,Please remove the #comment from your listen setting and try again
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,This port is for bots only
+0xe37,This port is for users only (no bots)

--- a/language/core.english.lang
+++ b/language/core.english.lang
@@ -430,3 +430,5 @@ Telnet to the bot and enter 'NEW' as your handle.
 0xe33,Lost telnet connection from %s while checking for duplicate
 0xe34,TIMEOUT ident connection
 0xe35,Please remove the #comment from your listen setting and try again
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -430,5 +430,5 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0xe33,Telnet yhteys hukattu %s silläaikaa kun tarkistettiin tuplausta
 0xe34,Kadotettu ident yhteys
 0xe35,Please remove the #comment from your listen setting and try again
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,This port is for bots only
+0xe37,This port is for users only (no bots)

--- a/language/core.finnish.lang
+++ b/language/core.finnish.lang
@@ -430,3 +430,5 @@ Telnettaa botille ja syötä 'UUSI' kuin sinun nickkisi.
 0xe33,Telnet yhteys hukattu %s silläaikaa kun tarkistettiin tuplausta
 0xe34,Kadotettu ident yhteys
 0xe35,Please remove the #comment from your listen setting and try again
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -431,5 +431,5 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
 0xe34,Timeout ident connection
 0xe35,Please remove the #comment from your listen setting and try again
-0xe36,This port is for bots only
-0xe37,This port is for users only (no bots)
+0xe36,Ce port est réservé aux bots
+0xe37,Ce port est réservé aux utilisateurs (pas de bots)

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -431,3 +431,5 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
 0xe34,Timeout ident connection
 0xe35,Please remove the #comment from your listen setting and try again
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/language/core.french.lang
+++ b/language/core.french.lang
@@ -431,5 +431,5 @@ Faites un Telnet sur le bot et entrez 'NEW' comme surnom.
 0xe33,Connexion telnet de %s perdue pendant la vérification des doublons
 0xe34,Timeout ident connection
 0xe35,Please remove the #comment from your listen setting and try again
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,This port is for bots only
+0xe37,This port is for users only (no bots)

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -439,5 +439,5 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe33,Telnet-Verbindung von %s waerend Kontrolle auf Duplikat verloren
 0xe34,Zeitueberschreitung bei der Ident-Verbindung
 0xe35,Bitte entferne den #Kommentar im listen-Befehl und versuche es erneut
-0xe36,Dieser Telnet-Port ist nur fuer Bots.
-0xe37,Dieser Telnet-Port ist nur fuer Benutzer (keine Bots).
+0xe36,Dieser Port ist nur fuer Bots
+0xe37,Dieser Port ist nur fuer Benutzer (keine Bots)

--- a/language/core.german.lang
+++ b/language/core.german.lang
@@ -279,7 +279,7 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0x90b,Missbrauch eines Desync
 0x90c,Flood
 
-0xa00,keine ignorierten User
+0xa00,keine ignorierten Benutzer 
 0xa01,Im Moment werden ignoriert
 0xa02,Ignoriere nicht mehr
 
@@ -439,3 +439,5 @@ Baue eine Telnetverbindung zu dem Bot auf und gib 'NEW' als Deinen Nickname ein.
 0xe33,Telnet-Verbindung von %s waerend Kontrolle auf Duplikat verloren
 0xe34,Zeitueberschreitung bei der Ident-Verbindung
 0xe35,Bitte entferne den #Kommentar im listen-Befehl und versuche es erneut
+0xe36,Dieser Telnet-Port ist nur fuer Bots.
+0xe37,Dieser Telnet-Port ist nur fuer Benutzer (keine Bots).

--- a/language/core.italian.lang
+++ b/language/core.italian.lang
@@ -434,3 +434,5 @@ Connetti in telnet il bot e  scrivi 'NEW' come tuo soprannome.
 0xe33,Connessione telnet persa da %s mentre controllo se è un duplicato
 0xe34,Connessione ident fuori tempo
 0xe35,Per favore togli il #commento dalle tue impostazione di ascolto e riprova
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/language/core.italian.lang
+++ b/language/core.italian.lang
@@ -434,5 +434,5 @@ Connetti in telnet il bot e  scrivi 'NEW' come tuo soprannome.
 0xe33,Connessione telnet persa da %s mentre controllo se è un duplicato
 0xe34,Connessione ident fuori tempo
 0xe35,Per favore togli il #commento dalle tue impostazione di ascolto e riprova
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,Questa porta è solo per bot
+0xe37,Questa porta è solo per utenti (non bot)

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -430,5 +430,5 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
 0xe34,Timeout em ligação de identificação
 0xe35,Por favor, remova o #comentário na configuração de listen e tente novamente
-0xe36,This port is for bots only
-0xe37,This port is for users only (no bots)
+0xe36,Esta porta é apenas para bots
+0xe37,Esta porta é apenas para utilizadores (sem bots)

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -430,5 +430,5 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
 0xe34,Timeout em ligação de identificação
 0xe35,Por favor, remova o #comentário na configuração de listen e tente novamente
-0xe36,This telnet port is for bots only.
-0xe37,This telnet port is for users only (no bots).
+0xe36,This port is for bots only
+0xe37,This port is for users only (no bots)

--- a/language/core.portuguese.lang
+++ b/language/core.portuguese.lang
@@ -430,3 +430,5 @@ Entre em ligação telnet com o bot e digite 'NEW' como o seu nick.
 0xe33,Perdida ligação telnet de %s aquando verificação de duplicados
 0xe34,Timeout em ligação de identificação
 0xe35,Por favor, remova o #comentário na configuração de listen e tente novamente
+0xe36,This telnet port is for bots only.
+0xe37,This telnet port is for users only (no bots).

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1578,8 +1578,16 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
 #endif
   /* Make sure users-only/bots-only connects are honored */
   if ((dcc[idx].status & STAT_BOTONLY) && !glob_bot(fr)) {
-    dprintf(idx, "This telnet port is for bots only.\n");
-    putlog(LOG_BOTS, "*", DCC_NONBOT, dcc[idx].host);
+    if (dcc[idx].user) {
+      if (!stealth_telnets)
+        dprintf(idx, "%s\n", DCC_NONBOT2);
+      putlog(LOG_BOTS, "*", DCC_NONBOT, dcc[idx].host);
+    }
+    else {
+      if (!stealth_telnets)
+        dprintf(idx, "You don't have access.\n");
+      putlog(LOG_MISC, "*", DCC_INVHANDLE, dcc[idx].host, buf);
+    }
     killsock(dcc[idx].sock);
     lostdcc(idx);
     return;
@@ -1587,7 +1595,8 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
   if ((dcc[idx].status & STAT_USRONLY) && glob_bot(fr)) {
     /* change here temp to use bot output */
     dcc[idx].type = &DCC_BOT_NEW;
-    dprintf(idx, "error Only users may connect at this port.\n");
+    if (!stealth_telnets)
+      dprintf(idx, "%s\n", DCC_NONUSER2);
     dcc[idx].type = old;
     putlog(LOG_BOTS, "*", DCC_NONUSER, dcc[idx].host);
     killsock(dcc[idx].sock);
@@ -1612,7 +1621,8 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
     ok = 1;
 
   if (!ok) {
-    dprintf(idx, "You don't have access.\n");
+    if (!stealth_telnets)
+      dprintf(idx, "You don't have access.\n");
     putlog(LOG_MISC, "*", DCC_INVHANDLE, dcc[idx].host, buf);
     killsock(dcc[idx].sock);
     lostdcc(idx);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1579,13 +1579,13 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
   /* Make sure users-only/bots-only connects are honored */
   if ((dcc[idx].status & STAT_BOTONLY) && !glob_bot(fr)) {
     if (dcc[idx].user) {
-      if (!stealth_telnets)
-        dprintf(idx, "%s\n", DCC_NONBOT2);
+      dprintf(idx, "%s\n", DCC_NONBOT2);
       putlog(LOG_BOTS, "*", DCC_NONBOT, dcc[idx].host);
     }
     else {
-      if (!stealth_telnets)
+      if (!stealth_telnets) {
         dprintf(idx, "You don't have access.\n");
+      }
       putlog(LOG_MISC, "*", DCC_INVHANDLE, dcc[idx].host, buf);
     }
     killsock(dcc[idx].sock);
@@ -1595,8 +1595,7 @@ static void dcc_telnet_id(int idx, char *buf, int atr)
   if ((dcc[idx].status & STAT_USRONLY) && glob_bot(fr)) {
     /* change here temp to use bot output */
     dcc[idx].type = &DCC_BOT_NEW;
-    if (!stealth_telnets)
-      dprintf(idx, "%s\n", DCC_NONUSER2);
+    dprintf(idx, "%s\n", DCC_NONUSER2);
     dcc[idx].type = old;
     putlog(LOG_BOTS, "*", DCC_NONUSER, dcc[idx].host);
     killsock(dcc[idx].sock);

--- a/src/lang.h
+++ b/src/lang.h
@@ -490,5 +490,7 @@
 #define DCC_LOSTDUP             get_language(0xe33)
 #define DCC_TIMEOUTIDENT        get_language(0xe34)
 #define DCC_BADLISTEN           get_language(0xe35)
+#define DCC_NONBOT2             get_language(0xe36)
+#define DCC_NONUSER2            get_language(0xe37)
 
 #endif /* _EGG_LANG_H */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix the bot reporting about bot-/user-only ports

Additional description (if needed):
Fix messages to incomming telnets regarding if the port is bot- ode user-only
also enhance stealth-telnets setting
Make those strings language-aware / translatable

Test cases demonstrating functionality (if applicable):
Telnettet to the bot in different configurations.
Mixes user-bot-port vs. bot-only vs. user-only port
With and without stealth-telnets set
With english and german language set
Tried Nicknames that were a) known users, b) known bots, c) no known nicknames