### PR TITLE
Crashfix heap-use-after-free

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -360,8 +360,14 @@ static char *get_bot_pass(struct userrec *u) {
     if (pass2) {
       if (!pass) {
         pass = pass2;
-        if (encrypt_pass)
+        if (encrypt_pass) {
+	  /* get_user() returns a pointer of struct user_entry
+           * and set_user()->pass2_set() could free() and realloc it
+	   * so fetch it again with get_user()
+	   */
           set_user(&USERENTRY_PASS, u, pass);
+          pass = get_user(&USERENTRY_PASS2, u);
+	}
       } else if (strcmp(pass2, pass) && encrypt_pass2)
         pass = pass2;
     } else if (pass && encrypt_pass2)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix heap-use-after-free

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
**Before:**
```
[06:42:33] Challenging BotB...
=================================================================
==105725==ERROR: AddressSanitizer: heap-use-after-free on address 0x502000017150 at pc 0x7bebae276831 bp 0x7fff71f5e520 sp 0x7fff71f5dcc8
READ of size 2 at 0x502000017150 thread T0
    #0 0x7bebae276830 in strlen /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x5fc7560a5905 in dcc_bot_check_digest /home/michael/projects/eggdrop/src/dcc.c:617
    #2 0x5fc7560a64be in dcc_chat_pass /home/michael/projects/eggdrop/src/dcc.c:684
    #3 0x5fc7560e189d in mainloop main.c:791
    #4 0x5fc7560e4ad5 in main main.c:1211
    #5 0x7bebad039c87  (/usr/lib/libc.so.6+0x25c87) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #6 0x7bebad039d4b in __libc_start_main (/usr/lib/libc.so.6+0x25d4b) (BuildId: 32a656aa5562eece8c59a585f5eacd6cf5e2307b)
    #7 0x5fc756035504 in _start (/home/michael/eggdrop/eggdrop-1.9.5+0x215504) (BuildId: ceec514c1723b66c0f2466f31a7c9d2b0d6e6fa2)

0x502000017150 is located 0 bytes inside of 7-byte region [0x502000017150,0x502000017157)
freed by thread T0 here:
    #0 0x7bebae2fb422 in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x5fc7560e80e1 in n_free /home/michael/projects/eggdrop/src/mem.c:443

previously allocated by thread T0 here:
    #0 0x7bebae2fca31 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5fc7560e7156 in n_malloc /home/michael/projects/eggdrop/src/mem.c:342

SUMMARY: AddressSanitizer: heap-use-after-free /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x502000016e80: fa fa fd fa fa fa fd fd fa fa 00 00 fa fa 00 01
  0x502000016f00: fa fa 00 01 fa fa fd fd fa fa 00 00 fa fa fd fd
  0x502000016f80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa fd fa
  0x502000017000: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fa
  0x502000017080: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fd
=>0x502000017100: fa fa fd fa fa fa fd fd fa fa[fd]fa fa fa fd fa
  0x502000017180: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fa
  0x502000017200: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fa
  0x502000017280: fa fa fd fd fa fa 00 06 fa fa fd fa fa fa fd fd
  0x502000017300: fa fa fd fa fa fa fd fd fa fa fd fa fa fa 00 00
  0x502000017380: fa fa 06 fa fa fa 00 00 fa fa 00 00 fa fa fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==105725==ABORTING
```
**After:**
```
[07:01:39] Challenging BotB...
[07:01:39] Linked to BotB.
```