### PR TITLE
Fix memleak in init_channel()

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -1998,17 +1998,17 @@ static void init_masklist(masklist *m)
 static void init_channel(struct chanset_t *chan, int reset)
 {
   int flags = reset ? reset : CHAN_RESETALL;
+  memberlist *m, *m1;
 
   if (flags & CHAN_RESETWHO) {
-    if (chan->channel.member) {
-      nfree(chan->channel.member); 
+    for (m = chan->channel.member; m; m = m1) {
+      m1 = m->next;
+      nfree(m);
     }
     chan->channel.members = 0;
     chan->channel.member = nmalloc(sizeof *chan->channel.member);
     /* Since we don't have channel_malloc, manually bzero */
     egg_bzero(chan->channel.member, sizeof *chan->channel.member);
-    chan->channel.member->nick[0] = 0;
-    chan->channel.member->next = NULL;
   }
 
   if (flags & CHAN_RESETMODES) {


### PR DESCRIPTION
Found by: michaelortmann (or Mystery-X if this fixes #1545, but unlikely, see https://github.com/eggheads/eggdrop/issues/1545#issuecomment-2041046997)
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix memleak in `init_channel()`

Additional description (if needed):
`init_channel()` was only freeing the first element of a linked list
Leak is triggered by the bot joining a channel and by use of `init_channel()`, like with `.reset`.
Fixing this leak could fix #1545, but it could- very likely - be a different leak.
We decided to ignore codacity code duplication warning here.

Test cases demonstrating functionality (if applicable):
`$ valgrind --leak-check=full --show-leak-kinds=all --verbose ./eggdrop -t BotA.conf`
make the bot join a channel and wait for the who reply
`.die`
the leak is shown like:
`==320050==    by 0x4868D36: init_channel (tclchan.c:2007)`

more visually, one could add
`char debug[1024 * 1024];`
to the memberlist stuct in `src/chan.c`
so that every leak would leak 1MB