### PR TITLE
Use strcasecmp() everywhere to compare handle.

### DIFF
--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -389,7 +389,7 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
     u2 = m->user ? m->user : get_user_by_host(s);
 
-    if (!u2 || strcmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
+    if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
       dprintf(idx, "You are not a channel op on %s.\n", chan->dname);
       return;
@@ -455,7 +455,7 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
     u2 = m->user ? m->user : get_user_by_host(s);
 
-    if (!u2 || strcmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
+    if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
       dprintf(idx, "You are not a channel op on %s.\n", chan->dname);
       return;
@@ -536,7 +536,7 @@ static void cmd_voice(struct userrec *u, int idx, char *par)
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
     u2 = m->user ? m->user : get_user_by_host(s);
 
-    if (!u2 || strcmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
+    if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
       dprintf(idx, "You are not a channel op or halfop on %s.\n", chan->dname);
       return;
@@ -589,7 +589,7 @@ static void cmd_devoice(struct userrec *u, int idx, char *par)
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
     u2 = m->user ? m->user : get_user_by_host(s);
 
-    if (!u2 || strcmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
+    if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
       dprintf(idx, "You are not a channel op or halfop on %s.\n", chan->dname);
       return;

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -226,7 +226,7 @@ static int msg_addhost(char *nick, char *host, struct userrec *u, char *par)
   if (!par[0]) {
     if (!quiet_reject)
       dprintf(DP_HELP, "NOTICE %s :You must supply a hostmask\n", nick);
-  } else if (rfc_casecmp(u->handle, origbotname)) {
+  } else if (strcasecmp(u->handle, origbotname)) {
     /* This could be used as detection... */
     if (u_pass_match(u, "-")) {
       if (!quiet_reject)

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -369,7 +369,7 @@ static int tcl_handonchan STDVAR
         egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
         m->user = get_user_by_host(nuh);
       }
-      if (m->user && !rfc_casecmp(m->user->handle, argv[1])) {
+      if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         Tcl_AppendResult(irp, "1", NULL);
         return TCL_OK;
       }
@@ -1056,7 +1056,7 @@ static int tcl_hand2nicks STDVAR
         m->tried_getuser = 1;
         m->user = get_user_by_host(nuh);
       }
-      if (m->user && !rfc_casecmp(m->user->handle, argv[1])) {
+      if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         /* Is the nick of the user already in the list? */
         Tcl_ListObjGetElements(irp, nicks, &nicksc, &nicksv);
         for (i = 0; i < nicksc; i++) {
@@ -1101,7 +1101,7 @@ static int tcl_hand2nick STDVAR
         m->tried_getuser = 1;
         m->user = get_user_by_host(nuh);
       }
-      if (m->user && !rfc_casecmp(m->user->handle, argv[1])) {
+      if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         Tcl_AppendResult(irp, m->nick, NULL);
         return TCL_OK;
       }

--- a/src/users.c
+++ b/src/users.c
@@ -1033,7 +1033,7 @@ void autolink_cycle(char *start)
   }                             /* new run through the user list */
   while (u && !autc) {
     while (u && !autc) {
-      if (u->flags & USER_BOT && strcmp(u->handle, botnetnick)) {              /* ignore our own user record */
+      if (u->flags & USER_BOT && strcasecmp(u->handle, botnetnick)) {              /* ignore our own user record */
         bfl = bot_flags(u);
         if (bfl & (BOT_HUB | BOT_ALT)) {
           linked = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Use strcasecmp() everywhere to compare handle.

Additional description (if needed):
```
<thommey> strcasecmp I'd say
<thommey> rfc compare can only be known once connected to a server, which not all bots
<thommey> but should be done for nicknames
<thommey> handles aren't nicknames
```

Test cases demonstrating functionality (if applicable):
