### PR TITLE
Fix module export for get_user_from_member

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -527,6 +527,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define lookup_user_record ((struct userrec * (*)(memberlist *, char *, char *))global[323])
 /* 324 - 327 */
 #define find_member_from_nick ((memberlist * (*) (char *))global[324])
+#define get_user_from_member ((struct userrec * (*) (memberlist *))global[325])
 
 
 /* hostmasking */

--- a/src/modules.c
+++ b/src/modules.c
@@ -629,7 +629,8 @@ Function global_table[] = {
   (Function) & argv0,
   (Function) lookup_user_record,
 /* 324 - 327 */
-  (Function) find_member_from_nick
+  (Function) find_member_from_nick,
+  (Function) get_user_from_member,
 };
 
 void init_modules(void)

--- a/src/modules.c
+++ b/src/modules.c
@@ -60,11 +60,7 @@
 #    ifndef RTLD_NOW
 #      define RTLD_NOW 1
 #    endif
-#    ifdef RTLD_LAZY
-#      define DLFLAGS RTLD_LAZY|RTLD_GLOBAL
-#    else
-#      define DLFLAGS RTLD_NOW|RTLD_GLOBAL
-#    endif
+#    define DLFLAGS RTLD_NOW|RTLD_GLOBAL
 #  endif /* MOD_USE_DL */
 #endif /* !STATIC */
 


### PR DESCRIPTION
Found by: Mystery-X
Patch by: thommey

Also enable RTLD_NOW linking so module loading fails as early as possible.