### PR TITLE
remove quick-logs, line buffer instead

### DIFF
--- a/doc/sphinx_source/tutorials/setup.rst
+++ b/doc/sphinx_source/tutorials/setup.rst
@@ -157,7 +157,7 @@ Now that your Eggdrop is on IRC and you've introduced yourself as owner, it's ti
 No show?
 ~~~~~~~~
 
-If your bot didn't appear on IRC, you should log in to the shell and view the bot's logfile (the default in the config file is "logs/eggdrop.log"). Note that logfile entries are not written to disk immediately unless quick-logs is enabled, so you may have to wait a few minutes before the logfile appears, or contains messages that indicate why your bot isn't showing up.
+If your bot didn't appear on IRC, you should log in to the shell and view the bot's logfile (the default in the config file is "logs/eggdrop.log").
 
 Additionally, you can kill the bot via the command line (``kill pid``, the pid is shown to you when you started the bot or can be viewed by running ``ps x``) and then restart it with the -mnt flag, which will launch you directly into the partyline, to assist with troubleshooting. Note that if you use the -nt flag, the bot will not persist and you will kill it once you quit the partyline.
 

--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -107,13 +107,6 @@ the logfile of the next day.
     reaches the size of 550 kilobytes. Note that this only works if you
     have keep-all-logs set to 0 (OFF).
 
-  set quick-logs 0
-    This could be good if you have had a problem with logfiles filling
-    your quota/hard disk or if you log +p and publish it to the web, and
-    you need more up-to-date info. Note that this setting might increase
-    the CPU usage of your bot (on the other hand it will decrease your RAM
-    usage).
-
   set raw-log 0
     This setting allows you the logging of raw incoming server traffic via
     console/log flag 'r', raw outgoing server traffic via console/log mode

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -157,9 +157,6 @@ set max-logs 20
 # have keep-all-logs 0 (OFF).
 set max-logsize 0
 
-# Interval between logfile saving operations in seconds.
-set log-interval 15
-
 # This setting allows you the logging of raw incoming server traffic via
 # console/log flag 'r', raw outgoing server traffic via console/log mode 'v',
 # raw incoming botnet traffic via console/log mode 't', raw outgoing botnet

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -157,11 +157,8 @@ set max-logs 20
 # have keep-all-logs 0 (OFF).
 set max-logsize 0
 
-# This could be good if you have had problem with the logfile filling
-# your quota/hard disk or if you log +p and publish it to the web and
-# need more up-to-date info. Note that this setting might increase the
-# CPU usage of your bot (on the other hand it will decrease your mem usage).
-set quick-logs 0
+# Interval between logfile saving operations in seconds.
+set log-interval 15
 
 # This setting allows you the logging of raw incoming server traffic via
 # console/log flag 'r', raw outgoing server traffic via console/log mode 'v',

--- a/help/core.help
+++ b/help/core.help
@@ -183,7 +183,6 @@ default-flags
 log-time
 timestamp-format
 max-logsize
-quick-logs
 logfile-suffix
 quiet-save
 remote-boots

--- a/help/set/cmds1.help
+++ b/help/set/cmds1.help
@@ -199,13 +199,6 @@
    This value is in kilobytes, so '550' would mean cycle logs when it
    reaches the size of 550 kilobytes. Note that this only works if you
    have keep-all-logs 0 (OFF).
-%{help=set quick-logs}%{+n}
-###  %bset quick-logs%b <0/1>
-   This could be good if you have had problem with the logfile
-   filling your quota/hard disk or if you log +p and publish it to
-   the web and need more up-to-date info. Note that this setting
-   might increase the CPU usage of your bot (on the other hand it will
-   decrease your mem usage).
 %{help=set logfile-suffix}%{+n}
 ###  %bset logfile-suffix%b <suffix>
    If keep-all-logs is 1, this setting will define the suffix of the

--- a/src/misc.c
+++ b/src/misc.c
@@ -579,8 +579,10 @@ void putlog (int type, char *chname, const char *format, ...)
           if (keep_all_logs) {
             snprintf(path, sizeof path, "%s%s", logs[i].filename, ct);
             logs[i].f = fopen(path, "a");
+            setvbuf(logs[i].f, NULL, _IOLBF, 0); /* line buffered */
           } else
             logs[i].f = fopen(logs[i].filename, "a");
+            setvbuf(logs[i].f, NULL, _IOLBF, 0); /* line buffered */
         }
         if (logs[i].f != NULL) {
           /* Check if this is the same as the last line added to
@@ -651,7 +653,6 @@ void logsuffix_change(char *s)
   }
   for (i = 0; i < max_logs; i++) {
     if (logs[i].f) {
-      fflush(logs[i].f);
       fclose(logs[i].f);
       logs[i].f = NULL;
     }
@@ -676,7 +677,6 @@ void check_logsize()
           if (logs[i].f) {
             /* write to the log before closing it huh.. */
             putlog(LOG_MISC, "*", MISC_CLOGS, logs[i].filename, ss.st_size);
-            fflush(logs[i].f);
             fclose(logs[i].f);
             logs[i].f = NULL;
           }
@@ -690,38 +690,6 @@ void check_logsize()
     }
   }
 }
