### PR TITLE
Fix copyright in main.c and misc/updatecopyright

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -158,5 +158,5 @@ the README file. If not, then READ IT!&@#%@!
 
 Have fun with Eggdrop!
 
-  Copyright (C) 1997 Robey Pointer Copyright (C) 1999 - 2023 Eggheads
+  Copyright (C) 1997 Robey Pointer Copyright (C) 1999 - 2024 Eggheads
   Development Team

--- a/README
+++ b/README
@@ -216,5 +216,5 @@ OBTAINING HELP
     -   Don't ask to ask- just state your question, along with any
         relevant details and error messages
 
-Copyright (C) 1997 Robey Pointer Copyright (C) 1999 - 2023 Eggheads
+Copyright (C) 1997 Robey Pointer Copyright (C) 1999 - 2024 Eggheads
 Development Team

--- a/misc/updatecopyright
+++ b/misc/updatecopyright
@@ -49,8 +49,8 @@ update_copyright() {
 		mv ${i}_ $i
 	fi
 	# Cats and Dogs
-	sed -i '/Eggdrop v%s (C) 1997 Robey Pointer/c\               "Eggdrop v%s (C) 1997 Robey Pointer (C) 2010-'$YEAR' Eggheads",' src/main.c
-    sed -i '/Eggdrop v%s+%s (C) 1997 Robey Pointer/c\               "Eggdrop v%s+%s (C) 1997 Robey Pointer (C) 2010-'$YEAR' Eggheads",' src/main.c
+	sed -i '/Eggdrop v" EGG_STRINGVER " (C) 1997 Robey Pointer (C) 1999-/c\          "Eggdrop v" EGG_STRINGVER " (C) 1997 Robey Pointer (C) 1999-'$YEAR' Eggheads Development Team",' src/main.c
+    sed -i '/Eggdrop v" EGG_STRINGVER "+" EGG_PATCH " (C) 1997 Robey Pointer (C) 1999-/c\          "Eggdrop v" EGG_STRINGVER "+" EGG_PATCH " (C) 1997 Robey Pointer (C) 1999-'$YEAR' Eggheads Development Team",' src/main.c
 
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -130,7 +130,7 @@ int make_userfile = 0; /* Using bot in userfile-creation mode? */
 int save_users_at = 0;   /* Minutes past the hour to save the userfile?     */
 int notify_users_at = 0; /* Minutes past the hour to notify users of notes? */
 
-char version[81];    /* Version info (long form)  */
+char version[128];   /* Version info (long form)  */
 char ver[41];        /* Version info (short form) */
 
 volatile sig_atomic_t do_restart = 0; /* .restart has been called, restart ASAP */
@@ -978,15 +978,15 @@ int main(int arg_c, char **arg_v)
 #ifdef EGG_PATCH
   egg_snprintf(egg_version, sizeof egg_version, "%s+%s %u", EGG_STRINGVER, EGG_PATCH, egg_numver);
   egg_snprintf(ver, sizeof ver, "eggdrop v%s+%s", EGG_STRINGVER, EGG_PATCH);
-  egg_snprintf(version, sizeof version,
-               "Eggdrop v%s+%s (C) 1997 Robey Pointer (C) 2010-2024 Eggheads",
-                EGG_STRINGVER, EGG_PATCH);
+  strlcpy(version,
+          "Eggdrop v" EGG_STRINGVER "+" EGG_PATCH " (C) 1997 Robey Pointer (C) 1999-2024 Eggheads Development Team",
+          sizeof version);
 #else
   egg_snprintf(egg_version, sizeof egg_version, "%s %u", EGG_STRINGVER, egg_numver);
   egg_snprintf(ver, sizeof ver, "eggdrop v%s", EGG_STRINGVER);
-  egg_snprintf(version, sizeof version,
-               "Eggdrop v%s (C) 1997 Robey Pointer (C) 2010-2024 Eggheads",
-                EGG_STRINGVER);
+  strlcpy(version,
+          "Eggdrop v" EGG_STRINGVER " (C) 1997 Robey Pointer (C) 1999-2024 Eggheads Development Team",
+          sizeof version);
 #endif
 
 /* For OSF/1 */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix copyright in main.c and misc/updatecopyright

Additional description (if needed):
We tried a fix of the copyright string with #1414
but we forgot to update misc/updatecopyright
so the fix was reverted by the last run of that script

Test cases demonstrating functionality (if applicable):
**Test 1:**
Before:
```
$ ./eggdrop -v
Eggdrop v1.9.5+python (C) 1997 Robey Pointer (C) 2010-2024 Eggheads
```
After:
```
$ ./eggdrop -v
Eggdrop v1.9.5+python (C) 1997 Robey Pointer (C) 1999-2024 Eggheads Development Team
```
**Test 2:**
```
$ misc/updatecopyright 2025
$ git diff src/main.c
diff --git a/src/main.c b/src/main.c
index d552f29f..003c4396 100644
--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
  */
 /*
  * Copyright (C) 1997 Robey Pointer
- * Copyright (C) 1999 - 2024 Eggheads Development Team
+ * Copyright (C) 1999 - 2025 Eggheads Development Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -979,13 +979,13 @@ int main(int arg_c, char **arg_v)
   egg_snprintf(egg_version, sizeof egg_version, "%s+%s %u", EGG_STRINGVER, EGG_PATCH, egg_numver);
   egg_snprintf(ver, sizeof ver, "eggdrop v%s+%s", EGG_STRINGVER, EGG_PATCH);
   strlcpy(version,
-          "Eggdrop v" EGG_STRINGVER "+" EGG_PATCH " (C) 1997 Robey Pointer (C) 1999-2024 Eggheads Development Team",
+          "Eggdrop v" EGG_STRINGVER "+" EGG_PATCH " (C) 1997 Robey Pointer (C) 1999-2025 Eggheads Development Team",
           sizeof version);
 #else
   egg_snprintf(egg_version, sizeof egg_version, "%s %u", EGG_STRINGVER, egg_numver);
   egg_snprintf(ver, sizeof ver, "eggdrop v%s", EGG_STRINGVER);
   strlcpy(version,
-          "Eggdrop v" EGG_STRINGVER " (C) 1997 Robey Pointer (C) 1999-2024 Eggheads Development Team",
+          "Eggdrop v" EGG_STRINGVER " (C) 1997 Robey Pointer (C) 1999-2025 Eggheads Development Team",
           sizeof version);
 #endif
$ ./eggdrop -v
Eggdrop v1.9.5+python (C) 1997 Robey Pointer (C) 1999-2025 Eggheads Development Team
```

