### PR TITLE
Enhance verification and error logging of userfile perm.

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1422,6 +1422,7 @@ void make_rand_str(char *s, const int len)
 
 /* Convert an octal string into a decimal integer value.  If the string
  * is empty or contains non-octal characters, -1 is returned.
+ * Deprecated, use strtol() instead.
  */
 int oatoi(const char *octal)
 {

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -183,9 +183,10 @@ static char *tcl_eggint(ClientData cdata, Tcl_Interp *irp,
                         EGG_CONST char *name1,
                         EGG_CONST char *name2, int flags)
 {
-  char *s, s1[40];
+  char *s, s1[40], *endptr;
   long l;
   intinfo *ii = (intinfo *) cdata;
+  int p;
 
   if (flags & (TCL_TRACE_READS | TCL_TRACE_UNSETS)) {
     /* Special cases */
@@ -223,10 +224,9 @@ static char *tcl_eggint(ClientData cdata, Tcl_Interp *irp,
 
         default_uflags = fr.udef_global;
       } else if ((int *) ii->var == &userfile_perm) {
-        int p = oatoi(s);
-
-        if (p <= 0)
-          return "Invalid userfile permissions";
+	p = strtol(s, &endptr, 8);
+        if ((p < 01) || (p > 0777) || (*endptr))
+          return "Invalid userfile permissions, must be octal between 01 and 0777";
         userfile_perm = p;
       } else if ((ii->ro == 2) || ((ii->ro == 1) && protect_readonly))
         return "Read-only variable";


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance verification and error logging of userfile perm.

Additional description (if needed):
Use strtol() instead of homebrew oatoi().

Test cases demonstrating functionality (if applicable):
```
.set userfile-perm 
Currently: 0600
```

```
.set userfile-perm 0
Error: can't set "userfile-perm": Invalid userfile permissions, must be octal between 01 and 0777
```

```
.set userfile-perm 0660   
Ok, set.
```

```
.set userfile-perm 01000
Error: can't set "userfile-perm": Invalid userfile permissions, must be octal between 01 and 0777
```

```
.set userfile-perm foo
Error: can't set "userfile-perm": Invalid userfile permissions, must be octal between 01 and 0777
```