### PR TITLE
Enhance ssl log

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -973,7 +973,12 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
       {
         if (slist[i].ssl) {
           x = SSL_read(slist[i].ssl, s, grab);
-          if (x < 0) {
+          if (!x && (SSL_get_shutdown(slist[i].ssl) == SSL_RECEIVED_SHUTDOWN)) {
+            *len = slist[i].sock;
+            slist[i].flags &= ~SOCK_CONNECT;
+            debug1("net: SSL_read(): received shutdown sock %i", slist[i].sock);
+            return -1;
+          } else if (x < 0) {
             int err = SSL_get_error(slist[i].ssl, x);
             if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE)
               errno = EAGAIN;

--- a/src/tls.c
+++ b/src/tls.c
@@ -799,7 +799,7 @@ static void ssl_info(const SSL *ssl, int where, int ret)
              SSL_alert_desc_string_long(ret));
     } else {
       /* Ignore close notify warnings */
-      debug1("TLS: Received close notify warning during %s",
+      debug1("TLS: Received close notify during %s",
              (where & SSL_CB_READ) ? "read" : "write");
     }
   } else if (where & SSL_CB_EXIT) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -531,6 +531,12 @@ static char *ssl_printname(X509_NAME *name)
 
   /* X509_NAME_oneline() is easier and shorter, but is deprecated and
      the manual discourages it's usage, so let's not be lazy ;) */
+  if (!bio) {
+    debug0("TLS: ssl_printname(): BIO_new(): error");
+    buf = nmalloc(1);
+    *buf = 0;
+    return buf;
+  }
   if (X509_NAME_print_ex(bio, name, 0, XN_FLAG_ONELINE & ~XN_FLAG_SPC_EQ)) {
     len = BIO_get_mem_data(bio, &data);
     if (len > 0) {
@@ -712,7 +718,7 @@ int ssl_verify(int ok, X509_STORE_CTX *ctx)
           !(data->verify & TLS_VERIFYFROM)) ||
           ((err == X509_V_ERR_CERT_HAS_EXPIRED) &&
           !(data->verify & TLS_VERIFYTO))) {
-        debug1("TLS: peer certificate warning: %s",
+        putlog(data->loglevel, "*", "TLS: peer certificate warning: %s",
                X509_verify_cert_error_string(err));
         ok = 1;
       }

--- a/src/tls.c
+++ b/src/tls.c
@@ -603,6 +603,12 @@ static char *ssl_printnum(ASN1_INTEGER *i)
   char *data, *buf;
   BIO *bio = BIO_new(BIO_s_mem());
 
+  if (!bio) {
+    debug0("TLS: ssl_printnum(): BIO_new(): error");
+    buf = nmalloc(1);
+    *buf = 0;
+    return buf;
+  }
   i2a_ASN1_INTEGER(bio, i);
   len = BIO_get_mem_data(bio, &data);
   if (len > 0) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -926,9 +926,9 @@ int ssl_handshake(int sock, int flags, int verify, int loglevel, char *host,
   SSL_set_mode(td->socklist[i].ssl, SSL_MODE_ENABLE_PARTIAL_WRITE |
                SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
   if (data->flags & TLS_CONNECT) {
-    struct timespec req = { 0, 1000000L };
     SSL_set_verify(td->socklist[i].ssl, SSL_VERIFY_PEER, ssl_verify);
     /* Introduce 1ms lag so an unpatched hub has time to setup the ssl handshake */
+    const struct timespec req = { 0, 1000000L };
     nanosleep(&req, NULL);
 #ifdef SSL_set_tlsext_host_name
     if (*data->host)

--- a/src/tls.c
+++ b/src/tls.c
@@ -570,6 +570,12 @@ static char *ssl_printtime(ASN1_UTCTIME *t)
   char *data, *buf;
   BIO *bio = BIO_new(BIO_s_mem());
 
+  if (!bio) {
+    debug0("TLS: ssl_printtime(): BIO_new(): error");
+    buf = nmalloc(1);
+    *buf = 0;
+    return buf;
+  }
   ASN1_UTCTIME_print(bio, t);
   len = BIO_get_mem_data(bio, &data);
   if (len > 0) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -799,7 +799,7 @@ static void ssl_info(const SSL *ssl, int where, int ret)
              SSL_alert_desc_string_long(ret));
     } else {
       /* Ignore close notify warnings */
-      debug1("Received close notify warning during %s",
+      debug1("TLS: Received close notify warning during %s",
              (where & SSL_CB_READ) ? "read" : "write");
     }
   } else if (where & SSL_CB_EXIT) {
@@ -819,10 +819,16 @@ static void ssl_info(const SSL *ssl, int where, int ret)
                SSL_state_string_long(ssl));
       }
     }
-  } else {
-    /* Display the state of the engine for debugging purposes */
-    debug1("TLS: state change: %s", SSL_state_string_long(ssl));
   }
