### PR TITLE
Fix possible memleak: defer putlog() from dns threads to main thread

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -563,6 +563,8 @@ void *thread_dns_ipbyhost(void *arg)
   }
   else if (error == EAI_NONAME)
     snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: not known", dtn->host);
+  else if (error == EAI_SYSTEM)
+    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: %s: %s", dtn->host, gai_strerror(error), strerror(errno));
   else
     snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: %s", dtn->host, gai_strerror(error));
   pthread_mutex_lock(&dtn->mutex);

--- a/src/dns.c
+++ b/src/dns.c
@@ -543,16 +543,19 @@ void *thread_dns_ipbyhost(void *arg)
       }
     }
 #else
-    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): hostname %s: no ipv4", dtn->host);
+    error = 1;
     for (res = res0; res; res = res->ai_next) {
       if (res->ai_family == AF_INET) {
         addr->family = res->ai_family;
         addr->addrlen = res->ai_addrlen;
         memcpy(&addr->addr.sa, res->ai_addr, res->ai_addrlen);
+	error = 0;
         *dtn->strerror = 0;
         break;
       }
     }
+    if (error)
+      snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): hostname %s: no ipv4", dtn->host);
 #endif
     if (res0) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
                * 2553 and 3493. Avoid to be compatible with all OSes. */

--- a/src/dns.c
+++ b/src/dns.c
@@ -507,7 +507,7 @@ void *thread_dns_hostbyip(void *arg)
   if (!i)
     *dtn->strerror = 0;
   else {
-    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_hostbyip(): getnameinfo(): hostname %s: %s", dtn->host, gai_strerror(i));
+    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_hostbyip(): getnameinfo(): %s", gai_strerror(i));
 #ifdef IPV6
     if (addr->family == AF_INET6)
       inet_ntop(AF_INET6, &addr->addr.s6.sin6_addr, dtn->host, sizeof dtn->host);
@@ -555,18 +555,18 @@ void *thread_dns_ipbyhost(void *arg)
       }
     }
     if (error)
-      snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): hostname %s: no ipv4", dtn->host);
+      snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): no ipv4");
 #endif
     if (res0) /* The behavior of freeadrinfo(NULL) is left unspecified by RFCs
                * 2553 and 3493. Avoid to be compatible with all OSes. */
       freeaddrinfo(res0);
   }
   else if (error == EAI_NONAME)
-    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: not known", dtn->host);
+    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): not known");
   else if (error == EAI_SYSTEM)
-    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: %s: %s", dtn->host, gai_strerror(error), strerror(errno));
+    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): %s: %s", gai_strerror(error), strerror(errno));
   else
-    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): hostname %s: %s", dtn->host, gai_strerror(error));
+    snprintf(dtn->strerror, sizeof dtn->strerror, "dns: thread_dns_ipbyhost(): getaddrinfo(): %s", gai_strerror(error));
   pthread_mutex_lock(&dtn->mutex);
   close(dtn->fildes[1]);
   pthread_mutex_unlock(&dtn->mutex);

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -757,7 +757,7 @@ struct dns_thread_node {
   int type;
   sockname_t addr;
   char host[256];
-  char strerror[256 + 128]; /* hostname + gai_strerror() + msg */
+  char strerror[256]; /* msg + gai_strerror() + strerror() */
   struct dns_thread_node *next;
 };
 

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -757,7 +757,7 @@ struct dns_thread_node {
   int type;
   sockname_t addr;
   char host[256];
-  char strerror[319];
+  char strerror[256 + 128]; /* hostname + gai_strerror() + msg */
   struct dns_thread_node *next;
 };
 

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -757,7 +757,7 @@ struct dns_thread_node {
   int type;
   sockname_t addr;
   char host[256];
-  int ok;
+  char strerror[319];
   struct dns_thread_node *next;
 };
 

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -757,7 +757,7 @@ struct dns_thread_node {
   int type;
   sockname_t addr;
   char host[256];
-  char strerror[256]; /* msg + gai_strerror() + strerror() */
+  char strerror[3 * 64]; /* msg + gai_strerror() + strerror() */
   struct dns_thread_node *next;
 };
 

