### PR TITLE
Cleanup

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1354,17 +1354,6 @@ void sub_lang(int idx, char *text)
     dprintf(idx, "%s\n", s);
 }
 
-/* This will return a pointer to the first character after the @ in the
- * string given it.  Possibly it's time to think about a regexp library
- * for eggdrop...
- */
-char *extracthostname(char *hostmask)
-{
-  char *p = strrchr(hostmask, '@');
-
-  return p ? p + 1 : "";
-}
-
 /* Show motd to dcc chatter
  */
 void show_motd(int idx)

--- a/src/net.c
+++ b/src/net.c
@@ -1588,6 +1588,16 @@ int sanitycheck_dcc(char *nick, char *from, char *ipaddy, char *port)
   return 1;
 }
 
+/* This will return a pointer to the first character after the last @ in the
+ * string given it.
+ */
+static char *extracthostname(char *hostmask)
+{
+  char *p = strrchr(hostmask, '@');
+
+  return p ? p + 1 : "";
+}
+
 int hostsanitycheck_dcc(char *nick, char *from, sockname_t *ip, char *dnsname,
                         char *prt)
 {
@@ -1601,12 +1611,12 @@ int hostsanitycheck_dcc(char *nick, char *from, sockname_t *ip, char *dnsname,
   /* It is disabled HERE so we only have to check in *one* spot! */
   if (!dcc_sanitycheck)
     return 1;
-  strlcpy(badaddress, iptostr(&ip->addr.sa), sizeof badaddress);
   strlcpy(hostn, extracthostname(from), sizeof hostn);
   if (!strcasecmp(hostn, dnsname)) {
     putlog(LOG_DEBUG, "*", "DNS information for submitted IP checks out.");
     return 1;
   }
+  strlcpy(badaddress, iptostr(&ip->addr.sa), sizeof badaddress);
   if (!strcmp(badaddress, dnsname))
     putlog(LOG_MISC, "*", "ALERT: (%s!%s) sent a DCC request with bogus IP "
            "information of %s port %s. %s does not resolve to %s!", nick, from,

--- a/src/proto.h
+++ b/src/proto.h
@@ -252,7 +252,6 @@ void rem_help_reference(char *);
 void add_help_reference(char *);
 void debug_help(int);
 void reload_help_data(void);
-char *extracthostname(char *);
 void show_banner(int i);
 void make_rand_str_from_chars(char *, int, char *);
 void make_rand_str(char *, int);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup

Additional description (if needed):
`extracthostname()` had only one caller, so move it over and make it static
this cleanup will later help to cleanup `sanitycheck_dcc()` and fix #102

Test cases demonstrating functionality (if applicable):
No functional change