### PR TITLE
Full account tacking

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -1136,7 +1136,7 @@ nick2hand <nickname> [channel]
   Module: irc
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-account2nicks <handle> [channel]
+account2nicks <account> [channel]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   Returns: a de-duplicated Tcl list of the nickname(s) on the specified channel (if one is specified) whose nickname matches the given account; "" is returned if no match is found. This command will only work if a server supports (and Eggdrop has enabled) the account-notify and extended-join capabilities, and the server understands WHOX requests (also known as raw 354 responses). If no channel is specified, all channels are checked.

--- a/src/chan.h
+++ b/src/chan.h
@@ -50,7 +50,6 @@ typedef struct memstruct {
   time_t split; /* in case they were just netsplit */
   time_t last;  /* for measuring idle time         */
   time_t delay; /* for delayed autoop              */
-  int tried_getuser;
   struct memstruct *next;
 } memberlist;
 
@@ -130,6 +129,7 @@ struct chan_t {
   char *topic;
   char *key;
   unsigned int mode;
+  int tried_getuser; // TODO: use it to invalidate user cache
   int maxmembers;
   int members;
 };

--- a/src/chan.h
+++ b/src/chan.h
@@ -50,7 +50,7 @@ typedef struct memstruct {
   time_t split; /* in case they were just netsplit */
   time_t last;  /* for measuring idle time         */
   time_t delay; /* for delayed autoop              */
-  struct userrec *user;
+//  struct userrec *user;
   int tried_getuser;
   struct memstruct *next;
 } memberlist;

--- a/src/chan.h
+++ b/src/chan.h
@@ -50,6 +50,7 @@ typedef struct memstruct {
   time_t split; /* in case they were just netsplit */
   time_t last;  /* for measuring idle time         */
   time_t delay; /* for delayed autoop              */
+  int tried_getuser; // TODO: use it to invalidate user cache
   struct memstruct *next;
 } memberlist;
 
@@ -129,7 +130,6 @@ struct chan_t {
   char *topic;
   char *key;
   unsigned int mode;
-  int tried_getuser; // TODO: use it to invalidate user cache
   int maxmembers;
   int members;
 };

--- a/src/chan.h
+++ b/src/chan.h
@@ -50,7 +50,6 @@ typedef struct memstruct {
   time_t split; /* in case they were just netsplit */
   time_t last;  /* for measuring idle time         */
   time_t delay; /* for delayed autoop              */
-//  struct userrec *user;
   int tried_getuser;
   struct memstruct *next;
 } memberlist;

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -116,31 +116,6 @@ struct chanset_t *findchan_by_dname(const char *name)
   return NULL;
 }
 
-
-/*
- *    "caching" functions
- */
-
-/* Shortcut for get_user_by_host -- might have user record in one
- * of the channel caches.
- */
-struct userrec *check_chanlist(const char *host)
-{
-  char *nick, *uhost, buf[UHOSTLEN];
-  memberlist *m;
-  struct chanset_t *chan;
-
-  strlcpy(buf, host, sizeof buf);
-  uhost = buf;
-  nick = splitnick(&uhost);
-  for (chan = chanset; chan; chan = chan->next)
-    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
-      if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
-//XXXXXXXX loop? Does this whole func come out?
-        return get_user_from_channel(m);
-  return NULL;
-}
-
 /* Clear the user pointers in the chanlists.
  *
  * Necessary when a hostmask is added/removed, a user is added or a new
@@ -173,24 +148,6 @@ void clear_chanlist_member(const char *nick)
         m->tried_getuser = 0;
         break;
       }
-}
-
-/* If this user@host is in a channel, set it (it was null)
- */
-void set_chanlist(const char *host, struct userrec *rec)
-{
-  char *nick, *uhost, buf[UHOSTLEN];
-  memberlist *m;
-  struct chanset_t *chan;
-
-//  strlcpy(buf, host, sizeof buf);
-//  uhost = buf;
-//  nick = splitnick(&uhost);
-//  for (chan = chanset; chan; chan = chan->next)
-//    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
-//      if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
-//XXXXXXXX Does this whole func come out?
-//        m->user = rec;
 }
 
 /* Calculate the memory we should be using

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -133,7 +133,7 @@ void clear_chanlist(void)
 }
 
 /* Clear the user pointer of a specific nick in the chanlists.
- *
+ 
  * Necessary when a hostmask is added/removed, a nick changes, etc.
  * Does not completely invalidate the channel cache like clear_chanlist().
  */

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -136,7 +136,8 @@ struct userrec *check_chanlist(const char *host)
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
       if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
-        return m->user;
+//XXXXXXXX loop? Does this whole func come out?
+        return get_user_from_channel(m);
   return NULL;
 }
 
@@ -152,7 +153,6 @@ void clear_chanlist(void)
 
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-      m->user = NULL;
       m->tried_getuser = 0;
     }
 }
@@ -170,7 +170,6 @@ void clear_chanlist_member(const char *nick)
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
       if (!rfc_casecmp(m->nick, nick)) {
-        m->user = NULL;
         m->tried_getuser = 0;
         break;
       }
@@ -190,6 +189,7 @@ void set_chanlist(const char *host, struct userrec *rec)
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
       if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
+//XXXXXXXX Does this whole func come out?
         m->user = rec;
 }
 

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -183,14 +183,14 @@ void set_chanlist(const char *host, struct userrec *rec)
   memberlist *m;
   struct chanset_t *chan;
 
-  strlcpy(buf, host, sizeof buf);
-  uhost = buf;
-  nick = splitnick(&uhost);
-  for (chan = chanset; chan; chan = chan->next)
-    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
-      if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
+//  strlcpy(buf, host, sizeof buf);
+//  uhost = buf;
+//  nick = splitnick(&uhost);
+//  for (chan = chanset; chan; chan = chan->next)
+//    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
+//      if (!rfc_casecmp(nick, m->nick) && !strcasecmp(uhost, m->userhost))
 //XXXXXXXX Does this whole func come out?
-        m->user = rec;
+//        m->user = rec;
 }
 
 /* Calculate the memory we should be using

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1731,7 +1731,7 @@ static int tcl_do_masklist(maskrec *m, Tcl_Interp *irp)
     list[3] = ts1;
     snprintf(ts2, sizeof ts2, "%" PRId64, (int64_t) m->lastactive);
     list[4] = ts2;
-    list[5] = get_user_from_channel(m);
+    list[5] = m->user;
     p = Tcl_Merge(6, list);
     Tcl_AppendElement(irp, p);
     Tcl_Free((char *) p);

--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1731,7 +1731,7 @@ static int tcl_do_masklist(maskrec *m, Tcl_Interp *irp)
     list[3] = ts1;
     snprintf(ts2, sizeof ts2, "%" PRId64, (int64_t) m->lastactive);
     list[4] = ts2;
-    list[5] = m->user;
+    list[5] = get_user_from_channel(m);
     p = Tcl_Merge(6, list);
     Tcl_AppendElement(irp, p);
     Tcl_Free((char *) p);

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -1270,7 +1270,7 @@ static int expired_mask(struct chanset_t *chan, char *who)
    * present in the channel and has op.
    */
 
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   /* Do not expire masks set by bots. */
   if (u && u->flags & USER_BOT)
     return 0;

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -1273,8 +1273,7 @@ static int expired_mask(struct chanset_t *chan, char *who)
   if (m->user)
     u = m->user;
   else {
-    simple_sprintf(buf, "%s!%s", m->nick, m->userhost);
-    u = get_user_by_host(buf);
+    u = get_user_from_channel(m);
   }
   /* Do not expire masks set by bots. */
   if (u && u->flags & USER_BOT)

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -1270,11 +1270,7 @@ static int expired_mask(struct chanset_t *chan, char *who)
    * present in the channel and has op.
    */
 
