### PR TITLE
Fix check for pre-existing eggdrop via pid file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1090,18 +1090,20 @@ int main(int arg_c, char **arg_v)
   if (!pid_file[0])
     egg_snprintf(pid_file, sizeof pid_file, "pid.%s", botnetnick);
 
-  /* Check for pre-existing eggdrop! */
+  /* Check for pre-existing eggdrop */
   f = fopen(pid_file, "r");
   if (f != NULL) {
     if (fgets(s, 10, f) != NULL) {
-      xx = atoi(s);
-      i = kill(xx, SIGCHLD);      /* Meaningless kill to determine if pid
-                                   * is used */
-      if (i == 0 || errno != ESRCH) {
-        printf(EGG_RUNNING1, botnetnick);
-        printf(EGG_RUNNING2, pid_file);
-        bg_send_quit(BG_ABORT);
-        exit(1);
+      xx = (int) strtol(s, NULL, 10);
+      if (xx != getpid()) {    /* New eggdrop got same PID as old one */
+        i = kill(xx, SIGCHLD); /* Meaningless kill to determine if pid is
+                                * used */
+        if (i == 0 || errno != ESRCH) {
+          printf(EGG_RUNNING1, botnetnick);
+          printf(EGG_RUNNING2, pid_file);
+          bg_send_quit(BG_ABORT);
+          exit(1);
+        }
       }
     } else {
       printf("Error checking for existing Eggdrop process.\n");


### PR DESCRIPTION
Found by: theZoMBiE
Patch by: michaelortmann
Fixes: 

One-line summary:
Problem was reported as: eggdrop in a docker. sometimes server does not shutdown properly. when containers start back up, eggdrop keeps telling to delete the bot.pid file.

Additional description (if needed):
In general, with or without random PIDs, it could happen, a new eggdrop could end up with the same PID as the old one stored in the pid file. There cannot be 2 processed with the same PID, so if the new eggdrop has the same PID as the one in the pid file, that new eggdrop can conclude it just got the same PID and can go on starting up.

Test cases demonstrating functionality (if applicable):
