### PR TITLE
add check for isidentified

### DIFF
--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -210,7 +210,7 @@ static int tcl_isidentified STDVAR {
   }
   while (chan && (thechan == NULL || thechan == chan)) {
     if ((m = ismember(chan, argv[1]))) {
-      if (strcmp(m->account, "")) {
+      if (strcmp(m->account, "*") && strcmp(m->account, "")) {
         Tcl_AppendResult(irp, "1", NULL);
         return TCL_OK;
       }


### PR DESCRIPTION
Found by: @crazycatdevs 
Patch by: Geo
Fixes: #1533 

One-line summary: Missing check for a user that has not been definitively confirmed as identified or unidentified