### PR TITLE
Fix --disable-tls

### DIFF
--- a/src/mod/pbkdf2.mod/Makefile
+++ b/src/mod/pbkdf2.mod/Makefile
@@ -36,4 +36,5 @@ distclean: clean
  ../../../src/compat/compat.h ../../../src/compat/base64.h \
  ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
  ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
- ../../../src/mod/modvals.h ../../../src/tandem.h
+ ../../../src/mod/modvals.h ../../../src/tandem.h \
+ .././pbkdf2.mod/tclpbkdf2.c

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -10,7 +10,7 @@
 #include "src/mod/module.h"
 
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL /* 1.0.0 */
-#include "src/mod/pbkdf2.mod/tclpbkdf2.c"
+#include "tclpbkdf2.c"
 
 #define MODULE_NAME "encryption2"
 

--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -8,9 +8,10 @@
  */
 
 #include "src/mod/module.h"
-#include "src/mod/pbkdf2.mod/tclpbkdf2.c"
 
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL /* 1.0.0 */
+#include "src/mod/pbkdf2.mod/tclpbkdf2.c"
+
 #define MODULE_NAME "encryption2"
 
 #include <resolv.h> /* base64 encode b64_ntop() and base64 decode b64_pton() */


### PR DESCRIPTION
Found by: Geo
Patch by: michaelortmann
Fixes: 

One-line summary:
Yet another hotfix

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`./configure --disable-tls`
**Before:**
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././pbkdf2.mod/pbkdf2.c && mv -f pbkdf2.o ../
In file included from .././pbkdf2.mod/pbkdf2.c:11:
../../../src/mod/pbkdf2.mod/tclpbkdf2.c: In function ‘tcl_pbkdf2’:
../../../src/mod/pbkdf2.mod/tclpbkdf2.c:43:12: error: implicit declaration of function ‘EVP_get_digestbyname’ [-Wimplicit-function-declaration]
   43 |   digest = EVP_get_digestbyname(argv[4 + !hex]);
      |            ^~~~~~~~~~~~~~~~~~~~
../../../src/mod/pbkdf2.mod/tclpbkdf2.c:43:10: error: assignment to ‘const EVP_MD *’ {aka ‘const struct evp_md_st *’} from ‘in’ makes pointer from integer without a cast [-Wint-conversion]
   43 |   digest = EVP_get_digestbyname(argv[4 + !hex]);
      |          ^
../../../src/mod/pbkdf2.mod/tclpbkdf2.c:48:15: error: implicit declaration of function ‘EVP_MD_size’ [-Wimplicit-function-declaration]
   48 |   digestlen = EVP_MD_size(digest);
      |               ^~~~~~~~~~~
../../../src/mod/pbkdf2.mod/tclpbkdf2.c:49:8: error: implicit declaration of function ‘PKCS5_PBKDF2_HMAC’ [-Wimplicit-function-declaration]
   49 |   if (!PKCS5_PBKDF2_HMAC(argv[1 + !hex], strlen(argv[1 + !hex]), (const unsigned char *) argv[2+ !hex], strlen(argv[2 + !hex]), rounds, digest, digestlen, buf)) {
      |        ^~~~~~~~~~~~~~~~~
In file included from /usr/include/openssl/rand.h:23,
                 from .././pbkdf2.mod/pbkdf2.c:19:
/usr/include/openssl/evp.h: At top level:
/usr/include/openssl/evp.h:1181:15: error: conflicting types for ‘EVP_get_digestbyname’; have ‘const EVP_MD *(const char *)’ {aka ‘const struct evp_md_st *(const char *)’}
 1181 | const EVP_MD *EVP_get_digestbyname(const char *name);
      |               ^~~~~~~~~~~~~~~~~~~~
../../../src/mod/pbkdf2.mod/tclpbkdf2.c:43:12: note: previous implicit declaration of ‘EVP_get_digestbyname’ with type ‘int()’
   43 |   digest = EVP_get_digestbyname(argv[4 + !hex]);
      |            ^~~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:17: ../pbkdf2.o] Error 1
make[2]: Leaving directory '/home/michael/projects/eggdrop/src/mod/pbkdf2.mod'
make[1]: *** [Makefile:60: pbkdf2.mod_so] Error 2
make[1]: Leaving directory '/home/michael/projects/eggdrop/src/mod'
make: *** [Makefile:251: debug] Error 2
```
**After:**
fixed