### PR TITLE
Cleanup console.mod, make 1 func void and cleanup includes

### DIFF
--- a/src/mod/console.mod/console.c
+++ b/src/mod/console.mod/console.c
@@ -25,7 +25,6 @@
 #define MAKING_CONSOLE
 
 #include "src/mod/module.h"
-#include <stdlib.h>
 #include "console.h"
 
 static Function *global = NULL;

--- a/src/mod/console.mod/console.c
+++ b/src/mod/console.mod/console.c
@@ -134,13 +134,12 @@ static int console_set(struct userrec *u, struct user_entry *e, void *buf)
   return 1;
 }
 
-static int console_tcl_format(char *work, struct console_info *i)
+static void console_tcl_format(char *work, struct console_info *i)
 {
   simple_sprintf(work, "%s %s %s %d %d %d",
                  i->channel, masktype(i->conflags),
                  stripmasktype(i->stripflags), i->echoflags,
                  i->page, i->conchan);
-  return 0;
 }
 
 static int console_tcl_get(Tcl_Interp *irp, struct userrec *u,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup console.mod, make 1 func void and cleanup includes

Additional description (if needed):
No functional change

Test cases demonstrating functionality (if applicable):