-  if (m->user)
-    u = m->user;
-  else {
-    u = get_user_from_channel(m);
-  }
+  u = get_user_from_channel(m);
   /* Do not expire masks set by bots. */
   if (u && u->flags & USER_BOT)
     return 0;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -901,6 +901,7 @@ static void recheck_channel(struct chanset_t *chan, int dobans)
 {
   memberlist *m;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+  struct userrec *u;
   static int stacking = 0;
   int stop_reset = 0;
 
@@ -910,10 +911,10 @@ static void recheck_channel(struct chanset_t *chan, int dobans)
   stacking++;
   /* Okay, sort through who needs to be deopped. */
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    if (!get_user_from_channel(m) && !m->tried_getuser) {
+    if (!m->tried_getuser) {
       m->tried_getuser = 1;
-      u = get_user_from_channel(m);
     }
+    u = get_user_from_channel(m);
     get_user_flagrec(u, &fr, chan->dname);
     if (glob_bot(fr) && chan_hasop(m) && !match_my_nick(m->nick))
       stop_reset = 1;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -910,9 +910,6 @@ static void recheck_channel(struct chanset_t *chan, int dobans)
   stacking++;
   /* Okay, sort through who needs to be deopped. */
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    if (!m->tried_getuser) {
-      m->tried_getuser = 1;
-    }
     u = get_user_from_member(m);
     get_user_flagrec(u, &fr, chan->dname);
     if (glob_bot(fr) && chan_hasop(m) && !match_my_nick(m->nick))

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -237,7 +237,7 @@ static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
     return 0;
 
 // XXXXXXXXX Check if m exists first?
-  get_user_flagrec(get_user_from_channel(m), &fr, chan->dname);
+  get_user_flagrec(get_user_by_host(from), &fr, chan->dname);
   if (glob_bot(fr) || ((which == FLOOD_DEOP) && (glob_master(fr) ||
       chan_master(fr)) && (glob_friend(fr) || chan_friend(fr))) ||
       ((which == FLOOD_KICK) && (glob_master(fr) || chan_master(fr)) &&
@@ -2021,7 +2021,6 @@ static int gotjoin(char *from, char *channame)
       /* The channel doesn't exist anymore, so get out of here. */
       goto exit;
 
-    /* Grab last time joined before we update it */
     if (!channel_active(chan) && !match_my_nick(nick)) {
       /* uh, what?!  i'm on the channel?! */
       putlog(LOG_MISC, chan->dname,
@@ -2032,7 +2031,7 @@ static int gotjoin(char *from, char *channame)
       reset_chan_info(chan, CHAN_RESETALL, 1);
     } else {
       m = ismember(chan, nick);
-      u = get_user_from_channel(m);
+      u = get_user_by_host(from);
       get_user_flagrec(u, &fr, chan->dname);
       if (m && m->split && !strcasecmp(m->userhost, uhost)) {
         check_tcl_rejn(nick, uhost, u, chan->dname);

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2022,7 +2022,6 @@ static int gotjoin(char *from, char *channame)
       goto exit;
 
     /* Grab last time joined before we update it */
-    get_user_flagrec(u, &fr, chan->dname);      /* Lam: fix to work with !channels */
     if (!channel_active(chan) && !match_my_nick(nick)) {
       /* uh, what?!  i'm on the channel?! */
       putlog(LOG_MISC, chan->dname,
@@ -2034,6 +2033,7 @@ static int gotjoin(char *from, char *channame)
     } else {
       m = ismember(chan, nick);
       u = get_user_from_channel(m);
+      get_user_flagrec(u, &fr, chan->dname);
       if (m && m->split && !strcasecmp(m->userhost, uhost)) {
         check_tcl_rejn(nick, uhost, u, chan->dname);
 

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -68,13 +68,11 @@ static int has_oporhalfop(int idx, struct chanset_t *chan)
  */
 static char *getnick(char *handle, struct chanset_t *chan)
 {
-  char s[UHOSTLEN];
   struct userrec *u;
   memberlist *m;
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    if ((u = get_user_by_host(s)) && !strcasecmp(u->handle, handle))
+    if ((u = get_user_from_channel(m)) && !strcasecmp(u->handle, handle))
       return m->nick;
   }
   return NULL;
@@ -163,8 +161,8 @@ static void cmd_kickban(struct userrec *u, int idx, char *par)
   struct chanset_t *chan;
   char *chname, *nick, *s1;
   memberlist *m;
-  char s[UHOSTLEN];
   char bantype = 0;
+  char s[UHOSTLEN];
 
   if (!par[0]) {
     dprintf(idx, "Usage: kickban [channel] [-|@]<nick> [reason]\n");
@@ -208,7 +206,7 @@ static void cmd_kickban(struct userrec *u, int idx, char *par)
     return;
   }
   egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_op(victim) || (glob_op(victim) && !chan_deop(victim))) &&
       !(chan_master(user) || glob_master(user))) {
@@ -265,7 +263,6 @@ static void cmd_op(struct userrec *u, int idx, char *par)
   struct chanset_t *chan;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -294,8 +291,7 @@ static void cmd_op(struct userrec *u, int idx, char *par)
     dprintf(idx, "%s is not on %s.\n", nick, chan->dname);
     return;
   }
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if (chan_deop(victim) || (glob_deop(victim) && !glob_op(victim))) {
     dprintf(idx, "%s is currently being auto-deopped.\n", m->nick);
@@ -315,7 +311,6 @@ static void cmd_deop(struct userrec *u, int idx, char *par)
   struct chanset_t *chan;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -348,8 +343,7 @@ static void cmd_deop(struct userrec *u, int idx, char *par)
     dprintf(idx, "I'm not going to deop myself.\n");
     return;
   }
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_master(victim) || glob_master(victim)) &&
       !(chan_owner(user) || glob_owner(user))) {
@@ -371,7 +365,6 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
   struct userrec *u2;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -386,8 +379,7 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
   get_user_flagrec(dcc[idx].user, &user, chan->dname);
   m = ismember(chan, nick);
   if (m && !chan_op(user) && (!glob_op(user) || chan_deop(user))) {
-    egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u2 = m->user ? m->user : get_user_by_host(s);
+    u2 = m->user ? m->user : get_user_from_channel(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
@@ -414,8 +406,7 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
     dprintf(idx, "%s is not on %s.\n", nick, chan->dname);
     return;
   }
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if (chan_dehalfop(victim) || (glob_dehalfop(victim) && !glob_halfop(victim))) {
     dprintf(idx, "%s is currently being auto-dehalfopped.\n", m->nick);
@@ -437,7 +428,6 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
   struct userrec *u2;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -452,9 +442,7 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
   get_user_flagrec(dcc[idx].user, &user, chan->dname);
   m = ismember(chan, nick);
   if (m && !chan_op(user) && (!glob_op(user) || chan_deop(user))) {
-    egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u2 = m->user ? m->user : get_user_by_host(s);
-
+    u2 = m->user ? m->user : get_user_from_channel(m);
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
       dprintf(idx, "You are not a channel op on %s.\n", chan->dname);
@@ -484,8 +472,7 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
     dprintf(idx, "I'm not going to dehalfop myself.\n");
     return;
   }
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_master(victim) || glob_master(victim)) &&
       !(chan_owner(user) || glob_owner(user))) {
@@ -512,7 +499,6 @@ static void cmd_voice(struct userrec *u, int idx, char *par)
   struct userrec *u2;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -533,8 +519,7 @@ static void cmd_voice(struct userrec *u, int idx, char *par)
    * - stdarg */
   if (m && !(chan_op(user) || chan_halfop(user) || (glob_op(user) &&
       !chan_deop(user)) || (glob_halfop(user) && !chan_dehalfop(user)))) {
-    egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u2 = m->user ? m->user : get_user_by_host(s);
+    u2 = m->user ? m->user : get_user_from_channel(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
@@ -570,7 +555,6 @@ static void cmd_devoice(struct userrec *u, int idx, char *par)
   struct userrec *u2;
   char *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   nick = newsplit(&par);
   chan = get_channel(idx, par);
@@ -586,8 +570,7 @@ static void cmd_devoice(struct userrec *u, int idx, char *par)
   m = ismember(chan, nick);
   if (m && !(chan_op(user) || chan_halfop(user) || (glob_op(user) &&
       !chan_deop(user)) || (glob_halfop(user) && !chan_dehalfop(user)))) {
-    egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u2 = m->user ? m->user : get_user_by_host(s);
+    u2 = m->user ? m->user : get_user_from_channel(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
@@ -623,7 +606,6 @@ static void cmd_kick(struct userrec *u, int idx, char *par)
   struct chanset_t *chan;
   char *chname, *nick;
   memberlist *m;
-  char s[UHOSTLEN];
 
   if (!par[0]) {
     dprintf(idx, "Usage: kick [channel] <nick> [reason]\n");
@@ -663,8 +645,7 @@ static void cmd_kick(struct userrec *u, int idx, char *par)
             chan->dname);
     return;
   }
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_op(victim) || (glob_op(victim) && !chan_deop(victim))) &&
       !(chan_master(user) || glob_master(user))) {
@@ -768,9 +749,9 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
           strftime(s, 6, "%H:%M", localtime(&(m->joined)));
       } else
         strlcpy(s, " --- ", sizeof s);
+      egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
       if (m->user == NULL) {
-        egg_snprintf(s1, sizeof s1, "%s!%s", m->nick, m->userhost);
-        m->user = get_user_by_host(s1);
+        m->user = get_user_from_channel(m);
       }
       if (m->user == NULL)
         strlcpy(handle, "*", sizeof handle);
@@ -1022,7 +1003,7 @@ static void cmd_adduser(struct userrec *u, int idx, char *par)
   if (strlen(hand) > HANDLEN)
     hand[HANDLEN] = 0;
   egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   if (u) {
     dprintf(idx, "%s is already known as %s.\n", nick, u->handle);
     return;
@@ -1059,7 +1040,7 @@ static void cmd_adduser(struct userrec *u, int idx, char *par)
 
 static void cmd_deluser(struct userrec *u, int idx, char *par)
 {
-  char *nick, s[UHOSTLEN];
+  char *nick;
   struct chanset_t *chan;
   memberlist *m = NULL;
   struct flag_record victim = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };
@@ -1080,8 +1061,7 @@ static void cmd_deluser(struct userrec *u, int idx, char *par)
     return;
   }
   get_user_flagrec(u, &user, chan->dname);
-  egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   if (!u) {
     dprintf(idx, "%s is not a valid user.\n", nick);
     return;

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -706,7 +706,6 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
   char handle[HANDLEN + 1], s[UHOSTLEN], s1[UHOSTLEN], atrflag, chanflag;
   struct chanset_t *chan;
   memberlist *m;
-  struct userrec *u;
   int maxnicklen, maxhandlen;
 
   chan = get_channel(idx, par);

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -72,7 +72,7 @@ static char *getnick(char *handle, struct chanset_t *chan)
   memberlist *m;
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    if ((u = get_user_from_channel(m)) && !strcasecmp(u->handle, handle))
+    if ((u = get_user_from_member(m)) && !strcasecmp(u->handle, handle))
       return m->nick;
   }
   return NULL;
@@ -206,7 +206,7 @@ static void cmd_kickban(struct userrec *u, int idx, char *par)
     return;
   }
   egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_op(victim) || (glob_op(victim) && !chan_deop(victim))) &&
       !(chan_master(user) || glob_master(user))) {
@@ -291,7 +291,7 @@ static void cmd_op(struct userrec *u, int idx, char *par)
     dprintf(idx, "%s is not on %s.\n", nick, chan->dname);
     return;
   }
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if (chan_deop(victim) || (glob_deop(victim) && !glob_op(victim))) {
     dprintf(idx, "%s is currently being auto-deopped.\n", m->nick);
@@ -343,7 +343,7 @@ static void cmd_deop(struct userrec *u, int idx, char *par)
     dprintf(idx, "I'm not going to deop myself.\n");
     return;
   }
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_master(victim) || glob_master(victim)) &&
       !(chan_owner(user) || glob_owner(user))) {
@@ -379,7 +379,7 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
   get_user_flagrec(dcc[idx].user, &user, chan->dname);
   m = ismember(chan, nick);
   if (m && !chan_op(user) && (!glob_op(user) || chan_deop(user))) {
-    u2 = get_user_from_channel(m);
+    u2 = get_user_from_member(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
@@ -406,7 +406,7 @@ static void cmd_halfop(struct userrec *u, int idx, char *par)
     dprintf(idx, "%s is not on %s.\n", nick, chan->dname);
     return;
   }
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if (chan_dehalfop(victim) || (glob_dehalfop(victim) && !glob_halfop(victim))) {
     dprintf(idx, "%s is currently being auto-dehalfopped.\n", m->nick);
@@ -442,7 +442,7 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
   get_user_flagrec(dcc[idx].user, &user, chan->dname);
   m = ismember(chan, nick);
   if (m && !chan_op(user) && (!glob_op(user) || chan_deop(user))) {
-    u2 = get_user_from_channel(m);
+    u2 = get_user_from_member(m);
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_halfop(user) &&
         (!glob_halfop(user) || chan_dehalfop(user)))) {
       dprintf(idx, "You are not a channel op on %s.\n", chan->dname);
@@ -472,7 +472,7 @@ static void cmd_dehalfop(struct userrec *u, int idx, char *par)
     dprintf(idx, "I'm not going to dehalfop myself.\n");
     return;
   }
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_master(victim) || glob_master(victim)) &&
       !(chan_owner(user) || glob_owner(user))) {
@@ -519,7 +519,7 @@ static void cmd_voice(struct userrec *u, int idx, char *par)
    * - stdarg */
   if (m && !(chan_op(user) || chan_halfop(user) || (glob_op(user) &&
       !chan_deop(user)) || (glob_halfop(user) && !chan_dehalfop(user)))) {
-    u2 = get_user_from_channel(m);
+    u2 = get_user_from_member(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
@@ -570,7 +570,7 @@ static void cmd_devoice(struct userrec *u, int idx, char *par)
   m = ismember(chan, nick);
   if (m && !(chan_op(user) || chan_halfop(user) || (glob_op(user) &&
       !chan_deop(user)) || (glob_halfop(user) && !chan_dehalfop(user)))) {
-    u2 = get_user_from_channel(m);
+    u2 = get_user_from_member(m);
 
     if (!u2 || strcasecmp(u2->handle, dcc[idx].nick) || (!chan_voice(user) &&
         (!glob_voice(user) || chan_quiet(user)))) {
@@ -645,7 +645,7 @@ static void cmd_kick(struct userrec *u, int idx, char *par)
             chan->dname);
     return;
   }
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
   if ((chan_op(victim) || (glob_op(victim) && !chan_deop(victim))) &&
       !(chan_master(user) || glob_master(user))) {
@@ -729,7 +729,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       if (strlen(m->nick) > maxnicklen)
         maxnicklen = strlen(m->nick);
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       if (u && (strlen(u->handle) > maxhandlen))
         maxhandlen = strlen(u->handle);
     }
@@ -752,7 +752,7 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
         strlcpy(s, " --- ", sizeof s);
       egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
 
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       if (u == NULL)
         strlcpy(handle, "*", sizeof handle);
       else
@@ -1003,7 +1003,7 @@ static void cmd_adduser(struct userrec *u, int idx, char *par)
   if (strlen(hand) > HANDLEN)
     hand[HANDLEN] = 0;
   egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   if (u) {
     dprintf(idx, "%s is already known as %s.\n", nick, u->handle);
     return;
@@ -1061,7 +1061,7 @@ static void cmd_deluser(struct userrec *u, int idx, char *par)
     return;
   }
   get_user_flagrec(u, &user, chan->dname);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   if (!u) {
     dprintf(idx, "%s is not a valid user.\n", nick);
     return;

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -232,7 +232,6 @@ static void maybe_revenge(struct chanset_t *chan, char *whobad,
   struct userrec *u, *u2;
   memberlist *m;
 
-
   if (!chan || (type < 0))
     return;
 
@@ -240,7 +239,6 @@ static void maybe_revenge(struct chanset_t *chan, char *whobad,
   badnick = splitnick(&whobad);
   m = ismember(chan, badnick);
   u = get_user_from_channel(m);
-
 
   /* Get info about victim */
   victim = splitnick(&whovictim);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -142,7 +142,6 @@ static void punish_badguy(struct chanset_t *chan, char *whobad,
   /* Set the offender +d */
   if ((chan->revenge_mode > 0) && !(chan_deop(fr) || glob_deop(fr))) {
     char s[UHOSTLEN], s1[UHOSTLEN];
-    memberlist *mx = NULL;
 
     /* Removing op */
     if (chan_op(fr) || (glob_op(fr) && !chan_deop(fr))) {
@@ -186,8 +185,6 @@ static void punish_badguy(struct chanset_t *chan, char *whobad,
       fr.chan = USER_DEOP;
       fr.udef_chan = 0;
       u = get_user_by_handle(userlist, s1);
-//      if ((mx = ismember(chan, badnick)))
-//        mx->user = u;
       set_user_flagrec(u, &fr, chan->dname);
       simple_sprintf(s, "(%s) %s (%s)", ct, reason, whobad);
       set_user(&USERENTRY_COMMENT, u, (void *) s);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -235,12 +235,12 @@ static void maybe_revenge(struct chanset_t *chan, char *whobad,
   /* Get info about offender */
   badnick = splitnick(&whobad);
   m = ismember(chan, badnick);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
 
   /* Get info about victim */
   victim = splitnick(&whovictim);
   m = ismember(chan, victim);
-  u2 = get_user_from_channel(m);
+  u2 = get_user_from_member(m);
   mevictim = match_my_nick(victim);
 
   /* Do we want to revenge? */
@@ -267,7 +267,7 @@ static int hand_on_chan(struct chanset_t *chan, struct userrec *u)
   memberlist *m;
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    if (u == get_user_from_channel(m))
+    if (u == get_user_from_member(m))
       return 1;
   }
   return 0;
@@ -573,7 +573,7 @@ static void check_lonely_channel(struct chanset_t *chan)
       chan->status |= CHAN_WHINED;
     }
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       if (!match_my_nick(m->nick) && (!u || !(u->flags & USER_BOT))) {
         ok = 0;
         break;
@@ -666,7 +666,7 @@ static void check_expired_chanstuff()
           for (m = chan->channel.member; m && m->nick[0]; m = m->next)
             if (now - m->last >= chan->idle_kick * 60 &&
                 !match_my_nick(m->nick) && !chan_issplit(m)) {
-              get_user_flagrec(get_user_from_channel(m), &fr, chan->dname);
+              get_user_flagrec(get_user_from_member(m), &fr, chan->dname);
               if ((!(glob_bot(fr) || glob_friend(fr) || (glob_op(fr) &&
                   !chan_deop(fr)) || chan_friend(fr) || chan_op(fr))) &&
                   (me_op(chan) || (me_halfop(chan) && !chan_hasop(m)))) {
@@ -679,7 +679,7 @@ static void check_expired_chanstuff()
       for (m = chan->channel.member; m && m->nick[0]; m = n) {
         n = m->next;
         if (m->split && now - m->split > wait_split) {
-          check_tcl_sign(m->nick, m->userhost, get_user_from_channel(m),
+          check_tcl_sign(m->nick, m->userhost, get_user_from_member(m),
                          chan->dname, "lost in the netsplit");
           putlog(LOG_JOIN, chan->dname,
                  "%s (%s) got lost in the net-split.", m->nick, m->userhost);
@@ -916,7 +916,7 @@ static int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
   simple_sprintf(host, "%s!%s", nick, from);
   chan = findchan(chname);
   m = ismember(chan, nick);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   hand = u ? u->handle : "*";
   get_user_flagrec(u, &fr, chname);
   Tcl_SetVar(interp, "_pub1", nick, 0);
@@ -946,7 +946,7 @@ static int check_tcl_pubm(char *nick, char *from, char *chname, char *msg)
   simple_sprintf(host, "%s!%s", nick, from);
   chan = findchan(chname);
   m = ismember(chan, nick);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &fr, chname);
   Tcl_SetVar(interp, "_pubm1", nick, 0);
   Tcl_SetVar(interp, "_pubm2", from, 0);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -186,8 +186,8 @@ static void punish_badguy(struct chanset_t *chan, char *whobad,
       fr.chan = USER_DEOP;
       fr.udef_chan = 0;
       u = get_user_by_handle(userlist, s1);
-      if ((mx = ismember(chan, badnick)))
-        mx->user = u;
+//      if ((mx = ismember(chan, badnick)))
+//        mx->user = u;
       set_user_flagrec(u, &fr, chan->dname);
       simple_sprintf(s, "(%s) %s (%s)", ct, reason, whobad);
       set_user(&USERENTRY_COMMENT, u, (void *) s);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -669,8 +669,7 @@ static void check_expired_chanstuff()
           for (m = chan->channel.member; m && m->nick[0]; m = m->next)
             if (now - m->last >= chan->idle_kick * 60 &&
                 !match_my_nick(m->nick) && !chan_issplit(m)) {
-              get_user_flagrec(m->user ? m->user : get_user_from_channel(m),
-                               &fr, chan->dname);
+              get_user_flagrec(get_user_from_channel(m), &fr, chan->dname);
               if ((!(glob_bot(fr) || glob_friend(fr) || (glob_op(fr) &&
                   !chan_deop(fr)) || chan_friend(fr) || chan_op(fr))) &&
                   (me_op(chan) || (me_halfop(chan) && !chan_hasop(m)))) {
@@ -683,8 +682,7 @@ static void check_expired_chanstuff()
       for (m = chan->channel.member; m && m->nick[0]; m = n) {
         n = m->next;
         if (m->split && now - m->split > wait_split) {
-          check_tcl_sign(m->nick, m->userhost,
-                         m->user ? m->user : get_user_from_channel(m),
+          check_tcl_sign(m->nick, m->userhost, get_user_from_channel(m),
                          chan->dname, "lost in the netsplit");
           putlog(LOG_JOIN, chan->dname,
                  "%s (%s) got lost in the net-split.", m->nick, m->userhost);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -919,7 +919,7 @@ static int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
   strlcpy(buf, msg, sizeof buf);
   cmd = newsplit(&args);
   simple_sprintf(host, "%s!%s", nick, from);
-  chan = findchan_by_dname(chname);
+  chan = findchan(chname);
   m = ismember(chan, nick);
   u = get_user_from_channel(m);
   hand = u ? u->handle : "*";
@@ -949,7 +949,7 @@ static int check_tcl_pubm(char *nick, char *from, char *chname, char *msg)
 
   simple_sprintf(buf, "%s %s", chname, msg);
   simple_sprintf(host, "%s!%s", nick, from);
-  chan = findchan_by_dname(chname);
+  chan = findchan(chname);
   m = ismember(chan, nick);
   u = get_user_from_channel(m);
   get_user_flagrec(u, &fr, chname);

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -421,7 +421,7 @@ static void got_op(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
 
   get_user_flagrec(u, &victim, chan->dname);
   /* Flags need to be set correctly right from the beginning now, so that
@@ -515,7 +515,7 @@ static void got_halfop(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
 
   get_user_flagrec(u, &victim, chan->dname);
   /* Flags need to be set correctly right from the beginning now, so that
@@ -604,7 +604,7 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
   strcpy(ch, chan->name);
   simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   simple_sprintf(s1, "%s!%s", nick, from);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
 
   had_halfop = chan_hasop(m);
@@ -696,7 +696,7 @@ static void got_dehalfop(struct chanset_t *chan, char *nick, char *from,
 
   strcpy(ch, chan->name);
   simple_sprintf(s1, "%s!%s", nick, from);
-  u = get_user_from_channel(m);
+  u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
 
   had_halfop = chan_hasop(m);
@@ -775,7 +775,7 @@ static void got_ban(struct chanset_t *chan, char *nick, char *from, char *who,
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       egg_snprintf(s1, sizeof s1, "%s!%s", m->nick, m->userhost);
       if (match_addr(who, s1)) {
-        targ = get_user_from_channel(m);
+        targ = get_user_from_member(m);
         if (targ) {
           get_user_flagrec(targ, &victim, chan->dname);
           if ((glob_friend(victim) || (glob_op(victim) && !chan_deop(victim)) ||
@@ -1019,7 +1019,7 @@ static int gotmode(char *from, char *origmsg)
       nick = splitnick(&from);
       m = ismember(chan, nick);
       if (m) {
-        u = get_user_from_channel(m);
+        u = get_user_from_member(m);
         get_user_flagrec(u, &user, ch);
         m->last = now;
       } else {
@@ -1243,7 +1243,7 @@ static int gotmode(char *from, char *origmsg)
             refresh_who_chan(chan->name);
           } else {
             simple_sprintf(s, "%s!%s", m->nick, m->userhost);
-            get_user_flagrec(get_user_from_channel(m), &victim, chan->dname);
+            get_user_flagrec(get_user_from_member(m), &victim, chan->dname);
             if (ms2[0] == '+') {
               m->flags &= ~SENTVOICE;
               m->flags |= CHANVOICE;

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -421,10 +421,7 @@ static void got_op(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  if (!m->user)
-    u = get_user_from_channel(m);
-  else
-    u = m->user;
+  u = get_user_from_channel(m);
 
   get_user_flagrec(u, &victim, chan->dname);
   /* Flags need to be set correctly right from the beginning now, so that
@@ -518,10 +515,7 @@ static void got_halfop(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  if (!m->user)
-    u = get_user_from_channel(m);
-  else
-    u = m->user;
+  u = get_user_from_channel(m);
 
   get_user_flagrec(u, &victim, chan->dname);
   /* Flags need to be set correctly right from the beginning now, so that
@@ -1245,8 +1239,7 @@ static int gotmode(char *from, char *origmsg)
             refresh_who_chan(chan->name);
           } else {
             simple_sprintf(s, "%s!%s", m->nick, m->userhost);
-            get_user_flagrec(m->user ? m->user : get_user_from_channel(m),
-                             &victim, chan->dname);
+            get_user_flagrec(get_user_from_channel, &victim, chan->dname);
             if (ms2[0] == '+') {
               m->flags &= ~SENTVOICE;
               m->flags |= CHANVOICE;

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -1022,6 +1022,8 @@ static int gotmode(char *from, char *origmsg)
         u = get_user_from_channel(m);
         get_user_flagrec(u, &user, ch);
         m->last = now;
+      } else {
+        u = NULL;
       }
       if (m && channel_active(chan) && (me_op(chan) || (me_halfop(chan) &&
           !chan_hasop(m))) && !(glob_friend(user) || chan_friend(user) ||

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -421,9 +421,8 @@ static void got_op(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   if (!m->user)
-    u = get_user_by_host(s);
+    u = get_user_from_channel(m);
   else
     u = m->user;
 
@@ -519,9 +518,8 @@ static void got_halfop(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
-  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   if (!m->user)
-    u = get_user_by_host(s);
+    u = get_user_from_channel(m);
   else
     u = m->user;
 
@@ -610,9 +608,8 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
   }
 
   strcpy(ch, chan->name);
-  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   simple_sprintf(s1, "%s!%s", nick, from);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
 
   had_halfop = chan_hasop(m);
@@ -703,9 +700,8 @@ static void got_dehalfop(struct chanset_t *chan, char *nick, char *from,
   }
 
   strcpy(ch, chan->name);
-  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   simple_sprintf(s1, "%s!%s", nick, from);
-  u = get_user_by_host(s);
+  u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
 
   had_halfop = chan_hasop(m);
@@ -784,7 +780,7 @@ static void got_ban(struct chanset_t *chan, char *nick, char *from, char *who,
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       egg_snprintf(s1, sizeof s1, "%s!%s", m->nick, m->userhost);
       if (match_addr(who, s1)) {
-        targ = get_user_by_host(s1);
+        targ = get_user_from_channel(m);
         if (targ) {
           get_user_flagrec(targ, &victim, chan->dname);
           if ((glob_friend(victim) || (glob_op(victim) && !chan_deop(victim)) ||
@@ -1025,10 +1021,10 @@ static int gotmode(char *from, char *origmsg)
         msg[z] = 0;
       putlog(LOG_MODES, chan->dname, "%s: mode change '%s %s' by %s", ch, chg,
              msg, from);
-      u = get_user_by_host(from);
-      get_user_flagrec(u, &user, ch);
       nick = splitnick(&from);
       m = ismember(chan, nick);
+      u = get_user_from_channel(m);
+      get_user_flagrec(u, &user, ch);
       if (m)
         m->last = now;
       if (m && channel_active(chan) && (me_op(chan) || (me_halfop(chan) &&
@@ -1249,7 +1245,7 @@ static int gotmode(char *from, char *origmsg)
             refresh_who_chan(chan->name);
           } else {
             simple_sprintf(s, "%s!%s", m->nick, m->userhost);
-            get_user_flagrec(m->user ? m->user : get_user_by_host(s),
+            get_user_flagrec(m->user ? m->user : get_user_from_channel(m),
                              &victim, chan->dname);
             if (ms2[0] == '+') {
               m->flags &= ~SENTVOICE;

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -602,6 +602,7 @@ static void got_deop(struct chanset_t *chan, char *nick, char *from,
   }
 
   strcpy(ch, chan->name);
+  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   simple_sprintf(s1, "%s!%s", nick, from);
   u = get_user_from_channel(m);
   get_user_flagrec(u, &victim, chan->dname);
@@ -1017,10 +1018,11 @@ static int gotmode(char *from, char *origmsg)
              msg, from);
       nick = splitnick(&from);
       m = ismember(chan, nick);
-      u = get_user_from_channel(m);
-      get_user_flagrec(u, &user, ch);
-      if (m)
+      if (m) {
+        u = get_user_from_channel(m);
+        get_user_flagrec(u, &user, ch);
         m->last = now;
+      }
       if (m && channel_active(chan) && (me_op(chan) || (me_halfop(chan) &&
           !chan_hasop(m))) && !(glob_friend(user) || chan_friend(user) ||
           (channel_dontkickops(chan) && (chan_op(user) || (glob_op(user) &&

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -1239,7 +1239,7 @@ static int gotmode(char *from, char *origmsg)
             refresh_who_chan(chan->name);
           } else {
             simple_sprintf(s, "%s!%s", m->nick, m->userhost);
-            get_user_flagrec(get_user_from_channel, &victim, chan->dname);
+            get_user_flagrec(get_user_from_channel(m), &victim, chan->dname);
             if (ms2[0] == '+') {
               m->flags &= ~SENTVOICE;
               m->flags |= CHANVOICE;

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -383,7 +383,7 @@ static int msg_who(char *nick, char *host, struct userrec *u, char *par)
     struct userrec *u;
 
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u = get_user_from_channel(m);
+    u = get_user_from_member(m);
     info = get_user(&USERENTRY_INFO, u);
     if (u && (u->flags & USER_BOT))
       info = 0;
@@ -462,7 +462,7 @@ static int msg_whois(char *nick, char *host, struct userrec *u, char *par)
     for (chan = chanset; chan && !ok; chan = chan->next) {
       m = ismember(chan, par);
       if (m) {
-        u2 = get_user_from_channel(m);
+        u2 = get_user_from_member(m);
         if (u2) {
           ok = 1;
           dprintf(DP_HELP, "NOTICE %s :[%s] AKA '%s':\n", nick,

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -383,7 +383,7 @@ static int msg_who(char *nick, char *host, struct userrec *u, char *par)
     struct userrec *u;
 
     egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
-    u = get_user_by_host(s);
+    u = get_user_from_channel(m);
     info = get_user(&USERENTRY_INFO, u);
     if (u && (u->flags & USER_BOT))
       info = 0;
@@ -431,7 +431,7 @@ static int msg_who(char *nick, char *host, struct userrec *u, char *par)
 
 static int msg_whois(char *nick, char *host, struct userrec *u, char *par)
 {
-  char s[UHOSTLEN + 1], s1[143], *s2, stime[14];
+  char s1[143], *s2, stime[14];
   int ok;
   struct chanset_t *chan;
   memberlist *m;
@@ -462,8 +462,7 @@ static int msg_whois(char *nick, char *host, struct userrec *u, char *par)
     for (chan = chanset; chan && !ok; chan = chan->next) {
       m = ismember(chan, par);
       if (m) {
-        egg_snprintf(s, sizeof s, "%s!%s", par, m->userhost);
-        u2 = get_user_by_host(s);
+        u2 = get_user_from_channel(m);
         if (u2) {
           ok = 1;
           dprintf(DP_HELP, "NOTICE %s :[%s] AKA '%s':\n", nick,

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -27,6 +27,7 @@ static int tcl_chanlist STDVAR
   int f;
   memberlist *m;
   struct chanset_t *chan;
+  struct userrec *u;
   struct flag_record plus = { FR_CHAN | FR_GLOBAL | FR_BOT, 0, 0, 0, 0, 0 },
                      minus = { FR_CHAN | FR_GLOBAL | FR_BOT, 0, 0, 0, 0, 0},
                      user = { FR_CHAN | FR_GLOBAL | FR_BOT, 0, 0, 0, 0, 0 };
@@ -1106,6 +1107,7 @@ static int tcl_nick2hand STDVAR
 {
   memberlist *m;
   struct chanset_t *chan, *thechan = NULL;
+  struct userrec *u;
 
   BADARGS(2, 3, " nick ?channel?");
 

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -24,7 +24,6 @@
  */
 static int tcl_chanlist STDVAR
 {
-  char nuh[1024];
   int f;
   memberlist *m;
   struct chanset_t *chan;
@@ -56,8 +55,7 @@ static int tcl_chanlist STDVAR
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
     if (!m->user) {
-      egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
-      m->user = get_user_by_host(nuh);
+      m->user = get_user_from_channel(m);
     }
     get_user_flagrec(m->user, &user, argv[1]);
     user.match = plus.match;
@@ -347,7 +345,6 @@ static int tcl_onchan STDVAR
 
 static int tcl_handonchan STDVAR
 {
-  char nuh[1024];
   struct chanset_t *chan, *thechan = NULL;
   memberlist *m;
 
@@ -366,8 +363,7 @@ static int tcl_handonchan STDVAR
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       if (!m->user) {
-        egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
-        m->user = get_user_by_host(nuh);
+        m->user = get_user_from_channel(m);
       }
       if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         Tcl_AppendResult(irp, "1", NULL);
@@ -1027,7 +1023,6 @@ static int tcl_account2nicks STDVAR
 
 static int tcl_hand2nicks STDVAR
 {
-  char nuh[1024];
   memberlist *m;
   struct chanset_t *chan, *thechan = NULL;
   Tcl_Obj *nicks;
@@ -1052,9 +1047,8 @@ static int tcl_hand2nicks STDVAR
       found = 0;
       /* Does this user have the account we're looking for? */
       if (!m->user && !m->tried_getuser) {
-        egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
         m->tried_getuser = 1;
-        m->user = get_user_by_host(nuh);
+        m->user = get_user_from_channel(m);
       }
       if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         /* Is the nick of the user already in the list? */
@@ -1078,7 +1072,6 @@ static int tcl_hand2nicks STDVAR
 
 static int tcl_hand2nick STDVAR
 {
-  char nuh[1024];
   memberlist *m;
   struct chanset_t *chan, *thechan = NULL;
 
@@ -1097,9 +1090,8 @@ static int tcl_hand2nick STDVAR
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       if (!m->user && !m->tried_getuser) {
-        egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
         m->tried_getuser = 1;
-        m->user = get_user_by_host(nuh);
+        m->user = get_user_from_channel(m);
       }
       if (m->user && !strcasecmp(m->user->handle, argv[1])) {
         Tcl_AppendResult(irp, m->nick, NULL);
@@ -1113,7 +1105,6 @@ static int tcl_hand2nick STDVAR
 
 static int tcl_nick2hand STDVAR
 {
-  char nuh[1024];
   memberlist *m;
   struct chanset_t *chan, *thechan = NULL;
 
@@ -1133,8 +1124,7 @@ static int tcl_nick2hand STDVAR
     m = ismember(chan, argv[1]);
     if (m) {
       if (!m->user) {
-        egg_snprintf(nuh, sizeof nuh, "%s!%s", m->nick, m->userhost);
-        m->user = get_user_by_host(nuh);
+        m->user = get_user_from_channel(m);
       }
       Tcl_AppendResult(irp, m->user ? m->user->handle : "*", NULL);
       return TCL_OK;

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -55,7 +55,7 @@ static int tcl_chanlist STDVAR
   minus.match = plus.match ^ (FR_AND | FR_OR);
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-    u = get_user_from_channel(m);
+    u = get_user_from_member(m);
     get_user_flagrec(u, &user, argv[1]);
     user.match = plus.match;
     if (flagrec_eq(&plus, &user)) {
@@ -362,7 +362,7 @@ static int tcl_handonchan STDVAR
 
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       if (u && !strcasecmp(u->handle, argv[1])) {
         Tcl_AppendResult(irp, "1", NULL);
         return TCL_OK;
@@ -1044,7 +1044,7 @@ static int tcl_hand2nicks STDVAR
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       found = 0;
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       /* Does this user have the account we're looking for? */
       if (!u && !m->tried_getuser) {
         m->tried_getuser = 1;
@@ -1089,7 +1089,7 @@ static int tcl_hand2nick STDVAR
 
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       if (!u && !m->tried_getuser) {
         m->tried_getuser = 1;
       }
@@ -1124,7 +1124,7 @@ static int tcl_nick2hand STDVAR
   while (chan && (thechan == NULL || thechan == chan)) {
     m = ismember(chan, argv[1]);
     if (m) {
-      u = get_user_from_channel(m);
+      u = get_user_from_member(m);
       Tcl_AppendResult(irp, u ? u->handle : "*", NULL);
       return TCL_OK;
     }

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -1045,10 +1045,6 @@ static int tcl_hand2nicks STDVAR
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       found = 0;
       u = get_user_from_member(m);
-      /* Does this user have the account we're looking for? */
-      if (!u && !m->tried_getuser) {
-        m->tried_getuser = 1;
-      }
       if (u && !strcasecmp(u->handle, argv[1])) {
         /* Is the nick of the user already in the list? */
         Tcl_ListObjGetElements(irp, nicks, &nicksc, &nicksv);
@@ -1090,9 +1086,6 @@ static int tcl_hand2nick STDVAR
   while (chan && (thechan == NULL || thechan == chan)) {
     for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       u = get_user_from_member(m);
-      if (!u && !m->tried_getuser) {
-        m->tried_getuser = 1;
-      }
       if (u && !strcasecmp(u->handle, argv[1])) {
         Tcl_AppendResult(irp, m->nick, NULL);
         return TCL_OK;

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -524,7 +524,8 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define bind_bind_entry ((int(*)(tcl_bind_list_t *, const char *, const char *, const char *))global[320])
 #define unbind_bind_entry ((int(*)(tcl_bind_list_t *, const char *, const char *, const char *))global[321])
 #define argv0 ((char *)global[322])
-
+#define get_user_from_channel ((struct userrec * (*)(memberlist *))global[323])
+/* 324 - 327 */
 
 
 /* hostmasking */

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -524,7 +524,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define bind_bind_entry ((int(*)(tcl_bind_list_t *, const char *, const char *, const char *))global[320])
 #define unbind_bind_entry ((int(*)(tcl_bind_list_t *, const char *, const char *, const char *))global[321])
 #define argv0 ((char *)global[322])
-#define get_user_from_channel ((struct userrec * (*)(memberlist *))global[323])
+#define get_user_from_member ((struct userrec * (*)(memberlist *))global[323])
 /* 324 - 327 */
 
 

--- a/src/mod/notes.mod/notes.c
+++ b/src/mod/notes.mod/notes.c
@@ -838,7 +838,7 @@ static void notes_hourly()
 
     for (chan = chanset; chan; chan = chan->next) {
       for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-        u = get_user_from_channel(m);
+        u = get_user_from_member(m);
         if (u) {
           k = num_notes(u->handle);
           for (l = 0; l < dcc_total; l++)

--- a/src/mod/notes.mod/notes.c
+++ b/src/mod/notes.mod/notes.c
@@ -834,13 +834,11 @@ static void notes_hourly()
     memberlist *m;
     int k;
     int l;
-    char s1[NICKMAX+UHOSTLEN+1];
     struct userrec *u;
 
     for (chan = chanset; chan; chan = chan->next) {
       for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-        sprintf(s1, "%s!%s", m->nick, m->userhost);
-        u = get_user_by_host(s1);
+        u = get_user_from_channel(m);
         if (u) {
           k = num_notes(u->handle);
           for (l = 0; l < dcc_total; l++)

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -194,7 +194,7 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
         m = ismember(chan, object);
         if (m) {
           onchan = 1;
-          urec = get_user_from_channel(m);
+          urec = get_user_from_member(m);
           if (!urec || !strcasecmp(object, urec->handle))
             break;
           strcat(whoredirect, object);
@@ -341,7 +341,7 @@ targetcont:
     if (m) {
       onchan = 1;
       snprintf(word1, sizeof word1, "%s!%s", whotarget, m->userhost);
-      urec = get_user_from_channel(m);
+      urec = get_user_from_member(m);
       if (!urec || !strcasecmp(whotarget, urec->handle))
         break;
       strcat(whoredirect, whotarget);
@@ -358,7 +358,7 @@ targetcont:
     while (chan) {
       m = chan->channel.member;
       while (m && m->nick[0]) {
-        urec = get_user_from_channel(m);
+        urec = get_user_from_member(m);
         if (urec && !strcasecmp(urec->handle, whotarget)) {
           strcat(whoredirect, whotarget);
           strcat(whoredirect, " is ");

--- a/src/mod/seen.mod/seen.c
+++ b/src/mod/seen.mod/seen.c
@@ -148,7 +148,7 @@ static int dcc_seen(struct userrec *u, int idx, char *par)
 static void do_seen(int idx, char *prefix, char *nick, char *hand,
                     char *channel, char *text)
 {
-  char stuff[512], word1[512], word2[512], whotarget[128], object[128],
+  char word1[512], word2[512], whotarget[128], object[128],
        whoredirect[512], *oix, *lastonplace = 0;
   struct userrec *urec;
   struct chanset_t *chan;
@@ -194,8 +194,7 @@ static void do_seen(int idx, char *prefix, char *nick, char *hand,
         m = ismember(chan, object);
         if (m) {
           onchan = 1;
-          snprintf(stuff, sizeof stuff, "%s!%s", object, m->userhost);
-          urec = get_user_by_host(stuff);
+          urec = get_user_from_channel(m);
           if (!urec || !strcasecmp(object, urec->handle))
             break;
           strcat(whoredirect, object);
@@ -342,7 +341,7 @@ targetcont:
     if (m) {
       onchan = 1;
       snprintf(word1, sizeof word1, "%s!%s", whotarget, m->userhost);
-      urec = get_user_by_host(word1);
+      urec = get_user_from_channel(m);
       if (!urec || !strcasecmp(whotarget, urec->handle))
         break;
       strcat(whoredirect, whotarget);
@@ -359,8 +358,7 @@ targetcont:
     while (chan) {
       m = chan->channel.member;
       while (m && m->nick[0]) {
-        snprintf(word2, sizeof word2, "%s!%s", m->nick, m->userhost);
-        urec = get_user_by_host(word2);
+        urec = get_user_from_channel(m);
         if (urec && !strcasecmp(urec->handle, whotarget)) {
           strcat(whoredirect, whotarget);
           strcat(whoredirect, " is ");

--- a/src/modules.c
+++ b/src/modules.c
@@ -627,7 +627,7 @@ Function global_table[] = {
   (Function) bind_bind_entry,
   (Function) unbind_bind_entry,
   (Function) & argv0,
-  (Function) get_user_from_channel
+  (Function) get_user_from_member
 /* 324 - 327 */
 };
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -626,7 +626,9 @@ Function global_table[] = {
 /* 320 - 323 */
   (Function) bind_bind_entry,
   (Function) unbind_bind_entry,
-  (Function) & argv0
+  (Function) & argv0,
+  (Function) get_user_from_channel
+/* 324 - 327 */
 };
 
 void init_modules(void)

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -80,7 +80,6 @@ static int expmem_mask(struct maskrec *m)
   for (; m; m = m->next) {
     result += sizeof(struct maskrec);
     result += strlen(m->mask) + 1;
-//XXXXXXXX How to handle this one?
     if (m->user)
       result += strlen(m->user) + 1;
     if (m->desc)
@@ -172,23 +171,6 @@ static struct userrec *check_dcclist_hand(char *handle)
   return NULL;
 }
 
-/* Shortcut for get_user_by_handle -- might have user record in channels
- */
-static struct userrec *check_chanlist_hand(const char *hand)
-{
-  struct chanset_t *chan;
-  struct userrec *u;
-  memberlist *m;
-
-  for (chan = chanset; chan; chan = chan->next)
-    for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
-      u = get_user_from_channel(m);
-      if (u && !strcasecmp(u->handle, hand))
-        return u;
-    }
-  return NULL;
-}
-
 /* Search userlist for a provided account name
  * Returns: userrecord for user containing the account
  */
@@ -230,11 +212,6 @@ struct userrec *get_user_by_handle(struct userrec *bu, char *handle)
       cache_hit++;
       return ret;
     }
-//    ret = check_chanlist_hand(handle);
-//    if (ret) {
-//      cache_hit++;
-//      return ret;
-//    }
     cache_miss++;
   }
   for (u = bu; u; u = u->next)
@@ -349,12 +326,7 @@ struct userrec *get_user_by_host(char *host)
   rmspace(host);
   if (!host[0])
     return NULL;
-//  ret = check_chanlist(host);
   cnt = 0;
-//  if (ret != NULL) {
-//    cache_hit++;
-//    return ret;
-//  }
   cache_miss++;
   strlcpy(host2, host, sizeof host2);
   for (u = userlist; u; u = u->next) {
@@ -369,7 +341,6 @@ struct userrec *get_user_by_host(char *host)
   }
   if (ret != NULL) {
     lastuser = ret;
-    set_chanlist(host2, ret);
   }
   return ret;
 }

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -179,12 +179,11 @@ struct userrec *get_user_by_account(char *acct)
   struct userrec *u;
   struct list_type *q;
 
-  if (acct == NULL)
+  if (!acct || !acct[0] || !strcmp(acct, "*"))
     return NULL;
   for (u = userlist; u; u = u->next) {
-    q = get_user(&USERENTRY_ACCOUNT, u);
-    for (; q; q = q->next) {
-      if(q && !strcasecmp(q->extra, acct)) {
+    for (q = get_user(&USERENTRY_ACCOUNT, u); q; q = q->next) {
+      if (!rfc_casecmp(q->extra, acct)) {
         return u;
       }
     }

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -228,14 +228,14 @@ struct userrec *get_user_from_channel(memberlist *m)
   struct userrec *ret;
 
   /* Check if there is a user with a matching account if one is provided */
-  if (m->account) {
+  if (m->account[0] != '*') {
     ret = get_user_by_account(m->account);
     if (ret) {
       return ret;
     }
   }
   /* Check if there is a user with a matching hostmask if one is provided */
-  if (m->userhost && m->nick) {
+  if ((m->userhost[0] != '\0') && (m->nick[0] != '\0')) {
     char s[NICKMAX+UHOSTLEN+1];
     sprintf(s, "%s!%s", m->nick, m->userhost);
     ret = get_user_by_host(s);

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -222,7 +222,7 @@ struct userrec *get_user_by_handle(struct userrec *bu, char *handle)
   return NULL;
 }
 
-struct userrec *get_user_from_channel(memberlist *m)
+struct userrec *get_user_from_member(memberlist *m)
 {
   struct userrec *ret;
 

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -242,6 +242,29 @@ struct userrec *get_user_by_handle(struct userrec *bu, char *handle)
   return NULL;
 }
 
+struct userrec *get_user_from_channel(memberlist *m)
+{
+  struct userrec *ret;
+
+  /* Check if there is a user with a matching account if one is provided */
+  if (m->account) {
+    ret = get_user_by_account(m->account);
+    if (ret) {
+      return ret;
+    }
+  }
+  /* Check if there is a user with a matching hostmask if one is provided */
+  if (m->userhost && m->nick) {
+    char s[NICKMAX+UHOSTLEN+1];
+    sprintf(s, "%s!%s", m->nick, m->userhost);
+    ret = get_user_by_host(s);
+    if (ret) {
+      return ret;
+    }
+  }
+  return NULL;
+}
+
 /* Fix capitalization, etc
  */
 void correct_handle(char *handle)

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -80,6 +80,7 @@ static int expmem_mask(struct maskrec *m)
   for (; m; m = m->next) {
     result += sizeof(struct maskrec);
     result += strlen(m->mask) + 1;
+//XXXXXXXX How to handle this one?
     if (m->user)
       result += strlen(m->user) + 1;
     if (m->desc)
@@ -176,12 +177,14 @@ static struct userrec *check_dcclist_hand(char *handle)
 static struct userrec *check_chanlist_hand(const char *hand)
 {
   struct chanset_t *chan;
+  struct userrec *u;
   memberlist *m;
 
   for (chan = chanset; chan; chan = chan->next)
     for (m = chan->channel.member; m && m->nick[0]; m = m->next)
-      if (m->user && !strcasecmp(m->user->handle, hand))
-        return m->user;
+      u = get_user_from_channel(m);
+      if (u && !strcasecmp(u->handle, hand))
+        return u;
   return NULL;
 }
 
@@ -288,8 +291,6 @@ void clear_masks(maskrec *m)
     temp = m->next;
     if (m->mask)
       nfree(m->mask);
-    if (m->user)
-      nfree(m->user);
     if (m->desc)
       nfree(m->desc);
     nfree(m);

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -181,10 +181,11 @@ static struct userrec *check_chanlist_hand(const char *hand)
   memberlist *m;
 
   for (chan = chanset; chan; chan = chan->next)
-    for (m = chan->channel.member; m && m->nick[0]; m = m->next)
+    for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
       u = get_user_from_channel(m);
       if (u && !strcasecmp(u->handle, hand))
         return u;
+    }
   return NULL;
 }
 
@@ -229,11 +230,11 @@ struct userrec *get_user_by_handle(struct userrec *bu, char *handle)
       cache_hit++;
       return ret;
     }
-    ret = check_chanlist_hand(handle);
-    if (ret) {
-      cache_hit++;
-      return ret;
-    }
+//    ret = check_chanlist_hand(handle);
+//    if (ret) {
+//      cache_hit++;
+//      return ret;
+//    }
     cache_miss++;
   }
   for (u = bu; u; u = u->next)
@@ -335,12 +336,10 @@ void clear_userlist(struct userrec *bu)
 
 /* Find CLOSEST host match
  * (if "*!*@*" and "*!*@*clemson.edu" both match, use the latter!)
- *
- * Checks the chanlist first, to possibly avoid needless search.
  */
 struct userrec *get_user_by_host(char *host)
 {
-  struct userrec *u, *ret;
+  struct userrec *u, *ret = NULL;
   struct list_type *q;
   int cnt, i;
   char host2[UHOSTLEN];
@@ -350,12 +349,12 @@ struct userrec *get_user_by_host(char *host)
   rmspace(host);
   if (!host[0])
     return NULL;
-  ret = check_chanlist(host);
+//  ret = check_chanlist(host);
   cnt = 0;
-  if (ret != NULL) {
-    cache_hit++;
-    return ret;
-  }
+//  if (ret != NULL) {
+//    cache_hit++;
+//    return ret;
+//  }
   cache_miss++;
   strlcpy(host2, host, sizeof host2);
   for (u = userlist; u; u = u->next) {

--- a/src/users.h
+++ b/src/users.h
@@ -184,7 +184,7 @@ struct userrec *get_user_by_handle(struct userrec *, char *);
 struct userrec *get_user_by_host(char *);
 struct userrec *get_user_by_account(char *);
 struct userrec *get_user_by_nick(char *);
-struct userrec *get_user_from_channel(memberlist *);
+struct userrec *get_user_from_member(memberlist *);
 struct userrec *check_chanlist(const char *);
 
 /* All the default userentry stuff, for code re-use

--- a/src/users.h
+++ b/src/users.h
@@ -184,6 +184,7 @@ struct userrec *get_user_by_handle(struct userrec *, char *);
 struct userrec *get_user_by_host(char *);
 struct userrec *get_user_by_account(char *);
 struct userrec *get_user_by_nick(char *);
+struct userrec *get_user_from_channel(memberlist *);
 struct userrec *check_chanlist(const char *);
 
 /* All the default userentry stuff, for code re-use

--- a/src/version.h
+++ b/src/version.h
@@ -27,5 +27,5 @@
  */
 
 #define EGG_STRINGVER "1.9.5"
-#define EGG_NUMVER 1090505
-#define EGG_PATCH "python"
+#define EGG_NUMVER 1090506
+#define EGG_PATCH "accounttracking"


### PR DESCRIPTION
a PR that tracks adds get_user_from_channel, that calls both get_user_by_account() and get_user_by_host(). This will allow Eggdrop to track a user by their account name (first), and then check a hostname. The assumption here is that account names are more precise and less prone to collisions/spoofing than a hostmask. All the user protections and checks associated with handles can now be used based on account names instead of hosts.