-
-/* Flush the logfiles to disk
- */
-void flushlogs()
-{
-  int i;
-
-  /* Logs may not be initialised yet. */
-  if (!logs)
-    return;
-
-  /* Now also checks to see if there's a repeat message and
-   * displays the 'last message repeated...' stuff too <cybah>
-   */
-  for (i = 0; i < max_logs; i++) {
-    if (logs[i].f != NULL) {
-      if (logs[i].repeats > 0) {
-        /* Repeat.. display 'last message repeated x times' and reset repeats.
-         */
-        char stamp[33];
-
-        strftime(stamp, sizeof(stamp) - 1, log_ts, localtime(&now));
-        fprintf(logs[i].f, "%s ", stamp);
-        fprintf(logs[i].f, MISC_LOGREPEAT, logs[i].repeats);
-        /* Reset repeats */
-        logs[i].repeats = 0;
-      }
-      fflush(logs[i].f);
-    }
-  }
-}
-
 
 /*
  *     String substitution functions

--- a/src/misc.c
+++ b/src/misc.c
@@ -43,8 +43,7 @@ extern struct chanset_t *chanset;
 
 extern char helpdir[], version[], origbotname[], botname[], admin[], network[],
             motdfile[], ver[], botnetnick[], bannerfile[], textdir[];
-extern int  backgrd, con_chan, term_z, use_stderr, dcc_total, keep_all_logs,
-            quick_logs;
+extern int  backgrd, con_chan, term_z, use_stderr, dcc_total, keep_all_logs;
 
 extern time_t now;
 extern Tcl_Interp *interp;
@@ -707,9 +706,8 @@ void flushlogs()
    */
   for (i = 0; i < max_logs; i++) {
     if (logs[i].f != NULL) {
-      if ((logs[i].repeats > 0) && quick_logs) {
-        /* Repeat.. if quicklogs used then display 'last message
-         * repeated x times' and reset repeats.
+      if (logs[i].repeats > 0) {
+        /* Repeat.. display 'last message repeated x times' and reset repeats.
          */
         char stamp[33];
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -578,10 +578,9 @@ void putlog (int type, char *chname, const char *format, ...)
           /* Open this logfile */
           if (keep_all_logs) {
             snprintf(path, sizeof path, "%s%s", logs[i].filename, ct);
-            logs[i].f = fopen(path, "a");
-            setvbuf(logs[i].f, NULL, _IOLBF, 0); /* line buffered */
-          } else
-            logs[i].f = fopen(logs[i].filename, "a");
+            if ((logs[i].f = fopen(path, "a")))
+              setvbuf(logs[i].f, NULL, _IOLBF, 0); /* line buffered */
+          } else if ((logs[i].f = fopen(logs[i].filename, "a")))
             setvbuf(logs[i].f, NULL, _IOLBF, 0); /* line buffered */
         }
         if (logs[i].f != NULL) {

--- a/src/proto.h
+++ b/src/proto.h
@@ -228,7 +228,6 @@ void debug_mem_to_dcc(int);
 int egg_strcatn(char *, const char *, size_t);
 int my_strcpy(char *, char *);
 void putlog(int type, char *chname, const char *format, ...) ATTRIBUTE_FORMAT(printf,3,4);
-void flushlogs(void);
 void check_logsize(void);
 void splitc(char *, char *, char);
 void splitcn(char *, char *, char, size_t);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -88,7 +88,6 @@ int must_be_owner = 1;
 int quiet_reject = 1;
 int copy_to_tmp = 1;
 int max_socks = 100;
-int log_interval = 15;
 int par_telnet_flood = 1;
 int quiet_save = 0;
 int strtot = 0;
@@ -481,7 +480,6 @@ static tcl_ints def_tcl_ints[] = {
   {"max-socks",             &max_socks,            0},
   {"max-logs",              &max_logs,             0},
   {"max-logsize",           &max_logsize,          0},
-  {"log-interval",          &log_interval,         0},
   {"raw-log",               &raw_log,              1},
   {"protect-telnet",        &protect_telnet,       0},
   {"dcc-sanitycheck",       &dcc_sanitycheck,      0},

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -88,7 +88,7 @@ int must_be_owner = 1;
 int quiet_reject = 1;
 int copy_to_tmp = 1;
 int max_socks = 100;
-int quick_logs = 0;
+int log_interval = 15;
 int par_telnet_flood = 1;
 int quiet_save = 0;
 int strtot = 0;
@@ -481,7 +481,7 @@ static tcl_ints def_tcl_ints[] = {
   {"max-socks",             &max_socks,            0},
   {"max-logs",              &max_logs,             0},
   {"max-logsize",           &max_logsize,          0},
-  {"quick-logs",            &quick_logs,           0},
+  {"log-interval",          &log_interval,         0},
   {"raw-log",               &raw_log,              1},
   {"protect-telnet",        &protect_telnet,       0},
   {"dcc-sanitycheck",       &dcc_sanitycheck,      0},


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1449

One-line summary:
remove quick-logs, line buffer instead

Additional description (if needed):
remove quick-logs
quick logs disabled meant file logfile was buffered with `flush()` every 5 minues
quick logs enabled meant logfile was buffered  `flush()` every minute
now, instead, we dont explicitely flush, but set logfile to line buffered
`setvbuf(_IOLBF)` is posix 2001
**Please regenerate docs via sphinx after merge**

Test cases demonstrating functionality (if applicable):
