### PR TITLE
Update gseen.mod info

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1615,7 +1615,9 @@ set info-party 0
 # This module provides very basic seen commands via msg, on channel or via dcc.
 # This module works only for users in the bot's userlist. If you are looking for
 # a better and more advanced seen module, try the gseen module by G'Quann. You
-# can find it at http://www.kreativrauschen.com/gseen.mod/.
+# can find it at http://www.kreativrauschen.com/gseen.mod/. Meanwhile
+# development by G'Quann stopped and an updated version can be found at
+# https://github.com/michaelortmann/gseen.mod.
 #loadmodule seen
 
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Update gseen.mod info

Additional description (if needed):
We still want to worship / give credit to G'Quann by linking to his site,
but at the same time, we need to provide a link to an updated version that will work with newer / current eggdrop
We probably also need / want to change that info in doc/
 
Test cases demonstrating functionality (if applicable):
