### PR TITLE
Add TCL_UTF_MAX log to status report

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -289,6 +289,7 @@ void tell_verbose_status(int idx)
 
   if (tcl_threaded())
     dprintf(idx, "Tcl is threaded.\n");
+  dprintf(idx, "Tcl TCL_UTF_MAX: %i\n", TCL_UTF_MAX);
 #ifdef TLS
   dprintf(idx, "TLS support is enabled.\n"
   #if defined HAVE_EVP_PKEY_GET1_EC_KEY && defined HAVE_OPENSSL_MD5


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add TCL_UTF_MAX log to status report

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.status
[...]
Tcl library: /usr/lib/tcl8.6
Tcl version: 8.6.14 (header version 8.6.14)
Tcl is threaded.
Tcl TCL_UTF_MAX: 3
[...]
```