### PR TITLE
Fix remaining openssl3 md5 deprecation warning

### DIFF
--- a/src/md5/md5.h
+++ b/src/md5/md5.h
@@ -28,7 +28,7 @@
 
 #include "src/main.h"
 
-#ifdef HAVE_OPENSSL_MD5
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L) && defined(HAVE_OPENSSL_MD5)
 #  include <openssl/md5.h>
 #else
 


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix remaining openssl3 md5 deprecation warning for eggdrop module API by using eggdrops fallback md5/

Additional description (if needed):
Fixes the following:
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c modules.c
modules.c:562:3: warning: ‘MD5_Init’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  562 |   (Function) MD5_Init,
      |   ^
In file included from md5/md5.h:32,
                 from modules.c:30:
/usr/include/openssl/md5.h:49:27: note: declared here
   49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
      |                           ^~~~~~~~
modules.c:563:3: warning: ‘MD5_Update’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  563 |   (Function) MD5_Update,
      |   ^
/usr/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
modules.c:564:3: warning: ‘MD5_Final’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  564 |   (Function) MD5_Final,
      |   ^
/usr/include/openssl/md5.h:51:27: note: declared here
   51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
      |                           ^~~~~~~~~
```

Test cases demonstrating functionality (if applicable):
`make` with openssl version 3
we should also test this PR with openssl version < 3
and should also test this PR with no openssl / disabled ssl