### PR TITLE
Fix prototypes

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -136,7 +136,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define zapfbot ((void (*)(int))global[36])
 #define n_free ((void (*)(void *,char *, int))global[37])
 #define u_pass_match ((int (*)(struct userrec *,char *))global[38])
-#define user_malloc(x) ((void *(*)(int,char *,int))global[39])(x,__FILE__,__LINE__)
+#define user_malloc(x) ((void *(*)(int, const char *, int))global[39])(x,__FILE__,__LINE__)
 /* 40 - 43 */
 #define get_user ((void *(*)(struct user_entry_type *,struct userrec *))global[40])
 #define set_user ((int(*)(struct user_entry_type *,struct userrec *,void *))global[41])
@@ -415,7 +415,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define make_rand_str ((void (*) (char *, int))global[243])
 /* 244 - 247 */
 #define protect_readonly (*(int *)(global[244]))
-#define findchan_by_dname ((struct chanset_t *(*)(char *))global[245])
+#define findchan_by_dname ((struct chanset_t *(*)(const char *))global[245])
 #define removedcc ((void (*) (int))global[246])
 #define userfile_perm (*(int *)global[247])
 /* 248 - 251 */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix prototypes

Additional description (if needed):
There are more...

Test cases demonstrating functionality (if applicable):
clang version 18.1.8
```
CC="clang -Og -g3 -fsanitize=address,undefined,leak -D_FORTIFY_SOURCE=3 -Wno-macro-redefined -Wno-deprecated-non-prototype"
[...]
.././console.mod/console.c:49:29: runtime error: call to function _user_malloc through pointer to incorrect function type 'void *(*)(int, char *, int)'
/home/michael/projects/eggdrop/src/userrec.c:49: note: _user_malloc defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior .././console.mod/console.c:49:29
[...]
.././channels.mod/channels.c:333:10: runtime error: call to function findchan_by_dname through pointer to incorrect function type 'struct chanset_t *(*)(char *)'
/home/michael/projects/eggdrop/src/chanprog.c:110: note: findchan_by_dname defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior .././channels.mod/channels.c:333:10
```