### PR TITLE
Add tcl pbkdf2 function

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -2208,9 +2208,7 @@ encpass2 <pass>
 ^^^^^^^^^^^^^^^
 
 
-  Returns: hash = "$pbkdf2-<digest>$rounds=<rounds>$<salt>$<hash>" (PHC string format)
-        salt and hash = base64
-        NULL = error
+  Returns: a hash in the format of "$pbkdf2-<digest>$rounds=<rounds>$<salt>$<hash>" where digest is the digest set in the config variable pbkdf2-method, rounds is the number of rounds set in the config variable pbkdf2-rounds, salt is the base64 salt used to generate the hash, and hash is the generated base64 hash.
 
   Module: pbkdf2
 
@@ -2218,8 +2216,7 @@ encpass2 <pass>
 pbkdf2 [-bin] <pass> <salt> <rounds> <digest>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: derived key from a password using a salt and iteration count as specified in RFC 2898 as a hexadecimal string. You may request the result as binary data by giving -bin.
-
+  Returns: a derived key from the provided "pass" string using "salt" and "rounds" count as specified in RFC 2898 as a hexadecimal string. Using the optional -bin flag will return the result as binary data.
 
   Module: pbkdf2
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -2200,6 +2200,28 @@ setflags <dir> [<flags> [channel]]
 
   Module: filesys
 
+PBKDF2 Module
+-------------
+
+^^^^^^^^^^^^^^^
+encpass2 <pass>
+^^^^^^^^^^^^^^^
+
+
+  Returns: hash = "$pbkdf2-<digest>$rounds=<rounds>$<salt>$<hash>" (PHC string format)
+        salt and hash = base64
+        NULL = error
+
+  Module: pbkdf2
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+pbkdf2 <pass> <salt> <rounds> <digest>
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Returns: derived key from a password using a salt and iteration count as specified in RFC 2898.
+
+  Module: pbkdf2
+
 Miscellaneous Commands
 ----------------------
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -2214,11 +2214,12 @@ encpass2 <pass>
 
   Module: pbkdf2
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-pbkdf2 <pass> <salt> <rounds> <digest>
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+pbkdf2 [-bin] <pass> <salt> <rounds> <digest>
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Returns: derived key from a password using a salt and iteration count as specified in RFC 2898.
+  Returns: derived key from a password using a salt and iteration count as specified in RFC 2898 as a hexadecimal string. You may request the result as binary data by giving -bin.
+
 
   Module: pbkdf2
 

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -8,6 +8,7 @@
  */
 
 #include "src/mod/module.h"
+#include "src/mod/pbkdf2.mod/tclpbkdf2.c"
 
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL /* 1.0.0 */
 #define MODULE_NAME "encryption2"
@@ -222,45 +223,6 @@ static char *pbkdf2_verify(const char *pass, const char *encrypted)
     return pbkdf2_encrypt(pass);
   return (char *) encrypted;
 }
