### PR TITLE
Fix format

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -738,7 +738,7 @@ static int trigger_bind(const char *proc, const char *param, char *mask)
 
   if(proc && proc[0] != '*') { /* proc[0] != '*' excludes internal binds */
 #ifdef DEBUG_CONTEXT
-    snprintf(last_bind_called, sizeof last_bind_called, proc);
+    strlcpy(last_bind_called, proc, sizeof last_bind_called);
 #endif
     debug1("triggering bind %s", proc);
     r = getrusage(RUSAGE_SELF, &ru1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format for #1390

Additional description (if needed):
`snprintf()` -> `strlcpy()`

Test cases demonstrating functionality (if applicable):
Before:
```
clang -Wno-deprecated-non-prototype -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tclhash.c
tclhash.c:741:57: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    snprintf(last_bind_called, sizeof last_bind_called, proc);
                                                        ^~~~
tclhash.c:741:57: note: treat the string as an argument to avoid this
    snprintf(last_bind_called, sizeof last_bind_called, proc);
                                                        ^
                                                        "%s", 
1 warning generated.
```
After:
`clang -Wno-deprecated-non-prototype -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c tclhash.c`
New test:
to test this PR, eggdrop has to crash, so i inserted
`*(char *) 0xc0ffee = 1;`
into `cmd_die()` to make it crash on `.die`:
```
.die
[22:34:36.%f] tcl: builtin dcc call: *dcc:die -HQ 1 
[22:34:36.%f] * Please report problem to https://github.com/eggheads/eggdrop/issues
[22:34:36.%f] * Check doc/BUG-REPORT on how to do so.
[22:34:36.%f] * Last bind (may not be related): evnt:init_server
[22:34:35.%f] * Wrote DEBUG
[22:34:35.%f] * SEGMENT VIOLATION -- CRASHING!
Segmentation fault (core dumped)
```