### PR TITLE
Cleanup python.mod includes

### DIFF
--- a/src/mod/python.mod/Makefile.in
+++ b/src/mod/python.mod/Makefile.in
@@ -42,6 +42,5 @@ distclean: clean
  ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
  ../../../src/mod/modvals.h ../../../src/tandem.h \
  ../../../src/mod/irc.mod/irc.h ../../../src/mod/server.mod/server.h \
- ../../../src/mod/python.mod/python.h \
- ../../../src/mod/python.mod/pycmds.c \
- ../../../src/mod/python.mod/tclpython.c
+ .././python.mod/python.h .././python.mod/pycmds.c \
+ .././python.mod/tclpython.c

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -35,7 +35,7 @@
 #include <datetime.h>
 #include "src/mod/irc.mod/irc.h"
 #include "src/mod/server.mod/server.h"
-#include "src/mod/python.mod/python.h"
+#include "python.h"
 
 //static PyObject *pymodobj;
 static PyObject *pirp, *pglobals;
@@ -43,8 +43,8 @@ static PyObject *pirp, *pglobals;
 #undef global
 static Function *global = NULL, *irc_funcs = NULL;
 static PyThreadState *_pythreadsave;
-#include "src/mod/python.mod/pycmds.c"
-#include "src/mod/python.mod/tclpython.c"
+#include "pycmds.c"
+#include "tclpython.c"
 
 EXPORT_SCOPE char *python_start(Function *global_funcs);
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup python.mod includes

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
No functional change