### PR TITLE
small performance enhancement for sockgets()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1211,9 +1211,10 @@ int sockgets(char *s, int *len)
   /* Might be necessary to prepend stored-up data! */
   if (socklist[ret].handler.sock.inbuf != NULL) {
     p = socklist[ret].handler.sock.inbuf;
-    socklist[ret].handler.sock.inbuf = nmalloc(strlen(p) + strlen(xx) + 1);
-    strcpy(socklist[ret].handler.sock.inbuf, p);
-    strcat(socklist[ret].handler.sock.inbuf, xx);
+    len2 = strlen(p);
+    socklist[ret].handler.sock.inbuf = nmalloc(len2 + strlen(xx) + 1);
+    memcpy(socklist[ret].handler.sock.inbuf, p, len2);
+    strcpy(socklist[ret].handler.sock.inbuf + len2, xx);
     nfree(p);
     if (strlen(socklist[ret].handler.sock.inbuf) < RECVLINEMAX) {
       strcpy(xx, socklist[ret].handler.sock.inbuf);
@@ -1264,10 +1265,11 @@ int sockgets(char *s, int *len)
   /* Prepend old data back */
   if (socklist[ret].handler.sock.inbuf != NULL) {
     p = socklist[ret].handler.sock.inbuf;
-    socklist[ret].handler.sock.inbuflen = strlen(p) + strlen(xx);
+    len2 = strlen(xx);
+    socklist[ret].handler.sock.inbuflen = len2 + strlen(p);
     socklist[ret].handler.sock.inbuf = nmalloc(socklist[ret].handler.sock.inbuflen + 1);
-    strcpy(socklist[ret].handler.sock.inbuf, xx);
-    strcat(socklist[ret].handler.sock.inbuf, p);
+    memcpy(socklist[ret].handler.sock.inbuf, xx, len2);
+    strcpy(socklist[ret].handler.sock.inbuf + len2, p);
     nfree(p);
   } else {
     socklist[ret].handler.sock.inbuflen = strlen(xx);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
small performance enhancement for `sockgets()`, which is called in `mainloop()`

Additional description (if needed):
`strcat()` is evil

Test cases demonstrating functionality (if applicable):
No functional change