### PR TITLE
Fix connection refused detection under cygwin

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1401,6 +1401,9 @@ static void dcc_telnet_hostresolved(int i)
   strcpy(dcc[j].nick, "*");
   dcc[j].u.ident_sock = dcc[i].sock;
   dcc[j].timeval = now;
+#ifdef CYGWIN_HACKS
+  threaddata()->socklist[findsock(dcc[j].sock)].flags = SOCK_CONNECT;
+#endif
   dprintf(j, "%d, %d\n", dcc[i].port, dcc[idx].port);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix connection refused detection under cygwin

Additional description (if needed):
Under cygwin `getsockopt()` doesnt return `ECONNREFUSED` for non-blocking socket `connect()`. Instead, `select()` returns socket as writeable and `write()` returns `ENOTCONN`, see also: https://pubs.opengroup.org/onlinepubs/007904975/functions/select.html. We need to do `getsockopt(SO_ERROR)` after `select(write)` to find out, whether a writeable socket means we are connected or connection refused.

Test cases demonstrating functionality (if applicable):
**Test 1 - server connect:**
Before:
```
[10:42:46] Trying server 127.0.0.1:6667
[10:42:46] net: open_telnet_raw(): idx 2 host 127.0.0.1 ip 127.0.0.1 port 6667 ssl 0
[10:42:48] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 6
[10:42:49] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 6
[10:42:50] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 6
```
After:
```
[02:49:03] Trying server 127.0.0.1:6667
[02:49:03] net: open_telnet_raw(): idx 2 host 127.0.0.1 ip 127.0.0.1 port 6667 ssl 0
[02:49:06] Connection refused: 127.0.0.1:6667
[02:49:06] Disconnected from 127.0.0.1
```
`Test 2 - ident of a telnet connect to the bot`
Before:
```
[02:59:15] Telnet connection: 192.168.16.3/50838
[02:59:17] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 8
[02:59:18] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 8
[02:59:19] dequeue_sockets(): errno = 128 (Transport endpoint is not connected) on 8
```
After:
```
[02:55:36] Telnet connection: 192.168.16.3/38754
[02:55:38] Connection refused: 192.168.16.3:113
[02:55:38] EOF ident connection
```
This means, without this fix, the user would have to wait until ident-timeout, probably throw windrop (eggdrop) into the trashcan and leave.