### PR TITLE
Fix include sys/resource.h

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -27,10 +27,7 @@
  */
 
 #include "main.h"
-
-#include <sys/resource.h>
 #include <sys/utsname.h>
-
 #include "modules.h"
 
 extern struct dcc_t *dcc;

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -22,7 +22,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <sys/resource.h>
 #include "main.h"
 #include "tandem.h"
 #include "modules.h"

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -185,6 +185,7 @@
 /* Almost every module needs some sort of time thingy, so... */
 #include <sys/time.h> /* gettimeofday() POSIX 2001 */
 #include <time.h> /* POSIX 2001 */
+#include <sys/resource.h> /* getrusage() setrlimit() after time.h because of BSD */
 
 /* Yikes...who would have thought finding a usable random() would be so much
  * trouble?

--- a/src/main.c
+++ b/src/main.c
@@ -63,10 +63,6 @@
 #include "modules.h"
 #include "bg.h"
 
-#ifdef DEBUG                            /* For debug compile */
-#  include <sys/resource.h>             /* setrlimit() */
-#endif
-
 #ifdef HAVE_GETRANDOM
 #  include <sys/random.h>
 #endif

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -13,7 +13,6 @@
 #define MODULE_NAME "encryption2"
 
 #include <resolv.h> /* base64 encode b64_ntop() and base64 decode b64_pton() */
-#include <sys/resource.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 

--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -26,7 +26,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <sys/resource.h>
 #include "main.h"
 
 extern Tcl_Interp *interp;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix include sys/resource.h

Additional description (if needed):
Followup PR to #719 and 1619

Test cases demonstrating functionality (if applicable):
Fixes the following bug:
```
$ uname -a
OpenBSD openbsd47.home.arpa 4.7 GENERIC#558 i386
$ make [...]
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/local/include/tcl8.5 -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -c cmds.c
In file included from cmds.c:25:
/usr/include/sys/resource.h:56: error: field `ru_utime' has incomplete type
/usr/include/sys/resource.h:57: error: field `ru_stime' has incomplete type
/usr/include/sys/resource.h:96: error: syntax error before "int32_t"
/usr/include/sys/resource.h:101: error: syntax error before "rlim_t"
/usr/include/sys/resource.h:107: error: syntax error before "fixpt_t"
In file included from cmds.c:25:
/usr/include/sys/resource.h:120: error: syntax error before "id_t"
/usr/include/sys/resource.h:123: error: syntax error before "id_t"
*** Error code 1
 
Stop in /home/michael/usr/src/eggdrop/src (line 92 of /usr/share/mk/sys.mk).
*** Error code 1
 
Stop in /home/michael/usr/src/eggdrop (line 256 of Makefile).
```