### PR TITLE
Fix another Wformat-overflow, this time proper

### DIFF
--- a/src/botmsg.c
+++ b/src/botmsg.c
@@ -755,7 +755,7 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
 {
   #define FROMLEN 40
   int status, i, iaway, sock;
-  char *p, botf[FROMLEN + 1 + HANDLEN + 1], ss[81], ssf[81];
+  char *p, botf[FROMLEN + 1 + HANDLEN + 1], ss[81], ssf[20 + 1 + sizeof botf];
   struct userrec *u;
 
   /* Notes have a length limit. Note + PRIVMSG header + nick + date must
@@ -786,7 +786,7 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
       if (strchr(from, '@')) {
         strcpy(botf, from);
       } else
-        sprintf(botf, "%s@%s", from, botnetnick);
+        snprintf(botf, sizeof botf, "%s@%s", from, botnetnick);
 
     } else
       strcpy(botf, botnetnick);
@@ -803,7 +803,7 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
       dprintf(idx, "-> %s@%s: %s\n", x, p, msg);
 
     if (idx >= 0) {
-      sprintf(ssf, "%lu:%s", dcc[idx].sock, botf);
+      snprintf(ssf, sizeof ssf, "%lu:%s", dcc[idx].sock, botf);
       botnet_send_priv(i, ssf, x, p, "%s", msg);
     } else
       botnet_send_priv(i, botf, x, p, "%s", msg);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Followup patch to #758

Additional description (if needed):
Now i found time to go over the logic "fixed" in #758 and fix it proper. size of `ssf` is not only dependent of max socket, but also on `HANDLEN` through dynamic size of `botf`. Rising `ssf` size above the old fixed value of 81 is not a problem (i wasnt sure at the time i "fixed" #758) but the right thing to do, no need to truncate here.

Also, after fixing buffer size i changed the `sprintf()`s here to `snprintf()`s to add another layer of safety.

Test cases demonstrating functionality (if applicable):
Warning triggered by gcc CFLAG `-Wformat-overflow=2`
Before:
```
gcc -Wall -Wformat=2 -Wno-format-nonliteral -Wformat-overflow=2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c botmsg.c
botmsg.c: In function ‘add_note’:
botmsg.c:806:25: warning: ‘%s’ directive writing up to 73 bytes into a region of size between 60 and 79 [-Wformat-overflow=]
  806 |       sprintf(ssf, "%lu:%s", dcc[idx].sock, botf);
      |                         ^~                  ~~~~
botmsg.c:806:7: note: ‘sprintf’ output between 3 and 95 bytes into a destination of size 81
  806 |       sprintf(ssf, "%lu:%s", dcc[idx].sock, botf);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
After:
`gcc -Wall -Wformat=2 -Wno-format-nonliteral -Wformat-overflow=2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c botmsg.c`
No functional change