### PR TITLE
(WIP) Fix and enhance logging for port already bound

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1108,8 +1108,10 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       if (ipv4) {
         if ((ipaddr4.s_addr != 0) && (dcc[idx].sockname.addr.s4.sin_addr.s_addr == 0)) {
           Tcl_AppendResult(irp, "This port is already bound to 0.0.0.0 on this "
-                "machine, remove it (using listen [ip] <port> off) before "
-                "trying to bind to this IP.", NULL);
+            "machine, remove it (using listen [ip] <port> off) before "
+            "trying to bind to this IP.", NULL);
+          if (do_restart == -2) /* do not exit eggdrop when rehashing */
+            return TCL_OK;
           return TCL_ERROR;
         }
       }
@@ -1119,6 +1121,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
           Tcl_AppendResult(irp, "This port is already bound to :: on this "
             "machine, remove it (using listen [ip] <port> off) before "
             "trying to bind to this IP.", NULL);
+          if (do_restart == -2) /* do not exit eggdrop when rehashing */
+            return TCL_OK;
           return TCL_ERROR;
       }
 #endif
@@ -1130,6 +1134,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
             inet_ntop(AF_INET, &dcc[idx].sockname.addr.s4.sin_addr, newip, sizeof newip),
             " on this machine, remove it (using listen [ip] <port> off) "
             "before trying to bind to all interfaces.", NULL);
+          if (do_restart == -2) /* do not exit eggdrop when rehashing */
+            return TCL_OK;
           return TCL_ERROR;
         }
       }
@@ -1140,6 +1146,8 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
           inet_ntop(AF_INET6, &dcc[idx].sockname.addr.s6.sin6_addr, newip, sizeof newip),
           " on this machine, remove it (using listen [ip] <port> off) "
           "before trying to bind to all interfaces", NULL);
+        if (do_restart == -2) /* do not exit eggdrop when rehashing */
+          return TCL_OK;
         return TCL_ERROR;
       }
 #endif

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1124,19 +1124,21 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       /* Check if IP is all-interfaces, but the already-bound IP is specific */
       if (ipv4) {
         if ((ipaddr4.s_addr == 0) && (dcc[idx].sockname.addr.s4.sin_addr.s_addr != 0)) {
-          Tcl_AppendResult(irp, "this port is already bound to a specific IP "
-                "on this machine, remove it before trying to bind to all "
-                "interfaces", NULL);
+          Tcl_AppendResult(irp, "this port is already bound to specific IP ",
+            inet_ntop(AF_INET, &dcc[idx].sockname.addr.s4.sin_addr, newip, sizeof newip),
+            " on this machine, remove it before trying to bind to all "
+            "interfaces", NULL);
           return TCL_ERROR;
         }
       }
 #ifdef IPV6
       else if (IN6_IS_ADDR_UNSPECIFIED(&ipaddr6) &&
                 (!IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))) {
-          Tcl_AppendResult(irp, "this port is already bound to a specific IP "
-                "on this machine, remove it before trying to bind to all "
-                "interfaces", NULL);
-          return TCL_ERROR;
+        Tcl_AppendResult(irp, "this port is already bound to specific IP ",
+          inet_ntop(AF_INET6, &dcc[idx].sockname.addr.s6.sin6_addr, newip, sizeof newip),
+          " on this machine, remove it before trying to bind to all "
+          "interfaces", NULL);
+        return TCL_ERROR;
       }
 #endif
     }

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1134,7 +1134,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       else if (IN6_IS_ADDR_UNSPECIFIED(&ipaddr6) &&
                 (!IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))) {
           Tcl_AppendResult(irp, "this port is already bound to a specific IP "
-                "on this machine, remove it before trying to bind to this all "
+                "on this machine, remove it before trying to bind to all "
                 "interfaces", NULL);
           return TCL_ERROR;
       }

--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1107,16 +1107,18 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       /* Check if IP is specific, but the already-bound IP is all-interfaces */
       if (ipv4) {
         if ((ipaddr4.s_addr != 0) && (dcc[idx].sockname.addr.s4.sin_addr.s_addr == 0)) {
-          Tcl_AppendResult(irp, "this port is already bound to 0.0.0.0 on this "
-                "machine, remove it before trying to bind to this IP", NULL);
+          Tcl_AppendResult(irp, "This port is already bound to 0.0.0.0 on this "
+                "machine, remove it (using listen [ip] <port> off) before "
+                "trying to bind to this IP.", NULL);
           return TCL_ERROR;
         }
       }
 #ifdef IPV6
       else if ((!IN6_IS_ADDR_UNSPECIFIED(&ipaddr6)) &&
                 (IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))) {
-          Tcl_AppendResult(irp, "this port is already bound to :: on this "
-                "machine, remove it before trying to bind to this IP", NULL);
+          Tcl_AppendResult(irp, "This port is already bound to :: on this "
+            "machine, remove it (using listen [ip] <port> off) before "
+            "trying to bind to this IP.", NULL);
           return TCL_ERROR;
       }
 #endif
