### PR TITLE
Crashfix: CFLAGS -fsanitize=address could lead to crash if pbkdf2 mod loaded

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -313,15 +313,12 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
 
   # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
   AC_MSG_CHECKING(for b64_ntop)
-  OLD_CFLAGS="$CFLAGS"
-  CFLAGS="$CFLAGS -fno-sanitize=address"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  AC_RUN_IFELSE([AC_LANG_PROGRAM([[
       #include <sys/types.h>
       #include <netinet/in.h>
       #include <resolv.h>
     ]], [[b64_ntop(NULL, 0, NULL, 0);]])],[found_b64_ntop=yes],[found_b64_ntop=no
   ])
-  CFLAGS=$OLD_CFLAGS
   if test "x$found_b64_ntop" = xno; then
     AC_MSG_RESULT(no)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -313,12 +313,15 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
 
   # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
   AC_MSG_CHECKING(for b64_ntop)
+  OLD_CFLAGS="$CFLAGS"
+  CFLAGS+="$CFLAGS -fno-sanitize=address"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <sys/types.h>
       #include <netinet/in.h>
       #include <resolv.h>
     ]], [[b64_ntop(NULL, 0, NULL, 0);]])],[found_b64_ntop=yes],[found_b64_ntop=no
   ])
+  CFLAGS=$OLD_CFLAGS
   if test "x$found_b64_ntop" = xno; then
     AC_MSG_RESULT(no)
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -325,7 +325,7 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
     AC_MSG_CHECKING(for b64_ntop with -lresolv)
     OLD_LIBS="$LIBS"
     LIBS="$LIBS -lresolv"
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    AC_RUN_IFELSE([AC_LANG_PROGRAM([[
         #include <sys/types.h>
         #include <netinet/in.h>
         #include <resolv.h>
@@ -338,7 +338,7 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
       AC_MSG_CHECKING(for b64_ntop with -lnetwork)
       OLD_LIBS="$LIBS"
       LIBS="-lnetwork"
-      AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([[
         #include <sys/types.h>
         #include <netinet/in.h>
         #include <resolv.h>

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -314,7 +314,7 @@ AC_DEFUN([EGG_FUNC_B64_NTOP],
   # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
   AC_MSG_CHECKING(for b64_ntop)
   OLD_CFLAGS="$CFLAGS"
-  CFLAGS+="$CFLAGS -fno-sanitize=address"
+  CFLAGS="$CFLAGS -fno-sanitize=address"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <sys/types.h>
       #include <netinet/in.h>


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Compiling eggdrop with `CFLAGS` `-fsanitize=address` on systems that require linker flag `-lresolv` for `b64_ntop()` or `b64_pton()`  could lead to crash if pbkdf2 mod loaded

Additional description (if needed):
gccs sanitizer will intercept calls to `b64_ntop` or `b64_pton()`
https://github.com/gcc-mirror/gcc/blob/releases/gcc-13/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc#L2512
which leads to eggdrops configure script misdetecting that eggdrop can be linked without `-lresolv` to call those functions.
**Please run `misc/runautotools` after merging or for testing this PR**

Test cases demonstrating functionality (if applicable):
**Before:**
```
$ CFLAGS="-fsanitize=address" ./configure
[...]
checking for b64_ntop... yes
[...]
.chpass testuser 123456
[03:15:50.%f] tcl: builtin dcc call: *dcc:chpass -HQ 1 [something]
[03:15:50.%f] * Last context: tclhash.c/726 [Tcl proc: *dcc:chpass, param:  $_dcc1 $_dcc2 $_dcc3]
[03:15:50.%f] * Please REPORT this BUG!
[03:15:50.%f] * Check doc/BUG-REPORT on how to do so.
[03:15:49.%f] * Wrote DEBUG
[03:15:49.%f] * SEGMENT VIOLATION -- CRASHING!
Segmentation fault (core dumped)
$ coredumpctl debug
[...]
#0  0x0000000000000000 in ?? ()
(gdb) bt full
#0  0x0000000000000000 in ?? ()
No symbol table info available.
#1  0x00007fe8abe81a91 in __interceptor___b64_ntop (src=0x7fe8a9003ce0 "m+r\032\036\303b\v*Y\373n\026\213\236O", 
    srclength=16, target=0x7fe8aa65573b <out+27> "", targsize=76)
    at /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:2512
        ctx = <optimized out>
        _ctx = <optimized out>
        res = <optimized out>
        v1 = <optimized out>
        v2 = <optimized out>
[...]
```
**After:**
```
$ CFLAGS="-fsanitize=address" ./configure
[...]
checking for b64_ntop... yes
[...]
checking for b64_ntop... no
checking for b64_ntop with -lresolv... yes
[...]
.chpass testuser 123456
[03:21:55.%f] tcl: builtin dcc call: *dcc:chpass -HQ 1 [something]
[03:21:55.%f] pbkdf2 method SHA256 rounds 1000, user 0.186ms sys 1.114ms
[03:21:55.%f] #-HQ# chpass testuser [something]
Changed password.
```