### PR TITLE
Fix egggdrop typo

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -112,7 +112,7 @@
 </section>
 <section id="how-to-get-eggdrop">
 <h2>How to get Eggdrop<a class="headerlink" href="#how-to-get-eggdrop" title="Permalink to this heading">¶</a></h2>
-<p>The Eggdrop project source code is hosted at <a class="reference external" href="https://github.com/eggheads/egggdrop">https://github.com/eggheads/egggdrop</a>. You can clone it via git, or alternatively a copy of the current stable snapshot is located at <a class="reference external" href="https://geteggdrop.com">https://geteggdrop.com</a>. Additional information can be found on the official Eggdrop webpage at <a class="reference external" href="https://www.eggheads.org">https://www.eggheads.org</a>. For more information, see <a class="reference external" href="install/install.html">Installing Eggdrop</a></p>
+<p>The Eggdrop project source code is hosted at <a class="reference external" href="https://github.com/eggheads/eggdrop">https://github.com/eggheads/eggdrop</a>. You can clone it via git, or alternatively a copy of the current stable snapshot is located at <a class="reference external" href="https://geteggdrop.com">https://geteggdrop.com</a>. Additional information can be found on the official Eggdrop webpage at <a class="reference external" href="https://www.eggheads.org">https://www.eggheads.org</a>. For more information, see <a class="reference external" href="install/install.html">Installing Eggdrop</a></p>
 </section>
 <section id="how-to-install-eggdrop">
 <h2>How to install Eggdrop<a class="headerlink" href="#how-to-install-eggdrop" title="Permalink to this heading">¶</a></h2>

--- a/doc/sphinx_source/index.rst
+++ b/doc/sphinx_source/index.rst
@@ -20,7 +20,7 @@ Eggdrop has a large number of features, such as:
 How to get Eggdrop
 ------------------
 
-The Eggdrop project source code is hosted at https://github.com/eggheads/egggdrop. You can clone it via git, or alternatively a copy of the current stable snapshot is located at https://geteggdrop.com. Additional information can be found on the official Eggdrop webpage at https://www.eggheads.org. For more information, see `Installing Eggdrop <install/install.html>`_
+The Eggdrop project source code is hosted at https://github.com/eggheads/eggdrop. You can clone it via git, or alternatively a copy of the current stable snapshot is located at https://geteggdrop.com. Additional information can be found on the official Eggdrop webpage at https://www.eggheads.org. For more information, see `Installing Eggdrop <install/install.html>`_
 
 How to install Eggdrop
 ----------------------


### PR DESCRIPTION
Found by: @iamnimnul
Patch by: @iamnimnul
Fixes: docs

One-line summary:
Fixed "egggdrop" typo in docs

Additional description (if needed):
-

Test cases demonstrating functionality (if applicable):
-