### PR TITLE
Simplify btos()

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -3269,33 +3269,20 @@ static void cmd_traffic(struct userrec *u, int idx, char *par)
   putlog(LOG_CMDS, "*", "#%s# traffic", dcc[idx].nick);
 }
 
-static char traffictxt[20];
 static char *btos(unsigned long bytes)
 {
-  const char *unit;
-  float xbytes;
+  static char traffictxt[20];
 
-  xbytes = bytes;
-  if (xbytes > 1024.0) {
-    unit = "KBytes";
-    xbytes = xbytes / 1024.0;
-  }
-  if (xbytes > 1024.0) {
-    unit = "MBytes";
-    xbytes = xbytes / 1024.0;
-  }
-  if (xbytes > 1024.0) {
-    unit = "GBytes";
-    xbytes = xbytes / 1024.0;
-  }
-  if (xbytes > 1024.0) {
-    unit = "TBytes";
-    xbytes = xbytes / 1024.0;
-  }
-  if (bytes > 1024)
-    sprintf(traffictxt, "%.2f %s", xbytes, unit);
-  else
+  if (bytes <= 1024)
     sprintf(traffictxt, "%lu Bytes", bytes);
+  else if (bytes <= (1024 * 1024))
+    sprintf(traffictxt, "%.2f KBytes", (float) bytes / 1024);
+  else if (bytes <= (1024 * 1024 * 1024))
+    sprintf(traffictxt, "%.2f MBytes", (float) bytes / 1024 / 1024);
+  else if (bytes <= (1024u * 1024 * 1024 * 1024))
+    sprintf(traffictxt, "%.2f GBytes", (float) bytes / 1024 / 1024 / 1024);
+  else if (bytes <= (1024u * 1024 * 1024 * 1024 * 1024))
+    sprintf(traffictxt, "%.2f TBytes", (float) bytes / 1024 / 1024 / 1024 / 1024);
   return traffictxt;
 }
 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -3281,7 +3281,7 @@ static char *btos(unsigned long bytes)
     sprintf(traffictxt, "%.2f MBytes", (float) bytes / 1024 / 1024);
   else if (bytes <= (1024u * 1024 * 1024 * 1024))
     sprintf(traffictxt, "%.2f GBytes", (float) bytes / 1024 / 1024 / 1024);
-  else if (bytes <= (1024u * 1024 * 1024 * 1024 * 1024))
+  else
     sprintf(traffictxt, "%.2f TBytes", (float) bytes / 1024 / 1024 / 1024 / 1024);
   return traffictxt;
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Simplify btos()

Additional description (if needed):
Also makes static analyzers like scan-build happy

Test cases demonstrating functionality (if applicable):
```
.traffic
[14:42:04] tcl: builtin dcc call: *dcc:traffic -HQ 1 
Traffic since last restart
==========================
IRC:
  out: 291 Bytes (291 Bytes today)
   in: 4.24 KBytes (4.24 KBytes today)
Partyline:
  out: 0 Bytes (0 Bytes today)
   in: 9 Bytes (9 Bytes today)
---
Total:
  out: 291 Bytes (291 Bytes today)
   in: 4.25 KBytes (4.25 KBytes today)
[14:42:04] #-HQ# traffic
```