### PR TITLE
Fix autoconf of tls action-if-not-given

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1520,7 +1520,7 @@ AC_DEFUN([EGG_TLS_ENABLE],
   AC_MSG_CHECKING([whether to enable TLS support])
   AC_ARG_ENABLE(tls,
     [  --disable-tls           disable TLS support ], [tls_enabled="$enableval"],
-    [tls_enabled="$enableval"])
+    [tls_enabled="yes"])
 
   AC_MSG_RESULT([$tls_enabled])
 ])


### PR DESCRIPTION
Found by: ZarTek-Creole
Patch by: michaelortmann
Fixes: #1554

One-line summary:
Fix autoconf of tls action-if-not-given

Additional description (if needed):
Please run **misc/runautotools** after merge

Test cases demonstrating functionality (if applicable):
**Before:**
```
./configure --disable-ipv6
[...]
IPv6 Support: no
Tcl version: 8.6.14 (threaded)
SSL/TLS Support: no
Threaded DNS core: yes
[...]
```
**After:**
```
misc/runautotools
./configure --disable-ipv6
[...]
IPv6 Support: no
Tcl version: 8.6.14 (threaded)
SSL/TLS Support: yes (OpenSSL 3.2.1 30 Jan 2024)
Threaded DNS core: yes
[...]
```