+  /* Display the state of the engine for debugging purposes */
+  else if (where == SSL_CB_HANDSHAKE_START)
+    debug1("TLS: handshake start: %s", SSL_state_string_long(ssl));
+  else if (where == SSL_CB_CONNECT_LOOP)
+    debug1("TLS: connect loop: %s", SSL_state_string_long(ssl));
+  else if (where == SSL_CB_ACCEPT_LOOP)
+    debug1("TLS: accept loop: %s", SSL_state_string_long(ssl));
+  else
+    debug1("TLS: state change: %s", SSL_state_string_long(ssl));
 }
 
 /* Switch a socket to SSL communication


### PR DESCRIPTION
Found by: Robby-
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance ssl log

Additional description (if needed):
Fixes part of #86
Also add more error handling (`BIO_new()`)

Test cases demonstrating functionality (if applicable):
Test with linking share bot BotB to BotA

Esp. notice the changed log lines below:
```
[11:25:56] TLS: Received close notify during read
[11:25:56] net: SSL_read(): received shutdown sock 9
```
instead of
```
[11:24:36] Received close notify warning during read
[11:24:36] net: eof!(read) socket 9
```

And on BotA:
 `[11:25:56] TLS: accept loop: [...]`
is logged while on BotB:
`[11:25:56] TLS: connect loop: [...]`
Before:
```
.link BotA
[11:24:34] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[11:24:34] #-HQ# link BotA
[11:24:34] Linking to BotA at 127.0.0.1:3343 ...
[11:24:34] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[11:24:35] TLS: attempting SSL negotiation...
[11:24:35] TLS: setting the server name indication (SNI) to 127.0.0.1 successful
[11:24:35] TLS: state change: before SSL initialization
[11:24:35] TLS: state change: before SSL initialization
[11:24:35] TLS: state change: SSLv3/TLS write client hello
[11:24:35] TLS: awaiting more reads
[11:24:35] TLS: handshake in progress
[11:24:35] TLS: state change: SSLv3/TLS write client hello
[11:24:35] TLS: state change: SSLv3/TLS read server hello
[11:24:35] TLS: state change: TLSv1.3 read encrypted extensions
[11:24:35] TLS: state change: SSLv3/TLS read server certificate request
[11:24:35] TLS: peer certificate warning: self-signed certificate
[11:24:35] TLS: peer certificate warning: certificate has expired
[11:24:35] TLS: peer certificate warning: certificate has expired
[11:24:35] TLS: state change: SSLv3/TLS read server certificate
[11:24:35] TLS: state change: TLSv1.3 read server certificate verify
[11:24:35] TLS: state change: SSLv3/TLS read finished
[11:24:35] TLS: state change: SSLv3/TLS write change cipher spec
[11:24:35] TLS: state change: SSLv3/TLS write client certificate
[11:24:35] TLS: state change: SSLv3/TLS write certificate verify
[11:24:35] TLS: state change: SSLv3/TLS write finished
[11:24:35] TLS: handshake successful. Secure connection established.
[11:24:35] TLS: certificate subject: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:24:35] TLS: certificate issuer: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:24:35] TLS: certificate SHA1 Fingerprint: 1F:5B:6F:78:03:9A:07:2A:82:1C:B4:FE:B9:04:81:DB:41:BB:9E:4F
[11:24:35] TLS: certificate SHA-256 Fingerprint: F7:94:50:38:33:81:E9:B0:62:A2:CC:E5:D8:24:23:87:12:50:B4:59:D0:88:6B:EB:6F:30:A1:E0:73:DC:C0:DD
[11:24:35] TLS: certificate valid from Nov  3 09:43:58 2020 GMT to Dec  3 09:43:58 2020 GMT
[11:24:35] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[11:24:35] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[11:24:35] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[11:24:35] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:24:35] TLS: state change: SSL negotiation finished successfully
[11:24:35] TLS: state change: SSL negotiation finished successfully
[11:24:35] TLS: state change: SSLv3/TLS read server session ticket
[11:24:35] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:24:35] TLS: state change: SSL negotiation finished successfully
[11:24:35] TLS: state change: SSL negotiation finished successfully
[11:24:35] TLS: state change: SSLv3/TLS read server session ticket
[11:24:35] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:24:35] Received challenge from BotA... sending response ...
[11:24:35] Linked to BotA.
[11:24:35] Downloading user file from BotA
[11:24:36] TLS: attempting SSL negotiation...
[11:24:36] TLS: not setting the server name indication (SNI) because host is an empty string
[11:24:36] TLS: state change: before SSL initialization
[11:24:36] TLS: state change: before SSL initialization
[11:24:36] TLS: state change: SSLv3/TLS write client hello
[11:24:36] TLS: awaiting more reads
[11:24:36] TLS: handshake in progress
[11:24:36] TLS: state change: SSLv3/TLS write client hello
[11:24:36] TLS: state change: SSLv3/TLS read server hello
[11:24:36] TLS: state change: TLSv1.3 read encrypted extensions
[11:24:36] TLS: state change: SSLv3/TLS read server certificate request
[11:24:36] TLS: peer certificate warning: self-signed certificate
[11:24:36] TLS: peer certificate warning: certificate has expired
[11:24:36] TLS: peer certificate warning: certificate has expired
[11:24:36] TLS: state change: SSLv3/TLS read server certificate
[11:24:36] TLS: state change: TLSv1.3 read server certificate verify
[11:24:36] TLS: state change: SSLv3/TLS read finished
[11:24:36] TLS: state change: SSLv3/TLS write change cipher spec
[11:24:36] TLS: state change: SSLv3/TLS write client certificate
[11:24:36] TLS: state change: SSLv3/TLS write certificate verify
[11:24:36] TLS: state change: SSLv3/TLS write finished
[11:24:36] TLS: handshake successful. Secure connection established.
[11:24:36] TLS: certificate subject: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:24:36] TLS: certificate issuer: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:24:36] TLS: certificate SHA1 Fingerprint: 1F:5B:6F:78:03:9A:07:2A:82:1C:B4:FE:B9:04:81:DB:41:BB:9E:4F
[11:24:36] TLS: certificate SHA-256 Fingerprint: F7:94:50:38:33:81:E9:B0:62:A2:CC:E5:D8:24:23:87:12:50:B4:59:D0:88:6B:EB:6F:30:A1:E0:73:DC:C0:DD
[11:24:36] TLS: certificate valid from Nov  3 09:43:58 2020 GMT to Dec  3 09:43:58 2020 GMT
[11:24:36] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[11:24:36] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[11:24:36] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[11:24:36] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[11:24:36] net: connect! sock 9
[11:24:36] TLS: state change: SSL negotiation finished successfully
[11:24:36] TLS: state change: SSL negotiation finished successfully
[11:24:36] TLS: state change: SSLv3/TLS read server session ticket
[11:24:36] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[11:24:36] TLS: state change: SSL negotiation finished successfully
[11:24:36] TLS: state change: SSL negotiation finished successfully
[11:24:36] TLS: state change: SSLv3/TLS read server session ticket
[11:24:36] Received close notify warning during read
[11:24:36] net: eof!(read) socket 9
[11:24:36] Userfile loaded, unpacking...
[11:24:36] Userlist transfer complete; switched over.
[11:24:36] Received close notify warning during write
```
After:
```
.link BotA
[11:25:54] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[11:25:54] #-HQ# link BotA
[11:25:54] Linking to BotA at 127.0.0.1:3343 ...
[11:25:54] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[11:25:55] TLS: attempting SSL negotiation...
[11:25:55] TLS: setting the server name indication (SNI) to 127.0.0.1 successful
[11:25:55] TLS: handshake start: before SSL initialization
[11:25:55] TLS: connect loop: before SSL initialization
[11:25:55] TLS: connect loop: SSLv3/TLS write client hello
[11:25:55] TLS: awaiting more reads
[11:25:55] TLS: handshake in progress
[11:25:55] TLS: connect loop: SSLv3/TLS write client hello
[11:25:55] TLS: connect loop: SSLv3/TLS read server hello
[11:25:55] TLS: connect loop: TLSv1.3 read encrypted extensions
[11:25:55] TLS: connect loop: SSLv3/TLS read server certificate request
[11:25:55] TLS: peer certificate warning: self-signed certificate
[11:25:55] TLS: peer certificate warning: certificate has expired
[11:25:55] TLS: peer certificate warning: certificate has expired
[11:25:55] TLS: connect loop: SSLv3/TLS read server certificate
[11:25:55] TLS: connect loop: TLSv1.3 read server certificate verify
[11:25:55] TLS: connect loop: SSLv3/TLS read finished
[11:25:55] TLS: connect loop: SSLv3/TLS write change cipher spec
[11:25:55] TLS: connect loop: SSLv3/TLS write client certificate
[11:25:55] TLS: connect loop: SSLv3/TLS write certificate verify
[11:25:55] TLS: connect loop: SSLv3/TLS write finished
[11:25:55] TLS: handshake successful. Secure connection established.
[11:25:55] TLS: certificate subject: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:25:55] TLS: certificate issuer: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:25:55] TLS: certificate SHA1 Fingerprint: 1F:5B:6F:78:03:9A:07:2A:82:1C:B4:FE:B9:04:81:DB:41:BB:9E:4F
[11:25:55] TLS: certificate SHA-256 Fingerprint: F7:94:50:38:33:81:E9:B0:62:A2:CC:E5:D8:24:23:87:12:50:B4:59:D0:88:6B:EB:6F:30:A1:E0:73:DC:C0:DD
[11:25:55] TLS: certificate valid from Nov  3 09:43:58 2020 GMT to Dec  3 09:43:58 2020 GMT
[11:25:55] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[11:25:55] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[11:25:55] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[11:25:55] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:25:55] TLS: connect loop: SSL negotiation finished successfully
[11:25:55] TLS: connect loop: SSL negotiation finished successfully
[11:25:55] TLS: connect loop: SSLv3/TLS read server session ticket
[11:25:55] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:25:55] TLS: connect loop: SSL negotiation finished successfully
[11:25:55] TLS: connect loop: SSL negotiation finished successfully
[11:25:55] TLS: connect loop: SSLv3/TLS read server session ticket
[11:25:55] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[11:25:55] Received challenge from BotA... sending response ...
[11:25:55] Linked to BotA.
[11:25:55] Downloading user file from BotA
[11:25:56] TLS: attempting SSL negotiation...
[11:25:56] TLS: not setting the server name indication (SNI) because host is an empty string
[11:25:56] TLS: handshake start: before SSL initialization
[11:25:56] TLS: connect loop: before SSL initialization
[11:25:56] TLS: connect loop: SSLv3/TLS write client hello
[11:25:56] TLS: awaiting more reads
[11:25:56] TLS: handshake in progress
[11:25:56] TLS: connect loop: SSLv3/TLS write client hello
[11:25:56] TLS: connect loop: SSLv3/TLS read server hello
[11:25:56] TLS: connect loop: TLSv1.3 read encrypted extensions
[11:25:56] TLS: connect loop: SSLv3/TLS read server certificate request
[11:25:56] TLS: peer certificate warning: self-signed certificate
[11:25:56] TLS: peer certificate warning: certificate has expired
[11:25:56] TLS: peer certificate warning: certificate has expired
[11:25:56] TLS: connect loop: SSLv3/TLS read server certificate
[11:25:56] TLS: connect loop: TLSv1.3 read server certificate verify
[11:25:56] TLS: connect loop: SSLv3/TLS read finished
[11:25:56] TLS: connect loop: SSLv3/TLS write change cipher spec
[11:25:56] TLS: connect loop: SSLv3/TLS write client certificate
[11:25:56] TLS: connect loop: SSLv3/TLS write certificate verify
[11:25:56] TLS: connect loop: SSLv3/TLS write finished
[11:25:56] TLS: handshake successful. Secure connection established.
[11:25:56] TLS: certificate subject: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:25:56] TLS: certificate issuer: C=EU, O=Eggheads, OU=Botnet, CN=localhost
[11:25:56] TLS: certificate SHA1 Fingerprint: 1F:5B:6F:78:03:9A:07:2A:82:1C:B4:FE:B9:04:81:DB:41:BB:9E:4F
[11:25:56] TLS: certificate SHA-256 Fingerprint: F7:94:50:38:33:81:E9:B0:62:A2:CC:E5:D8:24:23:87:12:50:B4:59:D0:88:6B:EB:6F:30:A1:E0:73:DC:C0:DD
[11:25:56] TLS: certificate valid from Nov  3 09:43:58 2020 GMT to Dec  3 09:43:58 2020 GMT
[11:25:56] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[11:25:56] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[11:25:56] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[11:25:56] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[11:25:56] net: connect! sock 9
[11:25:56] TLS: connect loop: SSL negotiation finished successfully
[11:25:56] TLS: connect loop: SSL negotiation finished successfully
[11:25:56] TLS: connect loop: SSLv3/TLS read server session ticket
[11:25:56] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[11:25:56] TLS: connect loop: SSL negotiation finished successfully
[11:25:56] TLS: connect loop: SSL negotiation finished successfully
[11:25:56] TLS: connect loop: SSLv3/TLS read server session ticket
[11:25:56] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[11:25:56] TLS: Received close notify during read
[11:25:56] net: SSL_read(): received shutdown sock 9
[11:25:56] Userfile loaded, unpacking...
[11:25:56] Userlist transfer complete; switched over.
[11:25:56] TLS: Received close notify warning during write
```
