### PR TITLE
Fix (unlikely) out of bounds in ident.mod

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -64,11 +64,11 @@ static void ident_activity(int idx, char *buf, int len)
     putlog(LOG_MISC, "*", "Ident error: %s", strerror(errno));
     return;
   }
-  buf2[i - 1] = 0;
+  buf2[i] = 0;
   if (!(pos = strpbrk(buf2, "\r\n"))) {
     putlog(LOG_MISC, "*", "Ident error: could not read request.");
     return;
-  } 
+  }
   snprintf(pos, (sizeof buf2) - (pos - buf2), " : USERID : UNIX : %s\r\n", botname);
   count = strlen(buf2) + 1;
   if ((i = write(s, buf2, count)) != count) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix out of bounds

Additional description (if needed):
Theoretically `i - 1` could become `-1`, if `read()` returns `0`
Im unsure, why that `i - 1` was there in the first place.
Additionally this PR fixes a surplus whitespace ;)

Test cases demonstrating functionality (if applicable):
**Not tested yet, please can someone test this PR?**