### PR TITLE
Fix memleak in egg_string_unicodesup_desurrogate()

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -767,6 +767,7 @@ Tcl_Obj *egg_string_unicodesup_desurrogate(const char *oldstr, int len)
 {
   int stridx = 0, bufidx = 0;
   char *buf = nmalloc(len);
+  Tcl_Obj *o;
 
   while (stridx < len) {
     uint32_t low, high;
@@ -787,7 +788,10 @@ Tcl_Obj *egg_string_unicodesup_desurrogate(const char *oldstr, int len)
       }
     }
   }
-  return Tcl_NewStringObj(buf, bufidx);
+
+  o = Tcl_NewStringObj(buf, bufidx);
+  nfree(buf);
+  return o;
 }
 
 /* C function called for ::egg_tcl_tolower/toupper/totitle


### PR DESCRIPTION
Found by: michaelortmann (or Mystery-X if this fixes #1545, but unlikely, see https://github.com/eggheads/eggdrop/issues/1545#issuecomment-2041046997)
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix memleak in `egg_string_unicodesup_desurrogate()`

Additional description (if needed):
This bug affects only eggdrop 1.9.5 RC 1 (since #1402)

Test cases demonstrating functionality (if applicable):
