### PR TITLE
Crash fix: dont create threads as detached but join

### DIFF
--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -793,6 +793,7 @@ enum {
 
 /* linked list instead of array because of multi threading */
 struct dns_thread_node {
+  pthread_t thread_id;
   pthread_mutex_t mutex;
   int fildes[2];
   int type;

--- a/src/net.c
+++ b/src/net.c
@@ -1066,7 +1066,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
         pthread_mutex_unlock(&dtn->mutex);
       }
       close(dtn->fildes[0]);
-      if (!pthread_join(dtn->thread_id, &res))
+      if (pthread_join(dtn->thread_id, &res))
         putlog(LOG_MISC, "*", "sockread(): pthread_join(): error = %s", strerror(errno));
       dtn_prev->next = dtn->next;
       nfree(dtn);

--- a/src/net.c
+++ b/src/net.c
@@ -898,6 +898,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
 #ifdef EGG_TDNS
   int fd;
   struct dns_thread_node *dtn, *dtn_prev;
+  void *res;
 #endif
 
   maxfd_r = preparefdset(&fdr, slist, slistmax, tclonly, TCL_READABLE);
@@ -1065,6 +1066,8 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
         pthread_mutex_unlock(&dtn->mutex);
       }
       close(dtn->fildes[0]);
+      if (!pthread_join(dtn->thread_id, &res))
+        putlog(LOG_MISC, "*", "sockread(): pthread_join(): error = %s", strerror(errno));
       dtn_prev->next = dtn->next;
       nfree(dtn);
       dtn = dtn_prev;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Crash fix: dont create threads as detached but join

Additional description (if needed):
detached threads could crash eggdrop under cygwin

Test cases demonstrating functionality (if applicable):
tested under windows, linux and netbsd 9.3