### PR TITLE
Fix more format specifiers for time_t / difftime

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -421,10 +421,7 @@ static void timeout_dcc_bot_new(int idx)
 
 static void display_dcc_bot_new(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "bot*  waited %lis", tv);
+  sprintf(buf, "bot*  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 static int expmem_dcc_bot_(void *x)
@@ -784,10 +781,7 @@ static void tout_dcc_chat_pass(int idx)
 
 static void display_dcc_chat_pass(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "pass  waited %lis", tv);
+  sprintf(buf, "pass  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 static int expmem_dcc_general(void *x)
@@ -1839,10 +1833,7 @@ static void timeout_dcc_telnet_id(int idx)
 
 static void display_dcc_telnet_id(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "t-in  waited %lis", tv);
+  sprintf(buf, "t-in  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 struct dcc_table DCC_TELNET_ID = {
@@ -1993,18 +1984,12 @@ static void tout_dcc_telnet_pw(int idx)
 
 static void display_dcc_telnet_new(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "new   waited %lis", tv);
+  sprintf(buf, "new   waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 static void display_dcc_telnet_pw(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "newp  waited %lis", tv);
+  sprintf(buf, "newp  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 struct dcc_table DCC_TELNET_NEW = {
@@ -2240,10 +2225,7 @@ void eof_dcc_identwait(int idx)
 
 static void display_dcc_identwait(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "idtw  waited %lis", tv);
+  sprintf(buf, "idtw  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 struct dcc_table DCC_IDENTWAIT = {

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -528,10 +528,7 @@ static void disp_dcc_files(int idx, char *buf)
 
 static void disp_dcc_files_pass(int idx, char *buf)
 {
-  long tv;
-
-  tv = now - dcc[idx].timeval;
-  sprintf(buf, "fpas  waited %lis", tv);
+  sprintf(buf, "fpas  waited %" PRId64 "s", (int64_t) (now - dcc[idx].timeval));
 }
 
 static void kill_dcc_files(int idx, void *x)

--- a/src/userent.c
+++ b/src/userent.c
@@ -422,13 +422,11 @@ static int laston_unpack(struct userrec *u, struct user_entry *e)
 static int laston_pack(struct userrec *u, struct user_entry *e)
 {
   char work[1024];
-  long tv;
   struct laston_info *li;
   int l;
 
   li = (struct laston_info *) e->u.extra;
-  tv = li->laston;
-  l = sprintf(work, "%lu %s", tv, li->lastonplace);
+  l = sprintf(work, "%" PRId64 " %s", (int64_t) li->laston, li->lastonplace);
   e->u.list = user_malloc(sizeof(struct list_type));
   e->u.list->next = NULL;
   e->u.list->extra = user_malloc(l + 1);
@@ -441,11 +439,9 @@ static int laston_pack(struct userrec *u, struct user_entry *e)
 static int laston_write_userfile(FILE *f, struct userrec *u,
                                  struct user_entry *e)
 {
-  long tv;
   struct laston_info *li = (struct laston_info *) e->u.extra;
 
-  tv = li->laston;
-  if (fprintf(f, "--LASTON %lu %s\n", tv,
+  if (fprintf(f, "--LASTON %" PRId64 " %s\n", (int64_t) li->laston,
               li->lastonplace ? li->lastonplace : "") == EOF)
     return 0;
   return 1;

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -413,7 +413,6 @@ int u_pass_match(struct userrec *u, char *pass)
 int write_user(struct userrec *u, FILE *f, int idx)
 {
   char s[181];
-  long tv;
   struct chanuserrec *ch;
   struct chanset_t *cst;
   struct user_entry *ue;
@@ -438,8 +437,7 @@ int write_user(struct userrec *u, FILE *f, int idx)
         fr.chan = ch->flags;
         fr.udef_chan = ch->flags_udef;
         build_flags(s, &fr, NULL);
-        tv = ch->laston;
-        if (fprintf(f, "! %-20s %lu %-10s %s\n", ch->channel, tv, s,
+        if (fprintf(f, "! %-20s %" PRId64 " %-10s %s\n", ch->channel, (int64_t) ch->laston, s,
             (((idx < 0) || share_greet) && ch->info) ? ch->info : "") == EOF)
           return 0;
       }
@@ -656,7 +654,6 @@ struct userrec *adduser(struct userrec *bu, char *handle, char *host,
   struct userrec *u, *x;
   struct xtra_key *xk;
   int oldshare = noshare;
-  time_t tv;
 
   noshare = 1;
   u = nmalloc(sizeof *u);
@@ -679,10 +676,9 @@ struct userrec *adduser(struct userrec *bu, char *handle, char *host,
     xk = nmalloc(sizeof *xk);
     xk->key = nmalloc(8);
     strcpy(xk->key, "created");
-    tv = now;
-    l = snprintf(NULL, 0, "%" PRId64, (int64_t) tv);
+    l = snprintf(NULL, 0, "%" PRId64, (int64_t) now);
     xk->data = nmalloc(l + 1);
-    sprintf(xk->data, "%" PRId64, (int64_t) tv);
+    sprintf(xk->data, "%" PRId64, (int64_t) now);
     set_user(&USERENTRY_XTRA, u, xk);
   }
   /* Strip out commas -- they're illegal */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix more format specifiers for time_t / difftime

Additional description (if needed):
Will also make analyzers like codacy happy

Test cases demonstrating functionality (if applicable):
No functional change