### PR TITLE
Add log for tls diffie–hellman ephemeral key

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -739,7 +739,8 @@ static void ssl_info(const SSL *ssl, int where, int ret)
   const
 #endif
   SSL_CIPHER *cipher;
-  int secret, processed;
+  int secret, processed, i;
+  EVP_PKEY *key;
 
   if (!(data = (ssl_appdata *) SSL_get_app_data(ssl)))
     return;
@@ -770,15 +771,23 @@ static void ssl_info(const SSL *ssl, int where, int ret)
     /* Display cipher information */
     cipher = SSL_get_current_cipher(ssl);
     processed = SSL_CIPHER_get_bits(cipher, &secret);
-    putlog(LOG_DEBUG, "*", "TLS: cipher used: %s %s; %d bits (%d secret)",
-           SSL_CIPHER_get_name(cipher), SSL_get_version(ssl),
-           processed, secret);
+    putlog(LOG_DEBUG, "*", "TLS: cipher used: %s, %d of %d secret bits used for cipher, %s",
+           SSL_CIPHER_get_name(cipher), processed, secret, SSL_get_version(ssl));
     /* secret are the actually secret bits. If processed and secret differ,
        the rest of the bits are fixed, i.e. for limited export ciphers */
 
     /* More verbose information, for debugging only */
     SSL_CIPHER_description(cipher, buf, sizeof buf);
+    i = strlen(buf);
+    if ((i > 0) && (buf[i - 1]) == '\n')
+      buf[i - 1] = 0;
     debug1("TLS: cipher details: %s", buf);
+
+    if (SSL_get_server_tmp_key((SSL *) ssl, &key)) {
+      putlog(LOG_DEBUG, "*", "TLS: diffie–hellman ephemeral key used: %s, bits %d",
+             OBJ_nid2sn(EVP_PKEY_id(key)), EVP_PKEY_bits(key));
+      EVP_PKEY_free(key);
+    }
   } else if (where & SSL_CB_ALERT) {
     if (strcmp(SSL_alert_type_string(ret), "W") ||
         strcmp(SSL_alert_desc_string(ret), "CN")) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add log for tls diffie–hellman ephemeral key

Additional description (if needed):
While at it, enhance log, remove a tailing `'\n'` from the result of `SSL_CIPHER_description()`

Test cases demonstrating functionality (if applicable):
**Before:**
```
[11:56:42] TLS: certificate valid from Nov 27 22:37:17 2023 GMT to Nov 26 22:37:17 2024 GMT
[11:56:42] TLS: cipher used: TLS_AES_256_GCM_SHA384 TLSv1.3; 256 bits (256 secret)
[11:56:42] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD

[11:56:42] TLS: state change: SSLv3/TLS write session ticket
```
**After:**
```
[11:57:25] TLS: certificate valid from Nov 27 22:37:17 2023 GMT to Nov 26 22:37:17 2024 GMT
[11:57:25] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[11:57:25] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[11:57:25] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[11:57:25] TLS: state change: SSLv3/TLS write session ticket
```
Tested with openssl 3.1.4, 1.1.1w and 1.0.2u