### PR TITLE
Only log certificate SHA256 Fingerprint

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -630,18 +630,12 @@ static void ssl_showcert(X509 *cert, const int loglev)
   } else
     putlog(loglev, "*", "TLS: cannot get issuer name from certificate!");
 
-  /* Fingerprints */
-  if (X509_digest(cert, EVP_sha1(), md, &len)) {
-    buf = OPENSSL_buf2hexstr(md, len);
-    putlog(loglev, "*", "TLS: certificate SHA1 Fingerprint: %s", buf);
-    OPENSSL_free(buf);
-  }
+  /* Fingerprint */
   if (X509_digest(cert, EVP_sha256(), md, &len)) {
     buf = OPENSSL_buf2hexstr(md, len);
-    putlog(loglev, "*", "TLS: certificate SHA-256 Fingerprint: %s", buf);
+    putlog(loglev, "*", "TLS: certificate SHA256 Fingerprint: %s", buf);
     OPENSSL_free(buf);
   }
-
 
   /* Validity time */
   from = ssl_printtime(X509_get_notBefore(cert));


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Only log certificate SHA256 Fingerprint

Additional description (if needed):
Currently we log SHA1 and SHA256. SHA1 is redundant, SHA256 is enough. Its always good to remove code and keep eggdrop slim.

Test cases demonstrating functionality (if applicable):
Before:
```
[...]
[02:21:11] TLS: certificate SHA1 Fingerprint: 20:29:12:7E:44:38:E4:32:14:AB:90:98:BA:A1:60:26:33:45:00:72
[02:21:11] TLS: certificate SHA-256 Fingerprint: A3:FE:B7:DF:FD:A6:F2:70:35:C6:67:08:1A:9D:A6:02:00:8B:CE:70:41:9A:1C:ED:01:2E:9B:A6:F4:35:F8:A1
[...]
```
After:
```
[...]
[09:18:16] TLS: certificate SHA256 Fingerprint: A3:FE:B7:DF:FD:A6:F2:70:35:C6:67:08:1A:9D:A6:02:00:8B:CE:70:41:9A:1C:ED:01:2E:9B:A6:F4:35:F8:A1
[...]
```