### PR TITLE
Do not call a modules restart() function if it is null pointer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -900,7 +900,10 @@ static void mainloop(int toplevel)
       for (p = module_list; p; p = p->next) {
         if (p->funcs) {
           startfunc = p->funcs[MODCALL_START];
-          startfunc(NULL);
+          if (startfunc)
+            startfunc(NULL);
+          else
+            debug2("module: %s: %s", p->name, MOD_NOSTARTDEF);
         }
       }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Do not call a modules restart() function if it is null pointer

Additional description (if needed):
Also helpful for mod development, because a debug message is printed

Test cases demonstrating functionality (if applicable):
Tested with a test module:
**Before:**
```
.reload
[...]
```
segfault
**After:**
```
.reload
[...]
[15:34:39] module: zig: No start function defined.
```