--- a/src/net.c
+++ b/src/net.c
@@ -1053,16 +1053,18 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
 #ifdef EGG_TDNS
   dtn_prev = dns_thread_head;
   for (dtn = dtn_prev->next; dtn; dtn = dtn->next) {
+    if (*dtn->strerror)
+      debug0(dtn->strerror);
     fd = dtn->fildes[0];
     if (FD_ISSET(fd, &fdr)) {
       if (dtn->type == DTN_TYPE_HOSTBYIP) {
         pthread_mutex_lock(&dtn->mutex);
-        call_hostbyip(&dtn->addr, dtn->host, dtn->ok);
+        call_hostbyip(&dtn->addr, dtn->host, !*dtn->strerror);
         pthread_mutex_unlock(&dtn->mutex);
       }
       else {
         pthread_mutex_lock(&dtn->mutex);
-        call_ipbyhost(dtn->host, &dtn->addr, dtn->ok);
+        call_ipbyhost(dtn->host, &dtn->addr, !*dtn->strerror);
         pthread_mutex_unlock(&dtn->mutex);
       }
       close(dtn->fildes[0]);

--- a/src/net.c
+++ b/src/net.c
@@ -1054,7 +1054,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
   dtn_prev = dns_thread_head;
   for (dtn = dtn_prev->next; dtn; dtn = dtn->next) {
     if (*dtn->strerror)
-      debug0(dtn->strerror);
+      debug2("%s: hostname %s", dtn->strerror, dtn->host);
     fd = dtn->fildes[0];
     if (FD_ISSET(fd, &fdr)) {
       if (dtn->type == DTN_TYPE_HOSTBYIP) {


### PR DESCRIPTION
Found by: if it fixes #1545 then Mystery-X else michaelortmann
Patch by: michaelortmann
Fixes: **could** fix #1545

One-line summary:
Fix possible memory leak:  defer debug() / putlog() from dns threads to main thread via dtn.strerror

Additional description (if needed):
valgrind doesnt like 

Test cases demonstrating functionality (if applicable):
**Test 1: 1 error in dnslookup leaks 144 bytes**
```
$ valgrind --leak-check=full ./eggdrop -t BotA.conf
.tcl dnslookup foo bar
.die
==619111== 144 (16 direct, 128 indirect) bytes in 1 blocks are definitely lost in loss record 375 of 543
==619111==    at 0x4843788: malloc (vg_replace_malloc.c:442)
==619111==    by 0x49A36DA: TSDTableCreate (tclThreadStorage.c:88)
==619111==    by 0x49A36DA: TclThreadStorageKeySet (tclThreadStorage.c:230)
==619111==    by 0x49A25DC: Tcl_GetThreadData (tclThread.c:92)
==619111==    by 0x4981DE3: TclFreeObj (tclObj.c:1444)
==619111==    by 0x49B1DD4: CleanupVar (tclVar.c:344)
==619111==    by 0x49B1DD4: TclPtrUnsetVarIdx (tclVar.c:2513)
==619111==    by 0x49B49E8: TclObjUnsetVar2 (tclVar.c:2386)
==619111==    by 0x49B4B16: Tcl_UnsetVar2 (tclVar.c:2338)
==619111==    by 0x153CF7: check_tcl_bind (tclhash.c:955)
==619111==    by 0x154F25: check_tcl_log (tclhash.c:1252)
==619111==    by 0x143998: putlog (misc.c:563)
==619111==    by 0x13A158: thread_dns_ipbyhost (dns.c:560)
==619111==    by 0x51ED559: start_thread (pthread_create.c:447)
```

**Test 2: 2 errors in (2) dnslookup leaks 288 bytes, so its scaling *ouch***
```
$ valgrind --leak-check=full ./eggdrop -t BotA.conf
.tcl dnslookup foo bar
.tcl dnslookup foo bar
.die
==658361== 288 (32 direct, 256 indirect) bytes in 2 blocks are definitely lost in loss record 402 of 543
==658361==    at 0x4843788: malloc (vg_replace_malloc.c:442)
==658361==    by 0x49A36DA: TSDTableCreate (tclThreadStorage.c:88)
==658361==    by 0x49A36DA: TclThreadStorageKeySet (tclThreadStorage.c:230)
==658361==    by 0x49A25DC: Tcl_GetThreadData (tclThread.c:92)
==658361==    by 0x4981DE3: TclFreeObj (tclObj.c:1444)
==658361==    by 0x49B1DD4: CleanupVar (tclVar.c:344)
==658361==    by 0x49B1DD4: TclPtrUnsetVarIdx (tclVar.c:2513)
==658361==    by 0x49B49E8: TclObjUnsetVar2 (tclVar.c:2386)
==658361==    by 0x49B4B16: Tcl_UnsetVar2 (tclVar.c:2338)
==658361==    by 0x153CF7: check_tcl_bind (tclhash.c:955)
==658361==    by 0x154F25: check_tcl_log (tclhash.c:1252)
==658361==    by 0x143998: putlog (misc.c:563)
==658361==    by 0x13A158: thread_dns_ipbyhost (dns.c:560)
==658361==    by 0x51ED559: start_thread (pthread_create.c:447)
```

gccs LeakSanitizer also finds it, but valgrinds report is more detailed