### PR TITLE
Add server version log to status report

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -95,6 +95,7 @@ static int kick_method;
 static int optimize_kicks;
 static int msgrate;             /* Number of seconds between sending
                                  * queued lines to server. */
+static char server_version[SERVER_VERSION_MAX];
 #ifdef TLS
 static int use_ssl;             /* Use SSL for the next server connection? */
 static int tls_vfyserver;       /* Certificate validation mode for servers */
@@ -2165,7 +2166,7 @@ static void server_report(int idx, int details)
 
   if (server_online) {
     dprintf(idx, "    Online as: %s%s%s (%s)\n", botname, botuserhost[0] ?
-            "!" : "", botuserhost[0] ? botuserhost : "", botrealname);
+            "!" : "", botuserhost, botrealname);
     if (nick_juped)
       dprintf(idx, "    NICK IS JUPED: %s%s\n", origbotname,
               keepnick ? " (trying)" : "");
@@ -2184,12 +2185,12 @@ static void server_report(int idx, int details)
       ((servidx = findanyidx(serv)) != -1)) {
     const char *networkname = server_online ? isupport_get("NETWORK", strlen("NETWORK")) : "unknown network";
 #ifdef TLS
-    dprintf(idx, "    Connected to %s [%s]:%s%d %s\n", networkname, dcc[servidx].host,
-            dcc[servidx].ssl ? "+" : "", dcc[servidx].port, trying_server ?
+    dprintf(idx, "    Connected to %s [%s]:%s%d%s%s %s\n", networkname, dcc[servidx].host,
+            dcc[servidx].ssl ? "+" : "", dcc[servidx].port, server_version[0] ? " " : "", server_version ,trying_server ?
             "(trying)" : s);
 #else
-    dprintf(idx, "    Connected to %s [%s]:%d %s\n", networkname, dcc[servidx].host,
-            dcc[servidx].port, trying_server ? "(trying)" : s);
+    dprintf(idx, "    Connected to %s [%s]:%d%s%s %s\n", networkname, dcc[servidx].host,
+            dcc[servidx].port, server_version[0] ? " " : "", server_version, trying_server ? "(trying)" : s);
 #endif
   } else
     dprintf(idx, "    %s\n", IRC_NOSERVER);
@@ -2419,6 +2420,7 @@ char *server_start(Function *global_funcs)
   serverror_quit = 1;
   lastpingcheck = 0;
   server_online = 0;
+  server_version[0] = 0;
   server_cycle_wait = 60;
   strcpy(botrealname, "A deranged product of evil coders");
   server_timeout = 60;

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -29,6 +29,7 @@
 #define MSGMAX       511    /* Max size of IRC message line    */
 #define SENDLINEMAX  CLITAGMAX + MSGMAX
 #define RECVLINEMAX  TOTALTAGMAX + MSGMAX
+#define SERVER_VERSION_MAX 64
 
 #define check_tcl_ctcp(a,b,c,d,e,f) check_tcl_ctcpr(a,b,c,d,e,f,H_ctcp)
 #define check_tcl_ctcr(a,b,c,d,e,f) check_tcl_ctcpr(a,b,c,d,e,f,H_ctcr)

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -410,6 +410,15 @@ static int got001(char *from, char *msg)
   return 0;
 }
 
+/* 002: welcome to IRC (use it to fix the server name) */
+static void got002(char *from, char *msg)
+{
+  int i;
+  for (i = strlen(msg) - 1; (msg[i] != ' ') && (i > 0); i--);
+  strlcpy(server_version, msg + i + 1, SERVER_VERSION_MAX);
+
+}
+
 /* Got 005: ISUPPORT network information
  */
 static int got005(char *from, char *msg)
@@ -1085,6 +1094,7 @@ static void disconnect_server(int idx)
     del_capability(cap->name);
   }
   server_online = 0;
+  server_version[0] = 0;
   if (realservername)
     nfree(realservername);
   realservername = 0;
@@ -2149,6 +2159,7 @@ static cmd_t my_raw_binds[] = {
   {"NOTE",         "",   (IntFunc) gotstdnote,      NULL},
   {"WARN",         "",   (IntFunc) gotstdwarn,      NULL},
   {"001",          "",   (IntFunc) got001,          NULL},
+  {"002",          "",   (IntFunc) got002,          NULL},
   {"005",          "",   (IntFunc) got005,          NULL},
   {"303",          "",   (IntFunc) got303,          NULL},
   {"311",          "",   (IntFunc) got311,          NULL},

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -414,7 +414,7 @@ static int got001(char *from, char *msg)
 static void got002(char *from, char *msg)
 {
   int i;
-  for (i = strlen(msg) - 1; (msg[i] != ' ') && (i > 0); i--);
+  for (i = strlen(msg) - 1; (i > 0) && (msg[i] != ' '); i--);
   strlcpy(server_version, msg + i + 1, SERVER_VERSION_MAX);
 
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add server version log to status report

Additional description (if needed):
Fetch server version from RPL_YOURHOST (002) Numeric

Test cases demonstrating functionality (if applicable):
```
.status server
[...]
    Connected to Libera.Chat [irc.libera.chat]:6667 solanum-1.0-dev (connected for 00:00)
```
In this example, **solanum-1.0-dev** is the new part