### PR TITLE
Properly report channel bans in .bans

### DIFF
--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -752,7 +752,7 @@ static void display_invite(int idx, int number, maskrec *invite,
 static void tell_bans(int idx, int show_inact, char *match)
 {
   int k = 1;
-  char *chname;
+  char *chname = NULL;
   struct chanset_t *chan = NULL;
   maskrec *u;
 
@@ -788,7 +788,16 @@ static void tell_bans(int idx, int show_inact, char *match)
     } else
       display_ban(idx, k++, u, chan, show_inact);
   }
-  if (chan) {
+  for (chan = chanset; chan; chan = chan->next) {
+    /* Show a channel's bans if:
+     * - the console is set to *
+     * - the console is set to this channel
+     * - we're matching a mask
+     * - this channel was specifically requested in .bans
+     */
+    if ( (!strcmp(dcc[idx].u.chat->con_chan, "*")) ||
+         (!strcmp(dcc[idx].u.chat->con_chan, chan->dname) && (!chname || match[0])) ||
+         (chname && !strcasecmp(chname, chan->dname)) ) {
     if (show_inact)
       dprintf(idx, "%s %s:   (! = %s, * = %s)\n",
               BANS_BYCHANNEL, chan->dname, MODES_NOTACTIVE2, MODES_NOTBYBOT);
@@ -800,6 +809,9 @@ static void tell_bans(int idx, int show_inact, char *match)
         if ((match_addr(match, u->mask)) ||
             (wild_match(match, u->desc)) || (wild_match(match, u->user)))
           display_ban(idx, k, u, chan, 1);
+        k++;
+      } else if (chname && !strcasecmp(chname, chan->dname)) {
+        display_ban(idx, k, u, chan, 0);
         k++;
       } else
         display_ban(idx, k++, u, chan, show_inact);
@@ -830,6 +842,7 @@ static void tell_bans(int idx, int show_inact, char *match)
           k++;
         }
       }
+    }
     }
   }
   if (k == 1)


### PR DESCRIPTION
Found by: @wilkowy 
Patch by: Geo
Fixes: #1297

One-line summary:
Properly report channel bans with .bans

Additional description (if needed):
Prior to this patch, .bans was inconsistent in reporting as the help described.... it was inconsistent enough where I struggle to even capture what didn't work. The two major points were running .bans with a console of '*' only reported channels bans of the first channel in the channel record, and ``.bans #channel``  didn't report the bans on the requested channel.

Test cases demonstrating functionality (if applicable):

For these examples, #eggdroptest has no active bans that are in the global banlist but does have active bans that are in the channel banlist.  #eggtest has one active bans that is in the global banlist, and one active bans in the channel banlist.

**Specific test cases below are:**

show active global and channel bans for the console channel
```
.console #eggdroptest
[03:55:55] #-HQ# console #eggdroptest
Set your console to #eggdroptest: mkcobxs (msgs, kicks/modes, cmds, misc, bots, files, server input).
.bans 
[03:55:57] #-HQ# bans 
Global bans:
Channel bans for #eggdroptest:  (* = not placed by bot)
* [  9] *!*@217-115-40-234.cust.bredband2.com (Eggdrop!beer@eggdrop/bot) (active 12:13)
* [ 10] *!*@flow.users.undernet.org (Eggdrop!beer@eggdrop/bot) (active 12:13)
* [ 11] Eggybot!*@* (Eggdrop!beer@eggdrop/bot) (active 12:13)
Use '.bans all' to see the total list.
```

show active global and channel bans for a channel that is not the console channel
```
.bans #eggtest
[03:56:02] #-HQ# bans #eggtest
Global bans:
  [  5] *!*@soo.com (perm)
        -HQ: $-1y
        Created 1905 days ago
Channel bans for #eggtest:  (* = not placed by bot)
  [  8] *!*@aol.com (perm)
        -HQ: requested
        Created 23:14
* [  9] *!*@eggtest.com (Geo!~scase@user/geo) (active 11:54)
Use '.bans all' to see the total list.
```

