### PR TITLE
Add Tcl 9 compatibility

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -722,7 +722,8 @@ int init_userent();
 int init_misc();
 int init_bots();
 int init_modules();
-void init_tcl(int, char **);
+void init_tcl0(int, char **);
+void init_tcl1(int, char **);
 void init_language(int);
 #ifdef TLS
 int ssl_init();
@@ -893,7 +894,7 @@ static void mainloop(int toplevel)
       }
 
       kill_tcl();
-      init_tcl(argc, argv);
+      init_tcl1(argc, argv);
       init_language(0);
 
       /* this resets our modules which we didn't unload (encryption and uptime) */
@@ -1034,6 +1035,7 @@ int main(int arg_c, char **arg_v)
   init_mem();
   if (argc > 1)
     do_arg();
+  init_tcl0(argc, argv);
   init_language(1);
 
   printf("\n%s\n", version);
@@ -1053,7 +1055,7 @@ int main(int arg_c, char **arg_v)
   init_modules();
   if (backgrd)
     bg_prepare_split();
-  init_tcl(argc, argv);
+  init_tcl1(argc, argv);
   init_language(0);
 #ifdef STATIC
   link_statics();

--- a/src/main.h
+++ b/src/main.h
@@ -41,15 +41,18 @@
 #include "eggint.h"
 #include "lush.h"
 
+#ifndef TCL_SIZE_MAX
+    typedef int Tcl_Size;
+# define Tcl_GetSizeIntFromObj Tcl_GetIntFromObj
+# define TCL_SIZE_MAX      INT_MAX
+# define TCL_SIZE_MODIFIER ""
+#endif
+
 #ifndef TCL_PATCH_LEVEL
 #  define TCL_PATCH_LEVEL "*unknown*"
 #endif
 
