### PR TITLE
Fix log output for channel

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1140,10 +1140,9 @@ int main(int arg_c, char **arg_v)
   putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.",
          botnetnick, i, (i == 1) ? "" : "s", j, (j == 1) ? "" : "s");
   if ((cliflags & CLI_N) && (cliflags & CLI_T)) {
-    printf("\n"
-           "NOTE: The -n flag is no longer used, it is as effective as Han\n"
-           "      without Chewie\n");
-  }
+    printf("\n");
+    printf("NOTE: The -n flag is no longer used, it is as effective as Han\n");
+    printf("      without Chewie\n");
 #ifdef TLS
   ssl_init();
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1136,8 +1136,8 @@ int main(int arg_c, char **arg_v)
   i = 0;
   for (chan = chanset; chan; chan = chan->next)
     i++;
-  putlog(LOG_MISC, "*", "=== %s: %d channels, %d users.",
-         botnetnick, i, count_users(userlist));
+  putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.",
+         botnetnick, i, (i == 1) ? "" : "s", count_users(userlist), (count_users(userlist) == 1) ? "" : "s");
   if ((cliflags & CLI_N) && (cliflags & CLI_T)) {
     printf("\n");
     printf("NOTE: The -n flag is no longer used, it is as effective as Han\n");

--- a/src/main.c
+++ b/src/main.c
@@ -1001,7 +1001,7 @@ static void init_random(void) {
 
 int main(int arg_c, char **arg_v)
 {
-  int i, j,  xx;
+  int i, j, xx;
   char s[25];
   FILE *f;
   struct sigaction sv;

--- a/src/main.c
+++ b/src/main.c
@@ -1136,12 +1136,13 @@ int main(int arg_c, char **arg_v)
   i = 0;
   for (chan = chanset; chan; chan = chan->next)
     i++;
-  putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.",
-         botnetnick, i, (i == 1) ? "" : "s", count_users(userlist), (count_users(userlist) == 1) ? "" : "s");
+  putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.", botnetnick, i,
+         (i == 1) ? "" : "s", count_users(userlist),
+         (count_users(userlist) == 1) ? "" : "s");
   if ((cliflags & CLI_N) && (cliflags & CLI_T)) {
-    printf("\n");
-    printf("NOTE: The -n flag is no longer used, it is as effective as Han\n");
-    printf("      without Chewie\n");
+    printf("\n"
+           "NOTE: The -n flag is no longer used, it is as effective as Han\n"
+           "      without Chewie\n");
   }
 #ifdef TLS
   ssl_init();

--- a/src/main.c
+++ b/src/main.c
@@ -1001,7 +1001,7 @@ static void init_random(void) {
 
 int main(int arg_c, char **arg_v)
 {
-  int i, xx;
+  int i, j,  xx;
   char s[25];
   FILE *f;
   struct sigaction sv;
@@ -1136,9 +1136,9 @@ int main(int arg_c, char **arg_v)
   i = 0;
   for (chan = chanset; chan; chan = chan->next)
     i++;
-  putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.", botnetnick, i,
-         (i == 1) ? "" : "s", count_users(userlist),
-         (count_users(userlist) == 1) ? "" : "s");
+  j = count_users(userlist);
+  putlog(LOG_MISC, "*", "=== %s: %d channel%s, %d user%s.",
+         botnetnick, i, (i == 1) ? "" : "s", j, (j == 1) ? "" : "s");
   if ((cliflags & CLI_N) && (cliflags & CLI_T)) {
     printf("\n"
            "NOTE: The -n flag is no longer used, it is as effective as Han\n"

--- a/src/main.c
+++ b/src/main.c
@@ -1143,6 +1143,7 @@ int main(int arg_c, char **arg_v)
     printf("\n");
     printf("NOTE: The -n flag is no longer used, it is as effective as Han\n");
     printf("      without Chewie\n");
+  }
 #ifdef TLS
   ssl_init();
 #endif


### PR DESCRIPTION
Found by: jackal
Patch by: jackal and michaelortmann
Fixes: 

One-line summary:
Fix log output for channel (1 channels -> 1 channel)

Additional description (if needed):
And reduce amount of `printf()` to 1 for multiple line output when `-nt` command line args

Test cases demonstrating functionality (if applicable):
`$ ./eggdrop -nt BotA.conf`
**Before:**
```
=== BotA: 1 channels, 23 users.

NOTE: The -n flag is no longer used, it is as effective as Han
      without Chewie
```
**After:**
```
=== BotA: 1 channel, 23 users.

NOTE: The -n flag is no longer used, it is as effective as Han
      without Chewie
```