### PR TITLE
Cleanup alloc()

### DIFF
--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -445,7 +445,7 @@ void reset_chan_info(struct chanset_t *chan, int reset, int do_reset)
     /* done here to keep expmem happy, as this is accounted in
        irc.mod, not channels.mod where clear_channel() resides */
     nfree(chan->channel.key);
-    chan->channel.key = (char *) channel_malloc (1);
+    chan->channel.key = (char *) channel_malloc(1);
     chan->channel.key[0] = 0;
     chan->status &= ~CHAN_ASKEDMODES;
     dprintf(DP_MODE, "MODE %s\n", chan->name);

--- a/src/net.c
+++ b/src/net.c
@@ -1199,7 +1199,7 @@ int sockgets(char *s, int *len)
     return socklist[ret].sock;
   }
   if (socklist[ret].flags & SOCK_BUFFER) {
-    socklist[ret].handler.sock.inbuf = (char *) nrealloc(socklist[ret].handler.sock.inbuf,
+    socklist[ret].handler.sock.inbuf = nrealloc(socklist[ret].handler.sock.inbuf,
                                             socklist[ret].handler.sock.inbuflen + *len + 1);
     memcpy(socklist[ret].handler.sock.inbuf + socklist[ret].handler.sock.inbuflen, xx, *len);
     socklist[ret].handler.sock.inbuflen += *len;
@@ -1325,7 +1325,7 @@ void tputs(int z, char *s, unsigned int len)
 
       if (socklist[i].handler.sock.outbuf != NULL) {
         /* Already queueing: just add it */
-        p = (char *) nrealloc(socklist[i].handler.sock.outbuf, socklist[i].handler.sock.outbuflen + len);
+        p = nrealloc(socklist[i].handler.sock.outbuf, socklist[i].handler.sock.outbuflen + len);
         memcpy(p + socklist[i].handler.sock.outbuflen, s, len);
         socklist[i].handler.sock.outbuf = p;
         socklist[i].handler.sock.outbuflen += len;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup alloc()

Additional description (if needed):
No functional change

Test cases demonstrating functionality (if applicable):
