### PR TITLE
Fix SERVER_NICKLEN off-by-one error

### DIFF
--- a/src/mod/filesys.mod/files.c
+++ b/src/mod/filesys.mod/files.c
@@ -425,6 +425,12 @@ static void cmd_reget_get(int idx, char *par, int resend)
   long where = 0;
   int nicklen = NICKLEN;
 
+  if (!par[0]) {
+    dprintf(idx, "%s: %sget <file(s)> [nickname]\n", MISC_USAGE,
+            resend ? "re" : "");
+    return;
+  }
+  what = newsplit(&par);
   /* Get the nick length if necessary. */
   if (NICKLEN > 9) {
     module_entry *me = module_find("server", 1, 1);
@@ -432,12 +438,6 @@ static void cmd_reget_get(int idx, char *par, int resend)
     if (me && me->funcs)
       nicklen = (*(int *)me->funcs[SERVER_NICKLEN]);
   }
-  if (!par[0]) {
-    dprintf(idx, "%s: %sget <file(s)> [nickname]\n", MISC_USAGE,
-            resend ? "re" : "");
-    return;
-  }
-  what = newsplit(&par);
   if (strlen(par) > nicklen) {
     dprintf(idx, "%s", FILES_BADNICK);
     return;

--- a/src/mod/modvals.h
+++ b/src/mod/modvals.h
@@ -72,7 +72,7 @@
 /* Server */
 #define SERVER_BOTNAME            4
 #define SERVER_BOTUSERHOST        5
-#define SERVER_NICKLEN           38
+#define SERVER_NICKLEN           37
 /* IRC */
 #define IRC_RECHECK_CHANNEL       15
 #define IRC_RECHECK_CHANNEL_MODES 17


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix SERVER_NICKLEN off-by-one error

Additional description (if needed):
https://github.com/eggheads/eggdrop/blob/4703f71067437c361ca8d5c8c4a09d41561a7a20/src/mod/filesys.mod/files.c#L433
https://github.com/eggheads/eggdrop/blob/4703f71067437c361ca8d5c8c4a09d41561a7a20/src/mod/modvals.h#L75
https://github.com/eggheads/eggdrop/blob/4703f71067437c361ca8d5c8c4a09d41561a7a20/src/mod/server.mod/server.h#L83-L84
Test cases demonstrating functionality (if applicable):
Bug can be triggert by loading server mod and filesys mod, starting eggdrop and issuing `.files` and `get`
I didnt analyze the implication any further, but this has crash potential, because currently it would not only set nicklen to a random value (in my test 1447122753) but also trigger a load of misaligned address