show all global bans stored on the bot (active and inactive), and all channel bans for the console channel stored on the bot
```
.bans all
[03:56:12] #-HQ# bans all
Global bans:   (! = not active on #eggdroptest)
! [  1] *!*@qwer.com (perm)
        -HQ: requested
        Created 21:35
! [  2] 123456789!987654321@423456789.523456789.62* (perm)
        -HQ: requested
        Created 1405 days ago
! [  3] *!*@423456789.523456789.62* (perm) (sticky)
        -HQ: requested
        Created 1405 days ago
! [  4] *!*@asdfasdf.com (perm)
        -HQ: requested
        Created 1405 days ago
Channel bans for #eggdroptest:   (! = not active, * = not placed by bot)
! [  5] *!*@asf.com (perm)
        -HQ: requested
        Created 21:35
* [  6] *!*@217-115-40-234.cust.bredband2.com (Eggdrop!beer@eggdrop/bot) (active 12:27)
* [  7] *!*@flow.users.undernet.org (Eggdrop!beer@eggdrop/bot) (active 12:27)
* [  8] Eggybot!*@* (Eggdrop!beer@eggdrop/bot) (active 12:27)
```


match a mask for the console channel
```
.bans aol
[04:08:10] #-HQ# bans aol
Global bans:
Channel bans for #eggtest:  (* = not placed by bot)
.bans *aol*
[04:08:16] #-HQ# bans *aol*
Global bans:
Channel bans for #eggtest:  (* = not placed by bot)
  [  8] *!*@aol.com (perm)
        -HQ: requested
        Created 23:14
```


with a console set to *, use .bans show all active global and channel bans  for all channels
```
.console *
[03:58:40] #-HQ# console *
Set your console to *: mkcobxs (msgs, kicks/modes, cmds, misc, bots, files, server input).
.bans
[03:58:42] #-HQ# bans 
Global bans:
Channel bans for #eggdroptest:  (* = not placed by bot)
* [  9] *!*@217-115-40-234.cust.bredband2.com (Eggdrop!beer@eggdrop/bot) (active 14:58)
* [ 10] *!*@flow.users.undernet.org (Eggdrop!beer@eggdrop/bot) (active 14:58)
* [ 11] Eggybot!*@* (Eggdrop!beer@eggdrop/bot) (active 14:58)
Channel bans for #foo:  (* = not placed by bot)
Channel bans for #eggtest:  (* = not placed by bot)
  [ 13] *!*@aol.com (perm)
        -HQ: requested
        Created 23:14
* [ 14] *!*@eggtest.com (Geo!~scase@user/geo) (active 14:34)
Use '.bans all' to see the total list.
```


with a console set to *, use .bans all to show all global and channel bans stored on the bot
```
.bans all
[04:02:24] #-HQ# bans all
Global bans:   (! = not active on #eggdroptest)
! [  1] *!*@qwer.com (perm)
        -HQ: requested
        Created 21:35
! [  2] 123456789!987654321@423456789.523456789.62* (perm)
        -HQ: requested
        Created 1405 days ago
! [  3] *!*@423456789.523456789.62* (perm) (sticky)
        -HQ: requested
        Created 1405 days ago
! [  4] *!*@asdfasdf.com (perm)
        -HQ: requested
        Created 1405 days ago
Channel bans for #eggdroptest:   (! = not active, * = not placed by bot)
! [  5] *!*@asf.com (perm)
        -HQ: requested
        Created 21:35
* [  6] *!*@217-115-40-234.cust.bredband2.com (Eggdrop!beer@eggdrop/bot) (active 18:40)
* [  7] *!*@flow.users.undernet.org (Eggdrop!beer@eggdrop/bot) (active 18:40)
* [  8] Eggybot!*@* (Eggdrop!beer@eggdrop/bot) (active 18:40)
Channel bans for #foo:   (! = not active, * = not placed by bot)
! [  9] *!*@sol.com (perm)
        -HQ: requested
        Created 21:35
Channel bans for #eggtest:   (! = not active, * = not placed by bot)
  [ 10] *!*@aol.com (perm)
        -HQ: requested
        Created 23:14
* [ 11] *!*@eggtest.com (Geo!~scase@user/geo) (active 18:16)
```


with a console set to *, use matching to match all bans matching a mask
```
.bans *asf*
[04:06:55] #-HQ# bans *asf*
Global bans:
Channel bans for #eggdroptest:  (* = not placed by bot)
! [  8] *!*@asf.com (perm)
        -HQ: requested
        Created 21:35
Channel bans for #foo:  (* = not placed by bot)
Channel bans for #eggtest:  (* = not placed by bot)