-
-static int tcl_encpass2 STDVAR
-{
-  BADARGS(2, 2, " string");
-  Tcl_SetResult(irp, pbkdf2_encrypt(argv[1]), TCL_STATIC);
-  return TCL_OK;
-}
-
-static int tcl_pbkdf2 STDVAR
-{
-  unsigned int rounds;
-  const EVP_MD *digest;
-  int digestlen;
-  unsigned char buf[256];
-
-  BADARGS(5, 5, " pass salt rounds digest");
-  rounds = atoi(argv[3]);
-  digest = EVP_get_digestbyname(argv[4]);
-  if (!digest) {
-    Tcl_AppendResult(irp, "PBKDF2 error: Unknown message digest '", argv[4], "'.", NULL);
-    return TCL_ERROR;
-  }
-  digestlen = EVP_MD_size(digest);
-  if (!PKCS5_PBKDF2_HMAC(argv[1], strlen(argv[1]), (const unsigned char *) argv[2], strlen(argv[2]), rounds, digest, digestlen, buf)) {
-    Tcl_AppendResult(irp, "PBKDF2 key derivation error: ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
-    return TCL_ERROR;
-  }
-  buf[digestlen] = 0;
-  Tcl_Obj *result = Tcl_NewByteArrayObj(buf, digestlen);
-  explicit_bzero(buf, digestlen);
-  Tcl_SetObjResult(irp, result);
-  return TCL_OK;
-}
-
-static tcl_cmds my_tcl_cmds[] = {
-  {"encpass2", tcl_encpass2},
-  {"pbkdf2",   tcl_pbkdf2},
-  {NULL,       NULL}
-};
 
 static tcl_ints my_tcl_ints[] = {
   {"pbkdf2-re-encode", &pbkdf2_re_encode, 0},

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -226,7 +226,7 @@ static char *pbkdf2_verify(const char *pass, const char *encrypted)
 static int tcl_encpass2 STDVAR
 {
   BADARGS(2, 2, " string");
-  Tcl_AppendResult(irp, pbkdf2_encrypt(argv[1]), NULL);
+  Tcl_SetResult(irp, pbkdf2_encrypt(argv[1]), TCL_STATIC);
   return TCL_OK;
 }
 

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -108,7 +108,7 @@ static char *pbkdf2_hash(const char *pass, const char *digest_name,
                          digestlen, buf)) {
     explicit_bzero(buf, digestlen);
     explicit_bzero(out, outlen);
-    putlog(LOG_MISC, "*", "PBKDF2 error: PKCS5_PBKDF2_HMAC(): %s.",
+    putlog(LOG_MISC, "*", "PBKDF2 key derivation error: %s.",
            ERR_error_string(ERR_get_error(), NULL));
     nfree(buf);
     return NULL;
@@ -246,7 +246,7 @@ static int tcl_pbkdf2 STDVAR
   }
   digestlen = EVP_MD_size(digest);
   if (!PKCS5_PBKDF2_HMAC(argv[1], strlen(argv[1]), (const unsigned char *) argv[2], strlen(argv[2]), rounds, digest, digestlen, buf)) {
-    Tcl_AppendResult(irp, "PBKDF2 error: PKCS5_PBKDF2_HMAC(): ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
+    Tcl_AppendResult(irp, "PBKDF2 key derivation error: ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
     return TCL_ERROR;
   }
   buf[digestlen] = 0;

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -249,11 +249,10 @@ static int tcl_pbkdf2 STDVAR
     Tcl_AppendResult(irp, "PBKDF2 error: PKCS5_PBKDF2_HMAC(): ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
     return TCL_ERROR;
   }
-  else {
-    buf[digestlen] = 0;
-    Tcl_Obj *result = Tcl_NewByteArrayObj(buf, digestlen);
-    Tcl_SetObjResult(irp, result);
-  }
+  buf[digestlen] = 0;
+  Tcl_Obj *result = Tcl_NewByteArrayObj(buf, digestlen);
+  explicit_bzero(buf, digestlen);
+  Tcl_SetObjResult(irp, result);
   return TCL_OK;
 }
 

--- a/src/mod/pbkdf2.mod/tclpbkdf2.c
+++ b/src/mod/pbkdf2.mod/tclpbkdf2.c
@@ -50,7 +50,6 @@ static int tcl_pbkdf2 STDVAR
     Tcl_AppendResult(irp, "PBKDF2 key derivation error: ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
     return TCL_ERROR;
   }
-  buf[digestlen] = 0;
   if (hex) {
     for (i = 0; i < digestlen; i++)
       sprintf(buf_hex + (i * 2), "%.2X", buf[i]);

--- a/src/mod/pbkdf2.mod/tclpbkdf2.c
+++ b/src/mod/pbkdf2.mod/tclpbkdf2.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * tclpbkdf2.c -- tcl functions for pbkdf2.mod
+ *
+ * Written by thommey and Michael Ortmann
+ *
+ * Copyright (C) 2017 - 2024 Eggheads Development Team
+ */
+
+#include <openssl/err.h>
+
+static char *pbkdf2_encrypt(const char *);
+
+static int tcl_encpass2 STDVAR
+{
+  BADARGS(2, 2, " string");
+  Tcl_SetResult(irp, pbkdf2_encrypt(argv[1]), TCL_STATIC);
+  return TCL_OK;
+}
+
+static int tcl_pbkdf2 STDVAR
+{
+  unsigned int rounds;
+  const EVP_MD *digest;
+  int digestlen;
+  unsigned char buf[256];
+
+  BADARGS(5, 5, " pass salt rounds digest");
+  rounds = atoi(argv[3]);
+  digest = EVP_get_digestbyname(argv[4]);
+  if (!digest) {
+    Tcl_AppendResult(irp, "PBKDF2 error: Unknown message digest '", argv[4], "'.", NULL);
+    return TCL_ERROR;
+  }
+  digestlen = EVP_MD_size(digest);
+  if (!PKCS5_PBKDF2_HMAC(argv[1], strlen(argv[1]), (const unsigned char *) argv[2], strlen(argv[2]), rounds, digest, digestlen, buf)) {
+    Tcl_AppendResult(irp, "PBKDF2 key derivation error: ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
+    return TCL_ERROR;
+  }
+  buf[digestlen] = 0;
+  Tcl_Obj *result = Tcl_NewByteArrayObj(buf, digestlen);
+  explicit_bzero(buf, digestlen);
+  Tcl_SetObjResult(irp, result);
+  return TCL_OK;
+}
+
+static tcl_cmds my_tcl_cmds[] = {
+  {"encpass2", tcl_encpass2},
+  {"pbkdf2",   tcl_pbkdf2},
+  {NULL,       NULL}
+};

--- a/src/mod/pbkdf2.mod/tclpbkdf2.c
+++ b/src/mod/pbkdf2.mod/tclpbkdf2.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/err.h>
+#include <string.h>
 
 static char *pbkdf2_encrypt(const char *);
 
@@ -20,25 +21,44 @@ static int tcl_encpass2 STDVAR
 
 static int tcl_pbkdf2 STDVAR
 {
+  int hex, digestlen, i;
   unsigned int rounds;
   const EVP_MD *digest;
-  int digestlen;
   unsigned char buf[256];
+  char buf_hex[256];
+  Tcl_Obj *result = 0;
 
-  BADARGS(5, 5, " pass salt rounds digest");
-  rounds = atoi(argv[3]);
-  digest = EVP_get_digestbyname(argv[4]);
+  BADARGS(5, 6, " ?-bin? pass salt rounds digest");
+  if (argc == 6) {
+    if (!strcmp(argv[1], "-bin"))
+      hex = 0;
+    else {
+      Tcl_AppendResult(irp, "bad option ", argv[1], ": must be -bin", NULL);
+      return TCL_ERROR;
+    }
+  }
+  else
+    hex = 1;
+  rounds = atoi(argv[3 + !hex]);
+  digest = EVP_get_digestbyname(argv[4 + !hex]);
   if (!digest) {
-    Tcl_AppendResult(irp, "PBKDF2 error: Unknown message digest '", argv[4], "'.", NULL);
+    Tcl_AppendResult(irp, "PBKDF2 error: Unknown message digest '", argv[4 + !hex], "'.", NULL);
     return TCL_ERROR;
   }
   digestlen = EVP_MD_size(digest);
-  if (!PKCS5_PBKDF2_HMAC(argv[1], strlen(argv[1]), (const unsigned char *) argv[2], strlen(argv[2]), rounds, digest, digestlen, buf)) {
+  if (!PKCS5_PBKDF2_HMAC(argv[1 + !hex], strlen(argv[1 + !hex]), (const unsigned char *) argv[2+ !hex], strlen(argv[2 + !hex]), rounds, digest, digestlen, buf)) {
     Tcl_AppendResult(irp, "PBKDF2 key derivation error: ", ERR_error_string(ERR_get_error(), NULL), ".", NULL);
     return TCL_ERROR;
   }
   buf[digestlen] = 0;
-  Tcl_Obj *result = Tcl_NewByteArrayObj(buf, digestlen);
+  if (hex) {
+    for (i = 0; i < digestlen; i++)
+      sprintf(buf_hex + (i * 2), "%.2X", buf[i]);
+    result = Tcl_NewByteArrayObj((unsigned char *) buf_hex, digestlen * 2);
+    explicit_bzero(buf_hex, digestlen * 2);
+  }
+  else
+    result = Tcl_NewByteArrayObj(buf, digestlen);
   explicit_bzero(buf, digestlen);
   Tcl_SetObjResult(irp, result);
   return TCL_OK;


### PR DESCRIPTION
Found by: grawity
Patch by: michaelortmann
Fixes: 

One-line summary:
Add tcl pbkdf2 function

Additional description (if needed):
Useful for tcl scripts like https://github.com/grawity/eggdrop-sasl/blob/master/README.md#scram-sha-support that add SASL SCRAM mechanism, where the author said "which is very slow in Tcl so the server may time out". So this PR will help the author out with a fast replacement function exported by eggdrop. hope that helps and cheerz to grawity for his great work :)

The new tcl function pbkdf2() returns as hexadecimal string by default and -bin by option, which is similar, to what tcllibs sha256() does (older tcllibs md5 had it the other way around), see https://core.tcl-lang.org/tcllib/doc/trunk/embedded/md/tcllib/files/modules/sha1/sha256.md

Test cases demonstrating functionality (if applicable):
Benchmark times were measured with #1568 applied
**Benchmark and Result of external tcl script providing pbkdf2():**
```
.tcl source scripts/g_pbkdf2.tcl
[03:05:34] tcl: builtin dcc call: *dcc:tcl -HQ 1 source scripts/g_pbkdf2.tcl
[03:05:34] tcl: evaluate (.tcl): source scripts/g_pbkdf2.tcl
Tcl: 
.tcl pbkdf2::pbkdf2 sha256 hunter 42 1500
[03:05:45] tcl: builtin dcc call: *dcc:tcl -HQ 1 pbkdf2::pbkdf2 sha256 hunter 42 1500
[03:05:45] tcl: evaluate (.tcl): pbkdf2::pbkdf2 sha256 hunter 42 1500
3V_nep¡Ð¤òüÌê »^Ã¡ÅÊT~3ö,
```
user 514.968ms sys 0.000ms
**Benchmark and result of new pmkdf2 mod function providing pbkdf2():**
```
.tcl pbkdf2 hunter 42 1500 sha256
[08:27:07] tcl: builtin dcc call: *dcc:tcl -HQ 1 pbkdf2 hunter 42 1500 sha256
[08:27:07] tcl: evaluate (.tcl): pbkdf2 hunter 42 1500 sha256
Tcl: 150D9333565F6E6570A193D0A4F2FC97CCEAA0BB5EC3A1C5CA9454067E33F62C
.tcl pbkdf2 -bin hunter 42 1500 sha256
[08:27:17] tcl: builtin dcc call: *dcc:tcl -HQ 1 pbkdf2 -bin hunter 42 1500 sha256
[08:27:17] tcl: evaluate (.tcl): pbkdf2 -bin hunter 42 1500 sha256
3V_nep¡Ð¤òüÌê »^Ã¡ÅÊT~3ö,
```
user 0.510ms sys 0.000ms
**Test and demo of replacement function for grawities script:**
```
.tcl source scripts/g_base64.tcl
.tcl source scripts/g_pbkdf2.tcl
```
orig func:
```
.tcl set saltedPassword [::pbkdf2::pbkdf2 sha256 hunter mysalt 1500]
.tcl b64:encode $saltedPassword
Tcl: rNb2VlyBIeNaSMc9YtVcthpvUoi1fPvAcN1PcHlc1J0=
```
replacement func:
```
.tcl set saltedPassword2 [pbkdf2 -bin hunter mysalt 1500 sha256]
.tcl b64:encode $saltedPassword2
Tcl: rNb2VlyBIeNaSMc9YtVcthpvUoi1fPvAcN1PcHlc1J0=
```
see also:
https://github.com/grawity/eggdrop-sasl/blob/master/g_scram.tcl#L156