### PR TITLE
Fix tcl compress/uncompress error handling and doc

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -1940,7 +1940,7 @@ uncompressfile <src-file> [target-file]
 
   Description: compresses or un-compresses files. The level option specifies the compression mode to use when compressing. Available modes are from 0 (minimum CPU usage, minimum compression) all the way up to 9 (maximum CPU usage, maximum compression). If you don't specify the target-file, the src-file will be overwritten.
 
-  Returns: nothing
+  Returns: 1 if successful; 0 otherwise
 
   Module: compress
 

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -314,7 +314,7 @@ static int compress_file(char *filename, int mode_num)
    * if the compression routine succeeded.
    */
   if (ret == COMPF_SUCCESS)
-    movefile(temp_fn, filename);
+    ret = movefile(temp_fn, filename) ? COMPF_ERROR : COMPF_SUCCESS;
 
   nfree(temp_fn);
   return ret;
@@ -340,7 +340,7 @@ static int uncompress_file(char *filename)
    * if the uncompression routine succeeded.
    */
   if (ret == COMPF_SUCCESS)
-    movefile(temp_fn, filename);
+    ret = movefile(temp_fn, filename) ? COMPF_ERROR : COMPF_SUCCESS;
 
   nfree(temp_fn);
   return ret;

--- a/src/mod/compress.mod/tclcompress.c
+++ b/src/mod/compress.mod/tclcompress.c
@@ -67,7 +67,7 @@ static int tcl_compress_file STDVAR
   else
     result = compress_file(fn_src, mode_num);
 
-  if (result)
+  if (result == COMPF_SUCCESS)
     Tcl_AppendResult(irp, "1", NULL);
   else
     Tcl_AppendResult(irp, "0", NULL);
@@ -85,7 +85,7 @@ static int tcl_uncompress_file STDVAR
   else
     result = uncompress_to_file(argv[1], argv[2]);
 
-  if (result)
+  if (result == COMPF_SUCCESS)
     Tcl_AppendResult(irp, "1", NULL);
   else
     Tcl_AppendResult(irp, "0", NULL);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix tcl compress/uncompress error handling and doc

Additional description (if needed):
compression functions were already returning different return values
but for case movefile() fails COMPF_SUCCESS was returned
This PR fixes that and and the doc that belongs to it

Test cases demonstrating functionality (if applicable):
