### PR TITLE
Fix strcpy-param-overlap

### DIFF
--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -212,11 +212,14 @@ static void dcc_files_pass(int idx, char *buf, int x)
  */
 static int got_files_cmd(int idx, char *msg)
 {
+  const char *filt;
   char *code;
 
-  strcpy(msg, check_tcl_filt(idx, msg));
-  if (!msg[0])
+  filt = check_tcl_filt(idx, msg);
+  if (!filt[0])
     return 1;
+  if (filt != msg)
+    strcpy(msg, filt);
   if (msg[0] == '.')
     msg++;
   code = newsplit(&msg);
@@ -225,13 +228,17 @@ static int got_files_cmd(int idx, char *msg)
 
 static void dcc_files(int idx, char *buf, int i)
 {
+  const char*filt;
+
   if (buf[0] && detect_dcc_flood(&dcc[idx].timeval, dcc[idx].u.file->chat,
       idx))
     return;
   dcc[idx].timeval = now;
-  strcpy(buf, check_tcl_filt(idx, buf));
-  if (!buf[0])
+  filt = check_tcl_filt(idx, buf);
+  if (!filt[0])
     return;
+  if (filt != buf)
+    strcpy(buf, filt);
   touch_laston(dcc[idx].user, "filearea", now);
   if (buf[0] == ',') {
     for (i = 0; i < dcc_total; i++) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1111 

One-line summary:
Fix strcpy-param-overlap

Additional description (if needed):
If your distribution or you compile with `CFLAGS` `-fsanitize=address` eggdrop could abort-crash

Test cases demonstrating functionality (if applicable):
compiled eggdrop with `-fsanitize=address`, run it, load filesys mod (default), issue command `.files` then `ls`.
```
$ ./eggdrop -t BotB.conf
[...]
.files
[...]
ls
=================================================================
==666518==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x7829b7b39170,0x7829b7b39173) and [0x7829b7b39170, 0x7829b7b39173) overlap
    #0 0x7829ba8a8be8 in __interceptor_strcpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:438
    #1 0x7829b54ba1da in dcc_files .././filesys.mod/filesys.c:232
[...]
==666518==ABORTING
$
```

```
[...]
ls
=================================================================
==731401==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x7bb2a5339170,0x7bb2a5339173) and [0x7bb2a5339170, 0x7bb2a5339173) overlap
    #0 0x7bb2a82a8be8 in __interceptor_strcpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:438
    #1 0x7bb2a2cb9a49 in got_files_cmd .././filesys.mod/filesys.c:217
[...]
==731401==ABORTING
$
```