@@ -1124,20 +1126,20 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       /* Check if IP is all-interfaces, but the already-bound IP is specific */
       if (ipv4) {
         if ((ipaddr4.s_addr == 0) && (dcc[idx].sockname.addr.s4.sin_addr.s_addr != 0)) {
-          Tcl_AppendResult(irp, "this port is already bound to specific IP ",
+          Tcl_AppendResult(irp, "This port is already bound to specific IP ",
             inet_ntop(AF_INET, &dcc[idx].sockname.addr.s4.sin_addr, newip, sizeof newip),
-            " on this machine, remove it before trying to bind to all "
-            "interfaces", NULL);
+            " on this machine, remove it (using listen [ip] <port> off) "
+            "before trying to bind to all interfaces.", NULL);
           return TCL_ERROR;
         }
       }
 #ifdef IPV6
       else if (IN6_IS_ADDR_UNSPECIFIED(&ipaddr6) &&
                 (!IN6_IS_ADDR_UNSPECIFIED(&dcc[idx].sockname.addr.s6.sin6_addr))) {
-        Tcl_AppendResult(irp, "this port is already bound to specific IP ",
+        Tcl_AppendResult(irp, "This port is already bound to specific IP ",
           inet_ntop(AF_INET6, &dcc[idx].sockname.addr.s6.sin6_addr, newip, sizeof newip),
-          " on this machine, remove it before trying to bind to all "
-          "interfaces", NULL);
+          " on this machine, remove it (using listen [ip] <port> off) "
+          "before trying to bind to all interfaces", NULL);
         return TCL_ERROR;
       }
 #endif
@@ -1153,7 +1155,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
     }
     /* Remove */
     if (idx < 0) {
-      Tcl_AppendResult(irp, "no such listen port is open", NULL);
+      Tcl_AppendResult(irp, "no such listen ip/port is open", NULL);
       return TCL_ERROR;
     }
     killsock(dcc[idx].sock);


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: #1479

One-line summary:
Fix #1479 by not letting the bot die on `.rehash` over a changed listen port and enhancing error logging, give the user hints, how to fix it.


Additional description (if needed):

Test cases demonstrating functionality (if applicable):
In `eggdrop.conf`:
`listen 4040 all`

```
.tcl listen 127.0.0.1 4040 all 
[23:21:10] tcl: builtin dcc call: *dcc:tcl -HQ 1 listen 127.0.0.1 4040 all
[23:21:10] tcl: evaluating .tcl listen 127.0.0.1 4040 all
[23:21:10] Listening for telnet connections on 127.0.0.1 port 4040 (all).
[23:21:10] tcl: evaluated .tcl listen 127.0.0.1 4040 all, user 0.031ms sys 0.031ms
Tcl: 4040
.rehash
[23:21:16] tcl: builtin dcc call: *dcc:rehash -HQ 1 
[23:21:16] #-HQ# rehash
Rehashing.
[23:21:16] Writing user file...
[23:21:15] Writing channel file...
[23:21:15] Rehashing ...
[23:21:15] Writing channel file...
[23:21:15] Loading dccwhois.tcl...
[23:21:15] Loaded dccwhois.tcl
[23:21:15] Userinfo TCL v1.08 loaded (URL BF GF IRL EMAIL DOB PHONE ICQ YOUTUBE TWITCH).
[23:21:15] use '.help userinfo' for commands.
[23:21:15] Loaded quotepong.tcl
[23:21:15] Listening for telnet connections on 0.0.0.0 port 3333 (all).
[23:21:15] Listening for telnet connections on 0.0.0.0 port +3343 (all).
[23:21:15] WARNING: Port 4040 is already bound to specific IP 127.0.0.1 on this machine, remove it (using listen [ip] <port> off) before trying to bind to IP 0.0.0.0, check listen settings in config file or restart instead of rehash.
[23:21:15] Writing channel file...
[23:21:15] Userfile loaded, unpacking...
```