### PR TITLE
Fix logging of QUIT msg

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2094,9 +2094,13 @@ static void server_postrehash()
 
 static void server_die()
 {
+  char msg[MSGMAX];
   cycle_time = 100;
   if (server_online) {
-    dprintf(-serv, "QUIT :%s\n", quit_msg[0] ? quit_msg : "");
+    snprintf(msg, sizeof msg, "QUIT :%s\n", quit_msg[0] ? quit_msg : "");
+    dprintf(-serv, msg);
+    if (raw_log)
+      putlog(LOG_SRVOUT, "*", "[->] %s", msg);
     sleep(3);                   /* Give the server time to understand */
   }
   nuke_server(NULL);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2097,8 +2097,8 @@ static void server_die()
   char msg[MSGMAX];
   cycle_time = 100;
   if (server_online) {
-    snprintf(msg, sizeof msg, "QUIT :%s\n", quit_msg[0] ? quit_msg : "");
-    dprintf(-serv, msg);
+    snprintf(msg, sizeof msg, "QUIT :%s", quit_msg[0] ? quit_msg : "");
+    dprintf(-serv, "%s\n", msg);
     if (raw_log)
       putlog(LOG_SRVOUT, "*", "[->] %s", msg);
     sleep(3);                   /* Give the server time to understand */

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2097,7 +2097,7 @@ static void server_die()
   char msg[MSGMAX];
   cycle_time = 100;
   if (server_online) {
-    snprintf(msg, sizeof msg, "QUIT :%s", quit_msg[0] ? quit_msg : "");
+    snprintf(msg, sizeof msg, "QUIT :%s", quit_msg);
     dprintf(-serv, "%s\n", msg);
     if (raw_log)
       putlog(LOG_SRVOUT, "*", "[->] %s", msg);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Log QUIT msg like we already do for any other msg sent to the server.

Additional description (if needed):
Messages from eggdrop to irc server are logged when raw-log is set. depending on the queue the message was put in, it gets logged like for example `[m->]` or `[s->]` The Quit message was sent to server directly without using those queues and thus was not logged.

Test cases demonstrating functionality (if applicable):
in eggdrop.conf `set raw-log 1`
```
.die
[23:29:24] tcl: builtin dcc call: *dcc:die -HQ 1 
[23:29:24] #-HQ# die 
[23:29:24] [->] QUIT :-HQ
```