### PR TITLE
Dont realloc (and fix use after free in 3rd party modules)

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -2000,15 +2000,11 @@ static void init_channel(struct chanset_t *chan, int reset)
   int flags = reset ? reset : CHAN_RESETALL;
 
   if (flags & CHAN_RESETWHO) {
-    if (chan->channel.member) {
-      nfree(chan->channel.member); 
-    }
     chan->channel.members = 0;
-    chan->channel.member = nmalloc(sizeof *chan->channel.member);
+    if (!chan->channel.member)
+      chan->channel.member = nmalloc(sizeof *chan->channel.member);
     /* Since we don't have channel_malloc, manually bzero */
     egg_bzero(chan->channel.member, sizeof *chan->channel.member);
-    chan->channel.member->nick[0] = 0;
-    chan->channel.member->next = NULL;
   }
 
   if (flags & CHAN_RESETMODES) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Dont realloc

Additional description (if needed):
No need to realloc. Besides the cleaning up, it will help with real world problem. Modules like starts.mod copy channel member pointers and suffer from use after free. A problem that is very hard to fix (and find) in those modules.

Test cases demonstrating functionality (if applicable):
No functional change for eggdrop core / channel mod.