### PR TITLE
Fix some prototypes to make clang 16 happy

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -63,7 +63,7 @@ int expmem_tcl();
 int expmem_tclhash();
 int expmem_tclmisc();
 int expmem_net();
-int expmem_modules();
+int expmem_modules(int);
 int expmem_language();
 int expmem_tcldcc();
 int expmem_dns();

--- a/src/modules.c
+++ b/src/modules.c
@@ -102,7 +102,6 @@ extern sock_list *socklist;
 int cmd_die();
 int xtra_kill();
 int xtra_unpack();
-char *check_validpass();
 static int module_rename(char *name, char *newname);
 
 #ifndef STATIC

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -41,22 +41,21 @@ p_tcl_bind_list H_chat, H_act, H_bcst, H_chon, H_chof, H_load, H_unld, H_link,
                 H_note, H_filt, H_event, H_die, H_cron, H_log = NULL;
 #ifdef TLS
 p_tcl_bind_list H_tls = NULL;
-static int builtin_idx();
+static int builtin_idx STDVAR;
 #endif
 
-static int builtin_2char();
-static int builtin_3char();
-static int builtin_5int();
-static int builtin_cron();
-static int builtin_char();
-static int builtin_chpt();
-static int builtin_chjn();
-static int builtin_idxchar();
-static int builtin_charidx();
-static int builtin_chat();
-static int builtin_dcc();
-static int builtin_log();
-
+static int builtin_2char STDVAR;
+static int builtin_3char STDVAR;
+static int builtin_5int STDVAR;
+static int builtin_cron STDVAR;
+static int builtin_char STDVAR;
+static int builtin_chpt STDVAR;
+static int builtin_chjn STDVAR;
+static int builtin_idxchar STDVAR;
+static int builtin_charidx STDVAR;
+static int builtin_chat STDVAR;
+static int builtin_dcc STDVAR;
+static int builtin_log STDVAR;
 
 /* Allocate and initialise a chunk of memory.
  */
@@ -203,9 +202,8 @@ int expmem_tclhash(void)
   return tot;
 }
 
-
 extern cmd_t C_dcc[];
-static int tcl_bind();
+static int tcl_bind STDVAR;
 
 static cd_tcl_cmd cd_cmd_table[] = {
   {"bind",   tcl_bind, (void *) 0},

--- a/src/users.h
+++ b/src/users.h
@@ -180,7 +180,6 @@ extern struct igrec *global_ign;
  * Note: Flags are in eggdrop.h
  */
 
-struct userrec *adduser();
 struct userrec *get_user_by_handle(struct userrec *, char *);
 struct userrec *get_user_by_host(char *);
 struct userrec *get_user_by_account(char *);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix some prototypes to make clang 16 happy

Additional description (if needed):
clang 16 throws a lot of the following warnings:
```
./users.h:183:17: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Wdeprecated-non-prototype]
struct userrec *adduser();
                ^
./proto.h:325:17: note: conflicting prototype is here
struct userrec *adduser(struct userrec *, char *, char *, char *, int);
```

Test cases demonstrating functionality (if applicable):
