### PR TITLE
Enhance module status report for zlib and python

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -303,10 +303,10 @@ static void write_debug()
             tcl_resultstring() : "*unknown*");
 
     /* info tclversion/patchlevel */
-    dprintf(-x, "Tcl version: %s (header version %s)\n",
+    dprintf(-x, "Tcl version: %s (header version " TCL_PATCH_LEVEL ")\n",
             ((interp) && (Tcl_Eval(interp, "info patchlevel") == TCL_OK)) ?
             tcl_resultstring() : (Tcl_Eval(interp, "info tclversion") == TCL_OK) ?
-            tcl_resultstring() : "*unknown*", TCL_PATCH_LEVEL);
+            tcl_resultstring() : "*unknown*");
 
     if (tcl_threaded())
       dprintf(-x, "Tcl is threaded\n");

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -396,7 +396,7 @@ static int compress_report(int idx, int details)
   if (details) {
     int size = compress_expmem();
 
-    dprintf(idx, "    zlib version %s\n", ZLIB_VERSION);
+    dprintf(idx, "    zlib version: %s (header version %s)\n", zlibVersion(), ZLIB_VERSION);
     dprintf(idx, "    %u file%s compressed\n", compressed_files,
             (compressed_files != 1) ? "s" : "");
     dprintf(idx, "    %u file%s uncompressed\n", uncompressed_files,

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -396,7 +396,7 @@ static int compress_report(int idx, int details)
   if (details) {
     int size = compress_expmem();
 
-    dprintf(idx, "    zlib version: %s (header version %s)\n", zlibVersion(), ZLIB_VERSION);
+    dprintf(idx, "    zlib version: %s (header version " ZLIB_VERSION ")\n", zlibVersion());
     dprintf(idx, "    %u file%s compressed\n", compressed_files,
             (compressed_files != 1) ? "s" : "");
     dprintf(idx, "    %u file%s uncompressed\n", uncompressed_files,

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -113,7 +113,7 @@ static void kill_python() {
 static void python_report(int idx, int details)
 {
   if (details)
-    dprintf(idx, "    python version: %s (header version %s)\n", Py_GetVersion(), PY_VERSION);
+    dprintf(idx, "    python version: %s (header version " PY_VERSION ")\n", Py_GetVersion());
 }
 
 static char *python_close()

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -112,7 +112,8 @@ static void kill_python() {
 
 static void python_report(int idx, int details)
 {
-  // TODO
+  if (details)
+    dprintf(idx, "    python version: %s (header version %s)\n", Py_GetVersion(), PY_VERSION);
 }
 
 static char *python_close()


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance module status report for zlib and python

Additional description (if needed):
let modules report version of used runtime lib and comptime header the same way eggdrop core does for tcl and tls

Test cases demonstrating functionality (if applicable):
```
.load compress
.load python
.status all
[...]
  Module: python, v 0.1
    python version: 3.11.8 (main, Feb 12 2024, 14:50:05) [GCC 13.2.1 20230801] (header version 3.11.8)
  Module: compress, v 1.2
    zlib version: 1.3.1 (header version 1.3.1)
[...]
```