### PR TITLE
Cleanup: strncpy() -> strlcpy()

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -174,10 +174,8 @@ int addparty(char *bot, char *nick, int chan, char flag, int sock,
     party = nrealloc(party, party_size * sizeof(party_t));
     debug1("botnet: party size doubled to %i.", party_size);
   }
-  strncpy(party[parties].nick, nick, HANDLEN);
-  party[parties].nick[HANDLEN] = 0;
-  strncpy(party[parties].bot, bot, HANDLEN);
-  party[parties].bot[HANDLEN] = 0;
+  strlcpy(party[parties].nick, nick, HANDLEN + 1);
+  strlcpy(party[parties].bot, bot, HANDLEN + 1);
   party[parties].chan = chan;
   party[parties].sock = sock;
   party[parties].status = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Migrate 2 remaining strncpy() to strlcpy()

Additional description (if needed):
No functional change

Test cases demonstrating functionality (if applicable):
