### PR TITLE
Cleanup: Replace magick number 8702 with a nice name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,8 @@
 #  include <sys/random.h>
 #endif
 
+#include "mod/server.mod/server.h" /* RECVLINEMAX */
+
 #ifndef _POSIX_SOURCE
 #  define _POSIX_SOURCE 1               /* Solaris needs this */
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -787,7 +787,7 @@ static void mainloop(int toplevel)
 {
   static int cleanup = 5;
   int xx, i, eggbusy = 1;
-  char buf[8702];
+  char buf[RECVLINEMAX];
 
   /* Lets move some of this here, reducing the number of actual
    * calls to periodic_timers


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup: Replace magick number 8702 with a nice name

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
no functional change