-#ifdef CONST
-#  define EGG_CONST CONST
-#else
-#  define EGG_CONST
-#endif
+#define EGG_CONST const
 
 #ifdef CONST86
 #  define TCL_CONST86 CONST86

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -737,7 +737,7 @@ static char *traced_globchanset(ClientData cdata, Tcl_Interp *irp,
                                 EGG_CONST char *name1,
                                 EGG_CONST char *name2, int flags)
 {
-  int i, items;
+  Tcl_Size i, items;
   char *t, *s;
   EGG_CONST char **item, *s2;
 

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1191,7 +1191,7 @@ static void cmd_mns_chrec(struct userrec *u, int idx, char *par)
 
 static void cmd_pls_chan(struct userrec *u, int idx, char *par)
 {
-  int i, argc;
+  Tcl_Size i, argc;
   EGG_CONST char **argv;
   char *chname;
   struct chanset_t *chan;

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1013,7 +1013,7 @@ static int tcl_channel_getlist(Tcl_Interp *irp, struct chanset_t *chan)
 {
   char s[121], *str;
   EGG_CONST char **argv = NULL;
-  int argc = 0;
+  Tcl_Size argc = 0;
   struct udef_struct *ul;
 
   /* String values first */
@@ -1133,7 +1133,7 @@ static int tcl_channel_get(Tcl_Interp *irp, struct chanset_t *chan,
 {
   char s[121], *str = NULL;
   EGG_CONST char **argv = NULL;
-  int argc = 0;
+  Tcl_Size argc = 0;
   struct udef_struct *ul;
 
   if (!strcmp(setting, "chanmode"))
@@ -2089,7 +2089,7 @@ static void clear_channel(struct chanset_t *chan, int reset)
  */
 static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
 {
-  int items;
+  Tcl_Size items;
   int ret = TCL_OK;
   int join = 0;
   char buf[2048], buf2[256];

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -986,7 +986,8 @@ static int tcl_account2nicks STDVAR
   struct chanset_t *chan, *thechan = NULL;
   Tcl_Obj *nicks;
   Tcl_Obj **nicksv = NULL;
-  int nicksc = 0, i, found;
+  Tcl_Size nicksc = 0, i;
+  int found;
 
   BADARGS(2, 3, " account ?channel?");
 
@@ -1032,7 +1033,8 @@ static int tcl_hand2nicks STDVAR
   struct chanset_t *chan, *thechan = NULL;
   Tcl_Obj *nicks;
   Tcl_Obj **nicksv = NULL;
-  int nicksc = 0, i, found;
+  Tcl_Size nicksc = 0, i;
+  int found;
 
   BADARGS(2, 3, " handle ?channel?");
 

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1413,6 +1413,7 @@ static int server_raw STDVAR
 
 static int server_rawt STDVAR
 {
+  Tcl_Size unused;
   Tcl_Obj *tagdict;
   Function F = (Function) cd;
 
@@ -1420,7 +1421,7 @@ static int server_rawt STDVAR
 
   CHECKVALIDITY(server_rawt);
   tagdict = Tcl_NewStringObj(argv[4], -1);
-  if (Tcl_DictObjSize(irp, tagdict, (Tcl_Size *)NULL) != TCL_OK) {
+  if (Tcl_DictObjSize(irp, tagdict, &unused) != TCL_OK) {
     /* check early, Tcl sets error string first */
     Tcl_AppendResult(irp, " in call to ", argv[0], NULL);
     return TCL_ERROR;

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1413,7 +1413,6 @@ static int server_raw STDVAR
 
 static int server_rawt STDVAR
 {
-  int unused;
   Tcl_Obj *tagdict;
   Function F = (Function) cd;
 
@@ -1421,7 +1420,7 @@ static int server_rawt STDVAR
 
   CHECKVALIDITY(server_rawt);
   tagdict = Tcl_NewStringObj(argv[4], -1);
-  if (Tcl_DictObjSize(irp, tagdict, &unused) != TCL_OK) {
+  if (Tcl_DictObjSize(irp, tagdict, (Tcl_Size *)NULL) != TCL_OK) {
     /* check early, Tcl sets error string first */
     Tcl_AppendResult(irp, " in call to ", argv[0], NULL);
     return TCL_ERROR;
@@ -1809,7 +1808,8 @@ static char *tcl_eggserver(ClientData cdata, Tcl_Interp *irp,
                            EGG_CONST char *name1,
                            EGG_CONST char *name2, int flags)
 {
-  int lc, code, i;
+  Tcl_Size lc, i;
+  int code;
   char x[1024];
   EGG_CONST char **list, *slist;
   struct server_list *q;

--- a/src/mod/server.mod/tclisupport.c
+++ b/src/mod/server.mod/tclisupport.c
@@ -67,7 +67,7 @@ int tcl_isupport STDOBJVAR
 
 static int tcl_isupport_get STDOBJVAR
 {
-  int keylen;
+  Tcl_Size keylen;
   const char *key, *value;
   Tcl_Obj *tclres;
 
@@ -95,7 +95,7 @@ static int tcl_isupport_get STDOBJVAR
 
 static int tcl_isupport_isset STDOBJVAR
 {
-  int keylen;
+  Tcl_Size keylen;
   const char *key, *value;
 
   BADOBJARGS(3, 3, 2, "setting");
@@ -109,7 +109,7 @@ static int tcl_isupport_isset STDOBJVAR
 /* not exposed for now */
 static int tcl_isupport_set STDOBJVAR
 {
-  int keylen, valuelen;
+  Tcl_Size keylen, valuelen;
   const char *key, *value;
 
   /* First one to check for type validity only */
@@ -126,7 +126,7 @@ static int tcl_isupport_set STDOBJVAR
 static int tcl_isupport_unset STDOBJVAR
 {
   struct isupport *data;
-  int keylen;
+  Tcl_Size keylen;
   const char *key;
 
   BADOBJARGS(3, 3, 2, "setting");
@@ -170,7 +170,7 @@ char *traced_isupport(ClientData cdata, Tcl_Interp *irp,
     }
     /* remove trailing space */
     if (Tcl_DStringLength(&ds))
-      Tcl_DStringTrunc(&ds, Tcl_DStringLength(&ds) - 1);
+      Tcl_DStringSetLength(&ds, Tcl_DStringLength(&ds) - 1);
     Tcl_SetVar2(interp, name1, name2, Tcl_DStringValue(&ds), TCL_GLOBAL_ONLY);
     Tcl_DStringFree(&ds);
 

--- a/src/net.c
+++ b/src/net.c
@@ -1708,7 +1708,7 @@ char *traced_myiphostname(ClientData cd, Tcl_Interp *irp, EGG_CONST char *name1,
 {
   const char *value;
 
-  if (flags & TCL_INTERP_DESTROYED)
+  if (Tcl_InterpDeleted(irp))
     return NULL;
   /* Recover trace in case of unset. */
   if (flags & TCL_TRACE_DESTROYED) {

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -925,7 +925,9 @@ void init_tcl0(int argc, char **argv)
    * the environment variable PATH for it to register anything.
    */
   Tcl_FindExecutable(argv[0]);
+#if TCL_MAJOR_VERSION >= 9
   Tcl_InitSubsystems();
+#endif
 }
 
 /* Not going through Tcl's crazy main() system (what on earth was he

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -901,17 +901,10 @@ void init_unicodesup(void)
 }
 #endif /* TCL_WORKAROUND_UNICODESUP */
 
-/* Not going through Tcl's crazy main() system (what on earth was he
- * smoking?!) so we gotta initialize the Tcl interpreter
- */
-void init_tcl(int argc, char **argv)
+void init_tcl0(int argc, char **argv)
 {
   Tcl_NotifierProcs notifierprocs;
-
-  const char *encoding;
-  int i, j;
-  char *langEnv, pver[1024] = "";
-
+ 
   egg_bzero(&notifierprocs, sizeof(notifierprocs));
   notifierprocs.initNotifierProc = tickle_InitNotifier;
   notifierprocs.createFileHandlerProc = tickle_CreateFileHandler;
@@ -923,8 +916,8 @@ void init_tcl(int argc, char **argv)
   notifierprocs.serviceModeHookProc = tickle_ServiceModeHook;
 
   Tcl_SetNotifier(&notifierprocs);
-
-/* This must be done *BEFORE* Tcl_SetSystemEncoding(),
+  
+  /* This must be done *BEFORE* Tcl_SetSystemEncoding(),
  * or Tcl_SetSystemEncoding() will cause a segfault.
  */
   /* This is used for 'info nameofexecutable'.
@@ -932,6 +925,17 @@ void init_tcl(int argc, char **argv)
    * the environment variable PATH for it to register anything.
    */
   Tcl_FindExecutable(argv[0]);
+  Tcl_InitSubsystems();
+}
+
+/* Not going through Tcl's crazy main() system (what on earth was he
+ * smoking?!) so we gotta initialize the Tcl interpreter
+ */
+void init_tcl1(int argc, char **argv)
+{
+  const char *encoding;
+  int i, j;
+  char *langEnv, pver[1024] = "";
 
   /* Initialize the interpreter */
   interp = Tcl_CreateInterp();

--- a/src/userent.c
+++ b/src/userent.c
@@ -1036,7 +1036,8 @@ static int xtra_pack(struct userrec *u, struct user_entry *e)
 
 static void xtra_display(int idx, struct user_entry *e)
 {
-  int code, lc, j;
+  int code;
+  Tcl_Size lc, j;
   EGG_CONST char **list;
   struct xtra_key *xk;
 


### PR DESCRIPTION
Found by: n/a
Patch by: DasBrain
Fixes: #1532

One-line summary:
Makes eggdrop compatible with Tcl 9.0b1

Additional description (if needed):
`init_tcl` has been split into 2 parts:
1. `init_tcl0` sets the notifier, calls `Tcl_FindExecutable` and if Tcl >= 9 calls `Tcl_InitSubsystem`.
2. `init_tcl1` does the rest.
`init_tcl0` must be called before the thread local storage is used.

Tests show that this compiles and runs with both Tcl 8.6.11 and Tcl 9.0b1.

Following minor changes have been made:
* Replace `TCL_INTERP_DESTROYED` with `Tcl_InterpDeleted()` (also see #1537)
* Define `EGG_CONST` as `const` (`CONST` is gone)
* Introduce `Tcl_Size` - which is `typedef int Tcl_Size` if not provided by tcl.h
* Update variable types to `Tcl_Size` where needed.
* Replace `Tcl_DStringTrunc` with `Tcl_DStringSetLength`

Test cases demonstrating functionality (if applicable):
* [Tcl9Eggdrop] (<redacted>): Running Eggdrop 1.9.5+python 1090505 with Tcl 9.0b
* [Tcl8Eggdrop] (<redacted>): Running Eggdrop 1.9.5+python 1090505 with Tcl 8.6.