### PR TITLE
Add IRCv3 standard-replies

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -909,7 +909,7 @@ channel add <name> [option-list]
 channel set <name> <options...>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: sets options for the channel specified. The full list of possible options are given in doc/settings/mod.channels.
+  Description: sets options for the channel specified. The full list of possible options are given in :ref:`channels`. Note that the syntax for setting the need-* settings in Tcl differs from that of the command line, in that the need-* value needs to be enclosed in {}s, such as ``channel set #chan need-op { putmsg NickServ "op #chan }``.
 
   Returns: nothing
 

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -909,7 +909,7 @@ channel add <name> [option-list]
 channel set <name> <options...>
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Description: sets options for the channel specified. The full list of possible options are given in :ref:`channels`. Note that the syntax for setting the need-* settings in Tcl differs from that of the command line, in that the need-* value needs to be enclosed in {}s, such as ``channel set #chan need-op { putmsg NickServ "op #chan }``.
+  Description: sets options for the channel specified. The full list of possible options are given in doc/settings/mod.channels.
 
   Returns: nothing
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2004,7 +2004,7 @@ static int got730or1(char *from, char *msg, int code)
 /* Got IRCv3 standard-reply
  * <FAIL/NOTE/WARN> <command> <code> [<context>...] <description>
  */
-static int gotstdreply(char *from, char * msgtype, char *msg)
+static int gotstdreply(char *from, char *msgtype, char *msg)
 {
   char *cmd, *code, *text = 0;
   char context[MSGMAX] = "";

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2006,7 +2006,7 @@ static int got730or1(char *from, char *msg, int code)
  */
 static int gotstdreply(char *from, char *msgtype, char *msg)
 {
-  char *cmd, *code, *text = 0;
+  char *cmd, *code, *text;
   char context[MSGMAX] = "";
   int len;
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2003,18 +2003,20 @@ static int got730or1(char *from, char *msg, int code)
 
 /* Got IRCv3 standard-reply
  * <FAIL/NOTE/WARN> <command> <code> [<context>...] <description>
- *
- * stdtype is 0 for FAIL, 1 for NOTE, 2 for WARN
  */
 static int gotstdreply(char *from, char * msgtype, char *msg)
 {
-  char *cmd, *code, *text;
+  char *cmd, *code, *text = 0;
   char context[MSGMAX] = "";
   int len;
 
   cmd = newsplit(&msg);
   code = newsplit(&msg);
-  text = strchr(msg, ':');
+/* TODO: Once this feature is better implemented, consider how to handle
+ * one-word descriptions that aren't technically required to have a :
+ */
+  text = strstr(msg, " :");
+  text++;
   if (text != msg) {
     len = text - msg;
     strncpy(context, msg, len);
@@ -2027,24 +2029,21 @@ static int gotstdreply(char *from, char * msgtype, char *msg)
 /* Got IRCv3 FAIL standard-reply */
 static int gotstdfail(char *from, char *msg)
 {
-  char msgtype[] = "FAIL";
-  gotstdreply(from, msgtype, msg);
+  gotstdreply(from, "FAIL", msg);
   return 0;
 }
 
 /* Got IRCv3 NOTE standard-reply */
 static int gotstdnote(char *from, char *msg)
 {
-  char msgtype[] = "NOTE";
-  gotstdreply(from, msgtype, msg);
+  gotstdreply(from, "NOTE", msg);
   return 0;
 }
 
 /* Got IRCv3 WARN standard-reply */
 static int gotstdwarn(char *from, char *msg)
 {
-  char msgtype[] = "WARN";
-  gotstdreply(from, msgtype, msg);
+  gotstdreply(from, "WARN", msg);
   return 0;
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2001,6 +2001,53 @@ static int got730or1(char *from, char *msg, int code)
   return 0;
 }
 
+/* Got IRCv3 standard-reply
+ * <FAIL/NOTE/WARN> <command> <code> [<context>...] <description>
+ *
+ * stdtype is 0 for FAIL, 1 for NOTE, 2 for WARN
+ */
+static int gotstdreply(char *from, char * msgtype, char *msg)
+{
+  char *cmd, *code, *text;
+  char context[MSGMAX] = "";
+  int len;
+
+  cmd = newsplit(&msg);
+  code = newsplit(&msg);
+  text = strchr(msg, ':');
+  if (text != msg) {
+    len = text - msg;
+    strncpy(context, msg, len);
+  }
+  fixcolon(text);
+  putlog(LOG_SERV, "*", "%s%s%s: Received a %s message from %s: %s", cmd, cmd ? ": " : "", code, msgtype, from, text);
+  return 0;
+}
+
+/* Got IRCv3 FAIL standard-reply */
+static int gotstdfail(char *from, char *msg)
+{
+  char msgtype[] = "FAIL";
+  gotstdreply(from, msgtype, msg);
+  return 0;
+}
+
+/* Got IRCv3 NOTE standard-reply */
+static int gotstdnote(char *from, char *msg)
+{
+  char msgtype[] = "NOTE";
+  gotstdreply(from, msgtype, msg);
+  return 0;
+}
+
+/* Got IRCv3 WARN standard-reply */
+static int gotstdwarn(char *from, char *msg)
+{
+  char msgtype[] = "WARN";
+  gotstdreply(from, msgtype, msg);
+  return 0;
+}
+
 /* Got 730/RPL_MONONLINE
  * :<server> 730 <nick> :target[!user@host][,target[!user@host]]*
  */
@@ -2097,6 +2144,9 @@ static cmd_t my_raw_binds[] = {
   {"PING",         "",   (IntFunc) gotping,         NULL},
   {"PONG",         "",   (IntFunc) gotpong,         NULL},
   {"WALLOPS",      "",   (IntFunc) gotwall,         NULL},
+  {"FAIL",         "",   (IntFunc) gotstdfail,      NULL},
+  {"NOTE",         "",   (IntFunc) gotstdnote,      NULL},
+  {"WARN",         "",   (IntFunc) gotstdwarn,      NULL},
   {"001",          "",   (IntFunc) got001,          NULL},
   {"005",          "",   (IntFunc) got005,          NULL},
   {"303",          "",   (IntFunc) got303,          NULL},

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2016,13 +2016,15 @@ static int gotstdreply(char *from, char * msgtype, char *msg)
  * one-word descriptions that aren't technically required to have a :
  */
   text = strstr(msg, " :");
-  text++;
-  if (text != msg) {
-    len = text - msg;
-    strncpy(context, msg, len);
-  }
-  fixcolon(text);
-  putlog(LOG_SERV, "*", "%s%s%s: Received a %s message from %s: %s", cmd, cmd ? ": " : "", code, msgtype, from, text);
+  if (text) {
+    text++;
+    if (text != msg) {
+      len = text - msg;
+      snprintf(context, sizeof context, "%.*s", len, msg);
+    }
+    fixcolon(text);
+    }
+    putlog(LOG_SERV, "*", "%s: %s: Received a %s message from %s: %s", cmd, code, msgtype, from, text);
   return 0;
 }
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2023,8 +2023,8 @@ static int gotstdreply(char *from, char *msgtype, char *msg)
       snprintf(context, sizeof context, "%.*s", len, msg);
     }
     fixcolon(text);
-    }
-    putlog(LOG_SERV, "*", "%s: %s: Received a %s message from %s: %s", cmd, code, msgtype, from, text);
+  }
+  putlog(LOG_SERV, "*", "%s: %s: Received a %s message from %s: %s", cmd, code, msgtype, from, text);
   return 0;
 }
 


### PR DESCRIPTION
One-line summary:
Capture IRCv3 standard-replies messages and log to the +s console flag.

Not much in terms of capability in the moment, but is used by future pending capabilities such as account-registration

Test cases demonstrating functionality (if applicable):
```
.dump register foo bar moo
[00:41:05] #-HQ# dump register foo bar moo
[00:41:05] [!s] register foo bar moo
[00:41:06] [s->] register foo bar moo
[00:41:06] [@] :irc.foo.uk FAIL REGISTER INVALID_NAME foo :Your account name must be at least 4 characters long.
[00:41:06] REGISTER: INVALID_NAME: Received a FAIL message from irc.valware.uk: Your account name must be at least 4 characters long.
```