### PR TITLE
Cleanup includes

### DIFF
--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -89,13 +89,6 @@
 #define PASSWORDMAX 30 /* highest value compatible to older eggdrop */
 #define PASSWORDLEN PASSWORDMAX + 1
 
-
-/* We have to generate compiler errors in a weird way since not all compilers
- * support the #error preprocessor directive. */
-#ifndef STDC_HEADERS
-#  include "Error: Your system must have standard ANSI C headers."
-#endif
-
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -57,12 +57,7 @@
 #  define TCL_CONST86
 #endif
 
-#ifdef HAVE_STDARG_H
-#  include <stdarg.h>
-#else
-#  error "Must have stdarg.h"
-#endif
-
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup includes

Additional description (if needed):
We check for STDC_HEADERS during configure, and if check fails, error out:
https://github.com/eggheads/eggdrop/blob/develop/aclocal.m4#L211-L225
So we dont have to check again later. Checking for STDC headers also checks for stdarg.h.

Test cases demonstrating functionality (if applicable):
No functional change