### PR TITLE
Tcl_AppendResult() -> Tcl_SetResult()

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -726,7 +726,7 @@ static int tcl_dnslookup STDVAR
     tcl_dnshostbyip(&addr, argv[2], Tcl_DStringValue(&paras));
   else {
     if (strlen(argv[1]) > 255) {
-      Tcl_AppendResult(irp, "hostname too long. max 255 chars.", NULL);
+      Tcl_SetResult(irp, "hostname too long. max 255 chars.", TCL_STATIC);
       return TCL_ERROR;
     }
     tcl_dnsipbyhost(argv[1], argv[2], Tcl_DStringValue(&paras));

--- a/src/flags.c
+++ b/src/flags.c
@@ -1419,7 +1419,7 @@ static int botfl_tcl_get(Tcl_Interp *interp, struct userrec *u,
 
   fr.bot = e->u.ulong;
   build_flags(x, &fr, NULL);
-  Tcl_AppendResult(interp, x, NULL);
+  Tcl_SetResult(interp, x, TCL_STATIC);
   return TCL_OK;
 }
 

--- a/src/language.c
+++ b/src/language.c
@@ -649,7 +649,7 @@ static int tcl_language STDVAR
   strcpy(buf, argv[1]);
 
   if (!split_lang(buf, &lang, &section)) {
-    Tcl_AppendResult(irp, "Invalid parameter", NULL);
+    Tcl_SetResult(irp, "Invalid parameter", TCL_STATIC);
     nfree(buf);
     return TCL_ERROR;
   }
@@ -677,7 +677,7 @@ static int tcl_mnslang STDVAR
   BADARGS(2, 2, " language");
 
   if (!del_lang(argv[1])) {
-    Tcl_AppendResult(irp, "Language not found.", NULL);
+    Tcl_SetResult(irp, "Language not found.", TCL_STATIC);
     return TCL_ERROR;
   }
   recheck_lang_sections();
@@ -698,7 +698,7 @@ static int tcl_dellangsection STDVAR
   BADARGS(2, 2, " section");
 
   if (!del_lang_section(argv[1])) {
-    Tcl_AppendResult(irp, "Section not found", NULL);
+    Tcl_SetResult(irp, "Section not found", TCL_STATIC);
     return TCL_ERROR;
   }
   return TCL_OK;

--- a/src/mod/console.mod/console.c
+++ b/src/mod/console.mod/console.c
@@ -149,7 +149,7 @@ static int console_tcl_get(Tcl_Interp *irp, struct userrec *u,
   char work[1024];
 
   console_tcl_format(work, e->u.extra);
-  Tcl_AppendResult(irp, work, NULL);
+  Tcl_SetResult(irp, work, TCL_STATIC);
   return TCL_OK;
 }
 

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -511,7 +511,7 @@ static int tcl_accounttracking STDVAR
   if (current->enabled) {
     acctnotify = 1;
   }
-  Tcl_SetResult(irp, use_354 && extjoin && acctnotify ? "1" : "0", NULL);
+  Tcl_SetResult(irp, use_354 && extjoin && acctnotify ? "1" : "0", TCL_STATIC);
   return TCL_OK;
 }
 

--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -149,7 +149,7 @@ static int tcl_call_python(ClientData cd, Tcl_Interp *irp, int objc, Tcl_Obj *co
   }
   if (!PyObject_Call(bindinfo->callback, args, NULL)) {
     PyErr_Print();
-    Tcl_SetResult(irp, "Error calling python code", NULL);
+    Tcl_SetResult(irp, "Error calling python code", TCL_STATIC);
     return TCL_ERROR;
   }
   return TCL_OK;

--- a/src/mod/server.mod/tclisupport.c
+++ b/src/mod/server.mod/tclisupport.c
@@ -101,7 +101,7 @@ static int tcl_isupport_isset STDOBJVAR
   BADOBJARGS(3, 3, 2, "setting");
   key = Tcl_GetStringFromObj(objv[2], &keylen);
   value = isupport_get(key, keylen);
-  Tcl_SetResult(interp, value ? "1" : "0", NULL);
+  Tcl_SetResult(interp, value ? "1" : "0", TCL_STATIC);
   return TCL_OK;
 }
 
@@ -138,7 +138,7 @@ static int tcl_isupport_unset STDOBJVAR
     TCL_ERR_NOTSET(irp, objv[2]);
   }
   if (!data->value) {
-    Tcl_SetResult(interp, "no server value set, cannot unset default values, change 'set isupport-default' instead", NULL);
+    Tcl_SetResult(interp, "no server value set, cannot unset default values, change 'set isupport-default' instead", TCL_STATIC);
     return TCL_ERROR;
   }
   isupport_unset(key, keylen);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -1242,17 +1242,17 @@ time_t get_expire_time(Tcl_Interp * irp, const char *s) {
   long expire_foo = strtol(s, &endptr, 10);
 
   if (*endptr) {
-    Tcl_AppendResult(irp, "bogus expire time", NULL);
+    Tcl_SetResult(irp, "bogus expire time", TCL_STATIC);
     return -1;
   }
   if (expire_foo < 0) {
-    Tcl_AppendResult(irp, "expire time must be 0 (perm) or greater than 0 days", NULL);
+    Tcl_SetResult(irp, "expire time must be 0 (perm) or greater than 0 days", TCL_STATIC);
     return -1;
   }
   if (expire_foo == 0)
     return 0;
   if (expire_foo > (60 * 24 * 2000)) {
-    Tcl_AppendResult(irp, "expire time must be equal to or less than 2000 days", NULL);
+    Tcl_SetResult(irp, "expire time must be equal to or less than 2000 days", TCL_STATIC);
     return -1;
   }
   return now + 60 * expire_foo;


### PR DESCRIPTION
Found by: thommey
Patch by: michaelortmann
Fixes: 

One-line summary:
Tcl_AppendResult() -> Tcl_SetResult()

Additional description (if needed):
Tcl_AppendResult() is deprecated. This PR migrates some Tcl_AppendResult()s to Tcl_SetResult(). Low hanging fruit. Part of fixing #51.

Test cases demonstrating functionality (if applicable):
No functional change