### PR TITLE
Cleanup get_user_by_handle()

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -140,20 +140,6 @@ struct userrec *check_chanlist(const char *host)
   return NULL;
 }
 
-/* Shortcut for get_user_by_handle -- might have user record in channels
- */
-struct userrec *check_chanlist_hand(const char *hand)
-{
-  struct chanset_t *chan;
-  memberlist *m;
-
-  for (chan = chanset; chan; chan = chan->next)
-    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
-      if (m->user && !strcasecmp(m->user->handle, hand))
-        return m->user;
-  return NULL;
-}
-
 /* Clear the user pointers in the chanlists.
  *
  * Necessary when a hostmask is added/removed, a user is added or a new

--- a/src/proto.h
+++ b/src/proto.h
@@ -338,7 +338,6 @@ void correct_handle(char *);
 int write_user(struct userrec *, FILE *, int);
 int write_ignores(FILE *f, int);
 void write_userfile(int);
-struct userrec *check_dcclist_hand(char *);
 void touch_laston(struct userrec *, char *, time_t);
 void user_del_chan(char *);
 int check_conflags(struct flag_record *fr, int md);

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -161,13 +161,29 @@ int count_users(struct userrec *bu)
   return tot;
 }
 
-struct userrec *check_dcclist_hand(char *handle)
+/* Shortcut for get_user_by_handle -- might have user record in dccs
+ */
+static struct userrec *check_dcclist_hand(char *handle)
 {
   int i;
 
   for (i = 0; i < dcc_total; i++)
     if (!strcasecmp(dcc[i].nick, handle))
       return dcc[i].user;
+  return NULL;
+}
+
+/* Shortcut for get_user_by_handle -- might have user record in channels
+ */
+static struct userrec *check_chanlist_hand(const char *hand)
+{
+  struct chanset_t *chan;
+  memberlist *m;
+
+  for (chan = chanset; chan; chan = chan->next)
+    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
+      if (m->user && !strcasecmp(m->user->handle, hand))
+        return m->user;
   return NULL;
 }
 
@@ -191,7 +207,6 @@ struct userrec *get_user_by_account(char *acct)
   }
   return NULL;
 }
-
 
 struct userrec *get_user_by_handle(struct userrec *bu, char *handle)
 {

--- a/src/users.h
+++ b/src/users.h
@@ -185,7 +185,6 @@ struct userrec *get_user_by_host(char *);
 struct userrec *get_user_by_account(char *);
 struct userrec *get_user_by_nick(char *);
 struct userrec *check_chanlist(const char *);
-struct userrec *check_chanlist_hand(const char *);
 
 /* All the default userentry stuff, for code re-use
  */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup `get_user_by_handle()`

Additional description (if needed):
`get_user_by_handle()` is probably _the_ (or one of the few) funcs where cpu cycles are burned in an otherwise very very cpu friendly eggdrop.
that lookup function doesnt use a hashtable (yet) but we can still clean it up and safe some cycles.
this PR makes 2 functions used only by `get_user_by_handle()` static which enables compiler optimization.

Test cases demonstrating functionality (if applicable):
No functional change.