### PR TITLE
Enhance auto detection of python-config

### DIFF
--- a/src/mod/python.mod/configure.ac
+++ b/src/mod/python.mod/configure.ac
@@ -21,7 +21,7 @@ python_avail="false"
 
 if test "x$egg_enable_python" != "xno"; then
   if test "x$egg_with_python_config" = "x"; then
-    AC_PATH_PROGS([python_config_bin], [python3-config python-config])
+    AC_PATH_PROGS([python_config_bin], [python3-config python-config python3.12-config python3.11-config python3.10-config python3.9-config python3.8-config])
   else
     if test -d "$egg_with_python_config"; then
       AC_MSG_NOTICE([Checking for python-config binaries in $egg_with_python_config])


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance auto detection of python-config

Additional description (if needed):
Operating systems like FreeBSD do not automatically have a symlink of python3-config or python-config, but only the direct python3.*-config
This PR doesnt make auto detection complete on my test system, but its a first step and certainly an enhancement of status quo
**Please run `misc/runautotools` when merging this PR**

Test cases demonstrating functionality (if applicable):
**Before:**
```
$ make config
[...]
Configuring module 'python'.
configure: loading cache ../../../config.cache
checking for grep that handles long lines and -e... /usr/bin/grep
checking for fgrep... /usr/bin/grep -F
checking whether to compile the Python module... autodetect
checking for python3-config... no
checking for python-config... no
configure: warning:

  Your system does not provide a working python-config binary.
  The python module will therefore be disabled.
[...]
```
**After:**
```
$ make config
[...]
Configuring module 'python'.
configure: loading cache ../../../config.cache
checking for grep that handles long lines and -e... /usr/bin/grep
checking for fgrep... /usr/bin/grep -F
checking for python3-config... no
checking for python-config... no
checking for python3.12-config... no
checking for python3.11-config... no
checking for python3.10-config... no
checking for python3.9-config... /usr/local/bin/python3.9-config
checking whether python-config supports --embed... yes
checking for python C flags... -I/usr/local/include/python3.9 -I/usr/local/include/python3.9  -Wno-unused-result -Wsign-compare -Wunreachable-code -O2 -pipe  -fstack-protector-strong -fno-strict-aliasing  -DNDEBUG 
checking for python LD flags...  -L/usr/local/lib -lpython3.9 -lcrypt -lintl -ldl -L/usr/local/lib -lintl -lutil -lm -lm 
checking for python... no
configure: WARNING: Cannot find python in your system path
.././python.mod/configure: -c: not found
checking for gawk... no
checking for mawk... no
checking for nawk... nawk
checking  version is >= 3.8.0... no ()
configure: WARNING: Eggdrop requires python version 3.8.0 or higher

  There was an issue with your python installation.
  Please read python.mod/config.log for more details.
  The python module will be disabled.
[...]
```