### PR TITLE
Enhance error msg and remove superfluous semicolon

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -130,7 +130,7 @@ char *iptostr(struct sockaddr *sa)
  */
 int setsockname(sockname_t *addr, char *src, int port, int allowres)
 {
-  char *endptr, *src2 = src;;
+  char *endptr, *src2 = src;
   long val;
   IP ip;
   volatile int af = AF_UNSPEC;

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1176,15 +1176,22 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     if (strlen(newip)) {
       setsockname(&name, newip, port, 1);
       i = open_address_listen(&name);
+      if (i < 0) {
+        snprintf(msg, sizeof msg, "Couldn't listen on port %d on the given "
+                 "address '%s': %s. Please check that the port is not already in use",
+                  realport, newip, strerror(errno));
+        Tcl_AppendResult(irp, msg, NULL);
+        return TCL_ERROR;
+      }
     } else {
       i = open_listen(&port);
-    }
-    if (i < 0) {
-      egg_snprintf(msg, sizeof msg, "Couldn't listen on port '%d' on the given "
+      if (i < 0) {
+        snprintf(msg, sizeof msg, "Couldn't listen on port %d on the given "
                  "address: %s. Please check that the port is not already in use",
                   realport, strerror(errno));
-      Tcl_AppendResult(irp, msg, NULL);
-      return TCL_ERROR;
+        Tcl_AppendResult(irp, msg, NULL);
+        return TCL_ERROR;
+      }
     }
     idx = new_dcc(&DCC_TELNET, 0);
     dcc[idx].sockname.addrlen = sizeof(dcc[idx].sockname.addr);

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1177,8 +1177,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       setsockname(&name, newip, port, 1);
       i = open_address_listen(&name);
       if (i < 0) {
-        snprintf(msg, sizeof msg, "Couldn't listen on port %d on the given "
-                 "address '%s': %s. Please check that the port is not already in use",
+        snprintf(msg, sizeof msg, "Couldn't listen on port %d on %s: %s. "
+                 "Please check that the port is not already in use",
                   realport, newip, strerror(errno));
         Tcl_AppendResult(irp, msg, NULL);
         return TCL_ERROR;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance error msg and remove superfluous semicolon

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`.tcl listen 1.2.3.4 2345 users`
Before:
```
.tcl listen 1.2.3.4 2345 users
Tcl error: Couldn't listen on port '2345' on the given address: Cannot assign requested address. Please check that the port is not already in use
```
After:
```
Tcl error: Couldn't listen on port 2345 on the given address '1.2.3.4': Cannot assign requested address. Please check that the port is not already in use
```