### PR TITLE
Call time() only once during mainloop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -631,7 +631,7 @@ static void core_secondly()
       tell_mem_status_dcc(DP_STDOUT);
     }
   }
-  nowmins = time(NULL) / 60;
+  nowmins = now / 60;
   if (nowmins > lastmin) {
     memcpy(&nowtm, localtime(&now), sizeof(struct tm));
     i = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Call time() only once during `mainloop()` and `core_secondly()`

Additional description (if needed):
found with `ltrace`

Test cases demonstrating functionality (if applicable):
`$ ltrace ./eggdrop -t BotA.conf`
**Before:**
```
time(0)                                                                        = 1701307982
time(0)                                                                        = 1701307982
```
**After:**
`time(0)                                                                        = 1701308015`