### PR TITLE
TCL_INTERP_DESTROYED -> Tcl_InterpDeleted()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1705,8 +1705,9 @@ char *traced_myiphostname(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
 {
   const char *value;
 
-  if (flags & TCL_INTERP_DESTROYED)
+  if (Tcl_InterpDeleted(irp))
     return NULL;
+
   /* Recover trace in case of unset. */
   if (flags & TCL_TRACE_DESTROYED) {
     Tcl_TraceVar2(irp, name1, name2, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS, traced_myiphostname, cd);


### PR DESCRIPTION
Found by: moonlightz
Patch by: michaelortmann
Fixes: #1532

One-line summary:
TCL_INTERP_DESTROYED -> Tcl_InterpDeleted()

Additional description (if needed):
see https://core.tcl-lang.org/tips/doc/trunk/tip/543.md

There is more to do to make eggdrop compatible (and not segfaulting) with upcoming tcl version 9, but this PR fixes a "low hanging fruit" in this regard.

Test cases demonstrating functionality (if applicable):
```
$ LD_LIBRARY_PATH=/home/michael/opt/tcl9.0a3/lib make
[...]
net.c:1708:15: error: ‘TCL_INTERP_DESTROYED’ undeclared (first use in this function); did you mean ‘TCL_TRACE_DESTROYED’?
 1708 |   if (flags & TCL_INTERP_DESTROYED)
      |               ^~~~~~~~~~~~~~~~~~~~
      |               TCL_TRACE_DESTROYED
[...]
```