### PR TITLE
Update autobotchk

### DIFF
--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -276,8 +276,8 @@ if {$systemd} {
   exit
  }
  puts "Creating systemd directory..."
- catch {file mkdir ~/.config/systemd/user } res
- if {[catch {open ~/.config/systemd/user/${botnet-nick}.service w} fd]} {
+ catch {file mkdir -p "$::env(HOME)/.config/systemd/user" } res
+ if {[catch {open "$::env(HOME)/.config/systemd/user/${botnet-nick}.service" w} fd]} {
   puts "  *** ERROR: unable to open '${botnet-nick}.service' for writing"
   puts ""
   exit

--- a/scripts/autobotchk
+++ b/scripts/autobotchk
@@ -276,7 +276,7 @@ if {$systemd} {
   exit
  }
  puts "Creating systemd directory..."
- catch {file mkdir -p "$::env(HOME)/.config/systemd/user" } res
+ catch {file mkdir "$::env(HOME)/.config/systemd/user" } res
  if {[catch {open "$::env(HOME)/.config/systemd/user/${botnet-nick}.service" w} fd]} {
   puts "  *** ERROR: unable to open '${botnet-nick}.service' for writing"
   puts ""


### PR DESCRIPTION
Found by: DasBrain
Patch by: TehPeGaSuS
Fixes: Fix tilde expansion removal on TCL 9

One-line summary:
Fix tilde expansion removal on TCL 9

Additional description (if needed):
- Apparently, with TCL 9, the `~` expansion ability was [removed](https://core.tcl-lang.org/tips/doc/trunk/tip/602.md). This PR should fix it.
- Added the `-p` flag to the `mkdir` command, which  stands for "parent" and it allows to create a directory hierarchy (a tree of directories) in one step, without getting an error if the parent directories already exist or if they don't exist at all.

Test cases demonstrating functionality (if applicable):
```
$ ./scripts/autobotchk micaela.conf -systemd

autobotchk 1.11, (C) 1999-2003 Jeff Fisher (guppy@eggheads.org)
                   (C) 2004-2022 Eggheads Development Team
------------------------------------------------------------

Opening 'micaela.conf' for processing ... done
Scanning the config file .................. done
Enabling user lingering...
Creating systemd directory...
Created symlink /home/bots/.config/systemd/user/default.target.wants/Micaela.service → /home/bots/.config/systemd/user/Micaela.service.
systemd job successfully installed as 'Micaela.service'.
* Use 'systemctl --user <start|stop|restart|reload|enable|disable> Micaela.service' to control your Eggdrop
Starting Eggdrop...
Success.
```
