### PR TITLE
Fix relay port and log

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1141,33 +1141,14 @@ static void failed_tandem_relay(int idx)
     lostdcc(idx);
     return;
   }
-  if (dcc[idx].port >= dcc[idx].u.relay->port + 3) {
-    struct chat_info *ci = dcc[uidx].u.relay->chat;
-
-    dprintf(uidx, "%s %s.\n", BOT_CANTLINKTO, dcc[idx].nick);
-    dcc[uidx].status = dcc[uidx].u.relay->old_status;
-    nfree(dcc[uidx].u.relay);
-    dcc[uidx].u.chat = ci;
-    dcc[uidx].type = &DCC_CHAT;
-    killsock(dcc[idx].sock);
-    lostdcc(idx);
-    return;
-  }
+  dcc[uidx].status = dcc[uidx].u.relay->old_status;
+  struct chat_info *ci = dcc[uidx].u.relay->chat;
+  nfree(dcc[uidx].u.relay);
+  dcc[uidx].u.chat = ci;
+  dcc[uidx].type = &DCC_CHAT;
   killsock(dcc[idx].sock);
-  if (!dcc[idx].sockname.addrlen)
-    (void) setsockname(&dcc[idx].sockname, dcc[idx].host, dcc[idx].port, 0);
-  dcc[idx].sock = getsock(dcc[idx].sockname.family, SOCK_STRONGCONN);
-  dcc[uidx].u.relay->sock = dcc[idx].sock;
-  dcc[idx].port++;
-  dcc[idx].timeval = now;
-  if (dcc[idx].sock < 0 ||
-      open_telnet_raw(dcc[idx].sock, &dcc[idx].sockname) < 0)
-    failed_tandem_relay(idx);
-#ifdef TLS
-  else if (dcc[idx].ssl && ssl_handshake(dcc[idx].sock, TLS_CONNECT,
-           tls_vfybots, LOG_BOTS, dcc[idx].host, NULL))
-    failed_tandem_relay(idx);
-#endif
+  lostdcc(idx);
+  return;
 }
 
 

--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1141,6 +1141,7 @@ static void failed_tandem_relay(int idx)
     lostdcc(idx);
     return;
   }
+  dprintf(uidx, "%s %s.\n", BOT_CANTLINKTO, dcc[idx].nick);
   dcc[uidx].status = dcc[uidx].u.relay->old_status;
   struct chat_info *ci = dcc[uidx].u.relay->chat;
   nfree(dcc[uidx].u.relay);

--- a/src/misc.c
+++ b/src/misc.c
@@ -614,7 +614,8 @@ void putlog (int type, char *chname, const char *format, ...)
     }
   }
   for (i = 0; i < dcc_total; i++) {
-    if ((dcc[i].type == &DCC_CHAT) && (dcc[i].u.chat->con_flags & type)) {
+    if (((dcc[i].type == &DCC_CHAT) && (dcc[i].u.chat->con_flags & type)) ||
+        ((dcc[i].type == &DCC_PRE_RELAY) && (dcc[i].u.relay->chat->con_flags & type))) {
       if ((chname[0] == '*') || (dcc[i].u.chat->con_chan[0] == '*') ||
           !rfc_casecmp(chname, dcc[i].u.chat->con_chan)) {
         dprintf(i, "%s", out);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1426

One-line summary:
`.relay` still did old port+1..3 and logging also didnt work properly while .`relay`-ing

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
For this test user HQ has console +d (debug), testuser2 does not.
**Before:**
Normal telnet user:
```
.relay BotB
Connecting to BotB @ 127.0.0.1:4567 ...
(Type *BYE* on a line by itself to abort.)
Could not link to BotB.
```
HQ (console user):
```
[20:13:55] tcl: builtin dcc call: *dcc:relay testuser2 7 BotB
[20:13:55] #testuser2# relay BotB
[20:13:55] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4567 ssl 0
[20:13:55] net: attempted socket connection refused: 127.0.0.1:4567
[20:13:55] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4568 ssl 0
[20:13:55] net: attempted socket connection refused: 127.0.0.1:4567
[20:13:55] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4569 ssl 0
[20:13:55] net: attempted socket connection refused: 127.0.0.1:4567
[20:13:55] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4570 ssl 0
[20:13:55] net: attempted socket connection refused: 127.0.0.1:4567

.relay BotB 
[20:15:26] tcl: builtin dcc call: *dcc:relay -HQ 1 BotB
[20:15:26] #-HQ# relay BotB
Connecting to BotB @ 127.0.0.1:4567 ...
(Type *BYE* on a line by itself to abort.)
Could not link to BotB.
```
**After:**
Normal telnet user:
```
.relay BotB
Connecting to BotB @ 127.0.0.1:4567 ...
(Type *BYE* on a line by itself to abort.)
Could not link to BotB.
```
HQ (console user):
```
[20:16:35] tcl: builtin dcc call: *dcc:relay testuser2 7 BotB
[20:16:35] #testuser2# relay BotB
[20:16:35] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4567 ssl 0
[20:16:35] net: attempted socket connection refused: 127.0.0.1:4567

.relay BotB
[20:17:27] tcl: builtin dcc call: *dcc:relay -HQ 1 BotB
[20:17:27] #-HQ# relay BotB
Connecting to BotB @ 127.0.0.1:4567 ...
(Type *BYE* on a line by itself to abort.)
[20:17:27] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 4567 ssl 0
[20:17:27] net: attempted socket connection refused: 127.0.0.1:4567
Could not link to BotB.
```