### PR TITLE
Fix log for 900 (RPL_LOGGEDIN) and 901 (RPL_LOGGEDOUT)

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1523,21 +1523,24 @@ static int gotauthenticate(char *from, char *msg)
   return 0;
 }
 
-/* Got 900: RPL_SASLLOGGEDIN, user account name is set */
+/* Got 900: RPL_LOGGEDIN, is sent when the users account name is set (whether by SASL or otherwise) */
 static int got900(char *from, char *msg)
 {
   newsplit(&msg); /* nick */
   newsplit(&msg); /* nick!ident@host */
   newsplit(&msg); /* account */
   fixcolon(msg);
-  putlog(LOG_SERV, "*", "SASL: %s", msg);
+  putlog(LOG_SERV, "RPL_LOGGEDIN: %s", msg);
   return 0;
 }
 
-/* Got 901: RPL_LOGGEDOUT, user account is logged out */
+/* Got 901: RPL_LOGGEDOUT, users account name is unset (whether by SASL or otherwise) */
 static int got901(char *from, char *msg)
 {
-  putlog(LOG_SERV, "*", "SASL: Account has been logged out");
+  newsplit(&msg); /* nick */
+  newsplit(&msg); /* nick!ident@host */
+  fixcolon(msg);
+  putlog(LOG_SERV, "RPL_LOGGEDOUT: %s", msg);
   return 0;
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1530,7 +1530,7 @@ static int got900(char *from, char *msg)
   newsplit(&msg); /* nick!ident@host */
   newsplit(&msg); /* account */
   fixcolon(msg);
-  putlog(LOG_SERV, "%s: %s", from, msg);
+  putlog(LOG_SERV, "*", "%s: %s", from, msg);
   return 0;
 }
 
@@ -1540,7 +1540,7 @@ static int got901(char *from, char *msg)
   newsplit(&msg); /* nick */
   newsplit(&msg); /* nick!ident@host */
   fixcolon(msg);
-  putlog(LOG_SERV, "%s: %s", from, msg);
+  putlog(LOG_SERV, "*", "%s: %s", from, msg);
   return 0;
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -159,7 +159,7 @@ static int check_tcl_msgm(char *cmd, char *nick, char *uhost,
   if (x == BIND_NOMATCH)
     return 0;
   if (x == BIND_EXEC_LOG)
-    return 2;
+    return 2;fff
 
   return 1;
 }
@@ -1530,7 +1530,7 @@ static int got900(char *from, char *msg)
   newsplit(&msg); /* nick!ident@host */
   newsplit(&msg); /* account */
   fixcolon(msg);
-  putlog(LOG_SERV, "RPL_LOGGEDIN: %s", msg);
+  putlog(LOG_SERV, "%s: %s", from, msg);
   return 0;
 }
 
@@ -1540,7 +1540,7 @@ static int got901(char *from, char *msg)
   newsplit(&msg); /* nick */
   newsplit(&msg); /* nick!ident@host */
   fixcolon(msg);
-  putlog(LOG_SERV, "RPL_LOGGEDOUT: %s", msg);
+  putlog(LOG_SERV, "%s: %s", from, msg);
   return 0;
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -159,7 +159,7 @@ static int check_tcl_msgm(char *cmd, char *nick, char *uhost,
   if (x == BIND_NOMATCH)
     return 0;
   if (x == BIND_EXEC_LOG)
-    return 2;fff
+    return 2;
 
   return 1;
 }

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1523,7 +1523,7 @@ static int gotauthenticate(char *from, char *msg)
   return 0;
 }
 
-/* Got 900: RPL_LOGGEDIN, is sent when the users account name is set (whether by SASL or otherwise) */
+/* Got 900: RPL_LOGGEDIN, users account name is set (whether by SASL or otherwise) */
 static int got900(char *from, char *msg)
 {
   newsplit(&msg); /* nick */


### PR DESCRIPTION
Found by: Geo
Patch by: michaelortmann
Fixes: #1497

One-line summary:
Fix log for 900 (RPL_LOGGEDIN) and 901 (RPL_LOGGEDOUT)

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
**Not tested yet**