### PR TITLE
Add eggdrop homepage to configure.ac AC_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl configure.ac: this file is processed by autoconf to produce ./configure.
 
 AC_PREREQ([2.71])
-AC_INIT([Eggdrop],[1.9.5],[bugs@eggheads.org])
+AC_INIT([Eggdrop],[1.9.5],[bugs@eggheads.org],[eggdrop],[https://www.eggheads.org])
 AC_COPYRIGHT([Copyright (C) 1999 - 2023 Eggheads Development Team])
 AC_LANG([C])
 AC_REVISION([m4_esyscmd([misc/getcommit])])


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add eggdrop homepage to configure.ac AC_INIT

Additional description (if needed):
See also: https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Initializing-configure.html
**Please run misc/runautotools after merge**

Test cases demonstrating functionality (if applicable):
```
$ ./configure --help
[...]
Eggdrop home page: <https://www.eggheads.org>.
```