### PR TITLE
(WIP) Add debug detail log for fopen() and tmpfile()

### DIFF
--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -26,6 +26,7 @@
 
 #include "src/mod/module.h"
 
+#include <errno.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/stat.h>
@@ -1244,9 +1245,11 @@ static void share_ufsend(int idx, char *par)
     zapfbot(idx);
   } else if (copy_to_tmp && !(f = tmpfile())) {
     putlog(LOG_MISC, "*", "CAN'T WRITE TEMPORARY USERFILE DOWNLOAD FILE!");
+    debug1("share: tmpfile(): %s", strerror(errno));
     zapfbot(idx);
   } else if (!copy_to_tmp && !(f = fopen(s, "wb"))) {
     putlog(LOG_MISC, "*", "CAN'T WRITE USERFILE DOWNLOAD FILE!");
+    debug2("share: fopen(%s): %s", s, strerror(errno));
     zapfbot(idx);
   } else {
     /* Ignore longip and use botaddr, arg kept for backward compat for pre 1.8.3 */

--- a/src/users.c
+++ b/src/users.c
@@ -30,15 +30,14 @@
  */
 
 #include <errno.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 #include "main.h"
 #include "users.h"
 #include "chan.h"
 #include "modules.h"
 #include "tandem.h"
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
 
 extern struct dcc_t *dcc;
 extern struct userrec *userlist, *lastuser;

--- a/src/users.c
+++ b/src/users.c
@@ -29,6 +29,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <errno.h>
+
 #include "main.h"
 #include "users.h"
 #include "chan.h"
@@ -698,9 +700,10 @@ int readuserfile(char *file, struct userrec **ret)
     global_invites = NULL;
   }
   lasthand[0] = 0;
-  f = fopen(file, "r");
-  if (f == NULL)
+  if (!(f = fopen(file, "r"))) {
+    debug2("users: fopen(%s): %s", file, strerror(errno));
     return 0;
+  }
   noshare = noxtra = 1;
   /* read opening comment */
   s = buf;


### PR DESCRIPTION
Found by: michaelortmann
Patch by:
Fixes: 

One-line summary:
Add debug detail log for fopen() and tmpfile()

Additional description (if needed):
This PR doesnt fix the "File descriptor leak during userfile sharing bug" Geo reported, but it can help with such issues and more detailed error logging is good here anyway.

Test cases demonstrating functionality (if applicable):
