### PR TITLE
Dont queue msg if its a WHOIS msg already queued as last msg

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -903,6 +903,14 @@ static void queue_server(int which, char *msg, int len)
   }
 
   if (h->tot < maxqmsg) {
+    /* Don't queue msg if it's a WHOIS msg already queued as last msg */
+    if (DP_SERVER && tempq.last &&
+        !strncasecmp(tempq.last->msg, "WHOIS", 5) &&
+        !strcasecmp(tempq.last->msg, buf)) {
+      debug1("WHOIS Message already queued as last message; skipping: %s",
+             buf);
+      return;
+    }
     /* Don't queue msg if it's already queued?  */
     if (!doublemsg) {
       for (tq = tempq.head; tq; tq = tqq) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #715

One-line summary:
Dont queue msg if its a WHOIS msg already queued as last msg

Additional description (if needed):
We already have config setting double-server, but it defaults to 1 and i guess it would have side effects to change its default value to 1, while sending two identical WHOIS in a row should be avoided and doesnt make sense.
https://github.com/eggheads/eggdrop/blob/322bddbd102d58cdb00864a3a335b086beaf042c/eggdrop.conf#L1250-L1251

Test cases demonstrating functionality (if applicable):
`.console *`
connect to irc server
Before:
```
[...]
[23:12:12] [!s] WHOIS BotA
[...]
[23:12:12] [@] :irc.example.org 422 BotA :MOTD File is missing
[23:12:12] [@] :BotA MODE BotA :+iwx
[23:12:12] [!s] WHOIS BotA
[23:12:14] [m->] MODE BotA +i-ws
[23:12:14] [@] :BotA MODE BotA :-w
[23:12:14] [!s] WHOIS BotA
[23:12:20] [s->] WHOIS BotA
[23:12:20] [@] :irc.example.org 311 BotA BotA BotA Clk-8553FB0D * :/msg BotA hello
[23:12:20] [@] :irc.example.org 379 BotA BotA :is using modes +ix 
[23:12:20] [@] :irc.example.org 378 BotA BotA :is connecting from *@localhost 127.0.0.1
[23:12:20] [@] :irc.example.org 312 BotA BotA irc.example.org :ExampleNET Server
[23:12:20] [@] :irc.example.org 317 BotA BotA 7 1697231532 :seconds idle, signon time
[23:12:20] [@] :irc.example.org 318 BotA BotA :End of /WHOIS list.
[23:12:22] [s->] WHOIS BotA
[23:12:22] [@] :irc.example.org 311 BotA BotA BotA Clk-8553FB0D * :/msg BotA hello
[23:12:22] [@] :irc.example.org 379 BotA BotA :is using modes +ix 
[23:12:22] [@] :irc.example.org 378 BotA BotA :is connecting from *@localhost 127.0.0.1
[23:12:22] [@] :irc.example.org 312 BotA BotA irc.example.org :ExampleNET Server
[23:12:22] [@] :irc.example.org 317 BotA BotA 10 1697231532 :seconds idle, signon time
[23:12:22] [@] :irc.example.org 318 BotA BotA :End of /WHOIS list.
[23:12:24] [s->] WHOIS BotA
[23:12:24] [@] :irc.example.org 311 BotA BotA BotA Clk-8553FB0D * :/msg BotA hello
[23:12:24] [@] :irc.example.org 379 BotA BotA :is using modes +ix 
[23:12:24] [@] :irc.example.org 378 BotA BotA :is connecting from *@localhost 127.0.0.1
[23:12:24] [@] :irc.example.org 312 BotA BotA irc.example.org :ExampleNET Server
[23:12:24] [@] :irc.example.org 317 BotA BotA 12 1697231532 :seconds idle, signon time
[23:12:24] [@] :irc.example.org 318 BotA BotA :End of /WHOIS list.
```
After:
```
[...]
[23:12:45] [!s] WHOIS BotA
[...]
[23:12:45] [@] :irc.example.org 422 BotA :MOTD File is missing
[23:12:45] [@] :BotA MODE BotA :+iwx
[23:12:45] WHOIS Message already queued as last message; skipping: WHOIS BotA
[23:12:47] [m->] MODE BotA +i-ws
[23:12:47] [@] :BotA MODE BotA :-w
[23:12:47] WHOIS Message already queued as last message; skipping: WHOIS BotA
[23:12:53] [s->] WHOIS BotA
[23:12:53] [@] :irc.example.org 311 BotA BotA BotA Clk-8553FB0D * :/msg BotA hello
[23:12:53] [@] :irc.example.org 379 BotA BotA :is using modes +ix 
[23:12:53] [@] :irc.example.org 378 BotA BotA :is connecting from *@localhost 127.0.0.1
[23:12:53] [@] :irc.example.org 312 BotA BotA irc.example.org :ExampleNET Server
[23:12:53] [@] :irc.example.org 317 BotA BotA 8 1697231565 :seconds idle, signon time
[23:12:53] [@] :irc.example.org 318 BotA BotA :End of /WHOIS list.
```