### PR TITLE
Enhance load module

### DIFF
--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -300,9 +300,8 @@ set ssl-capath "/etc/ssl/"
 ## Eggdrop, things change.
 
 ## This path specifies the path were Eggdrop should look for its modules.
-## If you run the bot from the compilation directory, you will want to set
-## this to "". If you use 'make install' (like all good kiddies do ;), this
-## is a fine default. Otherwise, use your head :)
+## If you use 'make install' (like all good kiddies do ;), this is a fine
+## default. Otherwise, use your head :)
 set mod-path "modules/"
 
 #### CHANNELS MODULE ####

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -605,9 +605,8 @@ die "Please make sure you edit your config file completely."
 # Eggdrop, things change.
 
 # This path specifies the path were Eggdrop should look for its modules.
-# If you run the bot from the compilation directory, you will want to set
-# this to "". If you use 'make install' (like all good kiddies do ;), this
-# is a fine default. Otherwise, use your head :)
+# If you use 'make install' (like all good kiddies do ;), this is a fine
+# default. Otherwise, use your head :)
 set mod-path "modules/"
 
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -739,7 +739,7 @@ const char *module_load(char *name)
       return MOD_BADCWD;
     }
     len = strlen(workbuf);
-    snprintf(workbuf + len, sizeof workbuf - len, "/%s%s." EGG_MOD_EXT, moddir, name);
+    snprintf(workbuf + len, (sizeof workbuf) - len, "/%s%s." EGG_MOD_EXT, moddir, name);
   } else {
     snprintf(workbuf, sizeof workbuf, "%s%s." EGG_MOD_EXT, moddir, name);
   }

--- a/src/modules.c
+++ b/src/modules.c
@@ -23,6 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <errno.h>
 #include <signal.h>
 #include "main.h"
 #include "modules.h"
@@ -698,6 +699,7 @@ int module_register(char *name, Function *funcs, int major, int minor)
 
 const char *module_load(char *name)
 {
+  size_t len;
   module_entry *p;
   char *e;
   Function f;
@@ -706,7 +708,7 @@ const char *module_load(char *name)
 #endif
 
 #ifndef STATIC
-  char workbuf[1024];
+  char workbuf[PATH_MAX];
 #  ifdef MOD_USE_SHL
   shl_t hand;
 #  endif
@@ -732,11 +734,14 @@ const char *module_load(char *name)
 
 #ifndef STATIC
   if (moddir[0] != '/') {
-    if (getcwd(workbuf, 1024) == NULL)
+    if (getcwd(workbuf, sizeof workbuf) == NULL) {
+      debug1("modules: getcwd(): %s\n", strerror(errno));
       return MOD_BADCWD;
-    sprintf(&(workbuf[strlen(workbuf)]), "/%s%s." EGG_MOD_EXT, moddir, name);
+    }
+    len = strlen(workbuf);
+    snprintf(workbuf + len, sizeof workbuf - len, "/%s%s." EGG_MOD_EXT, moddir, name);
   } else {
-    sprintf(workbuf, "%s%s." EGG_MOD_EXT, moddir, name);
+    snprintf(workbuf, sizeof workbuf, "%s%s." EGG_MOD_EXT, moddir, name);
   }
 
 #  ifdef MOD_USE_SHL


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance load module

Additional description (if needed):
1. `eggdrop.conf` doc was adapted to current behavior, where eggdrop cannot run from compilation / source dir anymore but would throw `* You are attempting to run Eggdrop from the source directory. Please finish installing Eggdrop by running "make install" and run it from the install location.`
2. Raise path for module loading to `PATH_MAX`. eggdrops `mod-path` setting is still limited to 120 chars, but path for module loading needs additional space for the current directory returned by `getcwd()`.
3. Enhance error reporting for `getcwd()`.

Test cases demonstrating functionality (if applicable):
