### PR TITLE
Fix ssl read

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -174,8 +174,7 @@ modules.o: modules.c main.h ../config.h ../eggint.h ../lush.h lang.h \
 net.o: net.c main.h ../config.h ../eggint.h ../lush.h lang.h eggdrop.h \
  compat/in6.h flags.h proto.h misc_file.h cmdt.h tclegg.h tclhash.h \
  chan.h users.h compat/compat.h compat/base64.h compat/inet_aton.h \
- ../src/main.h compat/snprintf.h compat/explicit_bzero.h compat/strlcpy.h \
- mod/server.mod/server.h
+ ../src/main.h compat/snprintf.h compat/explicit_bzero.h compat/strlcpy.h
 rfc1459.o: rfc1459.c main.h ../config.h ../eggint.h ../lush.h lang.h \
  eggdrop.h compat/in6.h flags.h proto.h misc_file.h cmdt.h tclegg.h \
  tclhash.h chan.h users.h compat/compat.h compat/base64.h \

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -60,6 +60,7 @@
 #define UHOSTMAX    291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
 #define DIRMAX      512           /* paranoia                            */
 #define LOGLINEMAX  9000          /* for misc.c/putlog() <cybah>         */
+#define READMAX     16384         /* for read() and SSL_read()           */
 
 /* Invalid characters */
 #define BADHANDCHARS "-,+*=:!.@#;$%&"

--- a/src/main.c
+++ b/src/main.c
@@ -787,7 +787,7 @@ static void mainloop(int toplevel)
 {
   static int cleanup = 5;
   int xx, i, eggbusy = 1;
-  char buf[8702];
+  char buf[READMAX + 2];
 
   /* Lets move some of this here, reducing the number of actual
    * calls to periodic_timers


### PR DESCRIPTION
Found by: pym67 and PeGaSuS
Patch by: michaelortmann with help from the whole eggheads crew
Fixes: #1496

One-line summary:
This is a more clean/efficient fix than #1501

Additional description (if needed):
Instead of fixing and using `SSL_pending()`, this PR fixes the problem by upping the read buffer size for `SSL_read()` and `read()` to `16K`, the maximum according to SSL spec and to `openssl`s internal buffer size.

Test cases demonstrating functionality (if applicable):
It fixes the IRC server connect mentioned in #1501
It also fixes a user file transfer over tls. I tested with a userfile `< 16K - 1`, one with `== 16K` and one `> 16K`