### PR TITLE
Crashfix: Forbid unloading of python mod

### DIFF
--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -116,6 +116,7 @@ static char *python_close()
    * - Reloading (Reexecuting PyDateTime_IMPORT) would crash
    * - Py_FinalizeEx() does not clean up everything
    * - Complexity regarding running python threads
+   * see https://bugs.python.org/issue34309 for details
    */
   return "The " MODULE_NAME " module is not allowed to be unloaded.";
 }

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -143,7 +143,6 @@ char *python_start(Function *global_funcs)
   if (forbid_reload)
     /* Reloading, reexecuting PyDateTime_IMPORT, would crash */
     return "You can't reload the " MODULE_NAME " module (it would crash the bot)";
-  forbid_reload = 1;
 
   /* Assign the core function table. After this point you use all normal
    * functions defined in src/mod/modules.h
@@ -164,6 +163,7 @@ char *python_start(Function *global_funcs)
   }
   // irc.mod depends on server.mod and channels.mod, so those were implicitely loaded
 
+  forbid_reload = 1;
   if ((s = init_python()))
     return s;
 

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -137,7 +137,14 @@ static Function python_table[] = {
 
 char *python_start(Function *global_funcs)
 {
+  static int forbid_reload = 0;
   char *s;
+
+  if (forbid_reload)
+    /* Reloading, reexecuting PyDateTime_IMPORT, would crash */
+    return "You can't reload the " MODULE_NAME " module (it would crash the bot)";
+  forbid_reload = 1;
+
   /* Assign the core function table. After this point you use all normal
    * functions defined in src/mod/modules.h
    */


### PR DESCRIPTION
Found by: 
Patch by: michaelortmann
Fixes: #1626

One-line summary:
Forbid unloading of python mod

Additional description (if needed):
Currently there is no way to avoid / fix crashes and other obstacles with unload/reload of embedded python

Test cases demonstrating functionality (if applicable):
```
.load python
[17:01:54] tcl: builtin dcc call: *dcc:loadmod -HQ 1 python
[17:01:54] Module loaded: python          
[17:01:54] #-HQ# loadmod python
Module loaded: python          
.unload python
[17:01:56] tcl: builtin dcc call: *dcc:unloadmod -HQ 1 python
Error unloading module: python: The python module is not allowed to be unloaded.
```