### PR TITLE
Un-hardcode buffer size

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -407,7 +407,7 @@ void tell_settings(int idx)
 
 void reaffirm_owners()
 {
-  char *p, *q, s[121];
+  char *p, *q, s[sizeof owner];
   struct userrec *u;
 
   /* Please stop breaking this function. */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Un-hardcode buffer size

Additional description (if needed):
No functional change

Test cases demonstrating functionality (if applicable):
