### PR TITLE
Update src/compat/explicit_bzero.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,7 @@ AX_TYPE_SOCKLEN_T
 AX_CREATE_STDINT_H([eggint.h])
 
 # Checks for functions and their arguments.
-AC_CHECK_FUNCS([dprintf explicit_bzero explicit_memset getrandom inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
+AC_CHECK_FUNCS([dprintf explicit_bzero memset_explicit explicit_memset getrandom inet_aton isascii memset_s random rand lrand48 snprintf strlcpy vsnprintf])
 AC_FUNC_SELECT_ARGTYPES
 EGG_FUNC_B64_NTOP
 AC_FUNC_MMAP

--- a/src/compat/explicit_bzero.c
+++ b/src/compat/explicit_bzero.c
@@ -22,12 +22,12 @@
 #include <config.h>
 
 #ifndef HAVE_EXPLICIT_BZERO
-/* https://raw.githubusercontent.com/jedisct1/libsodium/d47ded1867af69965b2374b8fb90aee01e6ff291/src/libsodium/sodium/utils.c */
+/* https://raw.githubusercontent.com/jedisct1/libsodium/6e8468d8750aecf91593f28a9d373bb9a5fe326e/src/libsodium/sodium/utils.c */
 
 /*
  * ISC License
  *
- * Copyright (c) 2013-2019
+ * Copyright (c) 2013-2023
  * Frank Denis <j at pureftpd dot org>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
@@ -68,12 +68,14 @@ _sodium_dummy_symbol_to_prevent_memzero_lto(void *const  pnt,
 void
 explicit_bzero(void *const pnt, const size_t len)
 {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__CRT_INLINE)
     SecureZeroMemory(pnt, len);
 #elif defined(HAVE_MEMSET_S)
     if (len > 0U && memset_s(pnt, (rsize_t) len, 0, (rsize_t) len) != 0) {
         fatal("explicit_bzero misuse", 0); /* LCOV_EXCL_LINE */
     }
+#elif defined(HAVE_MEMSET_EXPLICIT)
+    memset_explicit(pnt, 0, len);
 #elif defined(HAVE_EXPLICIT_MEMSET)
     explicit_memset(pnt, 0, len);
 #elif HAVE_WEAK_SYMBOLS


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Update src/compat/explicit_bzero.c

Additional description (if needed):
Enhances win32 support and adds C23 `memset_explicit()` support
Updated to version https://raw.githubusercontent.com/jedisct1/libsodium/6e8468d8750aecf91593f28a9d373bb9a5fe326e/src/libsodium/sodium/utils.c
**Please run `misc/runautotools` after merge into branch develop**

Test cases demonstrating functionality (if applicable):
