### PR TITLE
python.mod venv support

### DIFF
--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -64,6 +64,8 @@ static int python_gil_lock() {
 }
 
 static char *init_python() {
+  const char *venv;
+  char venvpython[PATH_MAX];
   PyObject *pmodule;
   PyStatus status;
   PyConfig config;
@@ -71,6 +73,14 @@ static char *init_python() {
   PyConfig_InitPythonConfig(&config);
   config.install_signal_handlers = 0;
   config.parse_argv = 0;
+  if ((venv = getenv("VIRTUAL_ENV"))) {
+    snprintf(venvpython, sizeof venvpython, "%s/bin/python3", venv);
+    status = PyConfig_SetBytesString(&config, &config.executable, venvpython);
+    if (PyStatus_Exception(status)) {
+      PyConfig_Clear(&config);
+      return "Python: Fatal error: Could not set venv executable";
+    }
+  }
   status = PyConfig_SetBytesString(&config, &config.program_name, argv0);
   if (PyStatus_Exception(status)) {
     PyConfig_Clear(&config);


### PR DESCRIPTION
Found by: simple
Patch by: thommey

Default Python (no venv):
```
sys.base_exec_prefix='/usr'
sys._base_executable='/usr/bin/python3'
sys.base_prefix='/usr'
sys.exec_prefix='/usr'
sys.executable='/usr/bin/python3'
sys.prefix='/usr'
sys.path =['/home/bot/eggdrop', '/usr/lib/python311.zip', '/usr/lib/python3.11', '/usr/lib/python3.11/lib-dynload', '/usr/local/lib/python3.11/dist-packages', '/usr/lib/python3/dist-packages']
```

Python with venv:
```
sys.base_exec_prefix='/usr'
sys._base_executable='/usr/bin/python3.11'
sys.base_prefix='/usr'
sys.exec_prefix='/home/bot/eggdrop/venv'
sys.executable='/home/bot/eggdrop/venv/bin/python3'
sys.prefix='/home/bot/eggdrop/venv'
sys.path =['/home/bot/eggdrop', '/usr/lib/python311.zip', '/usr/lib/python3.11', '/usr/lib/python3.11/lib-dynload', '/home/bot/eggdrop/venv/lib/python3.11/site-packages']
```

Eggdrop before this PR:
```
Module loaded: python
sys.base_exec_prefix='/usr'
sys._base_executable=''
sys.base_prefix='/usr'
sys.exec_prefix='/usr'
sys.executable=''
sys.prefix='/usr'
sys.path =['/usr/lib/python311.zip', '/usr/lib/python3.11', '/usr/lib/python3.11/lib-dynload', '/usr/local/lib/python3.11/dist-packages', '/usr/lib/python3/dist-packages', '.']
```

Eggdrop after this PR:
```
Module loaded: python
sys.base_exec_prefix='/usr'
sys._base_executable='/usr/bin/python3.11'
sys.base_prefix='/usr'
sys.exec_prefix='/home/bot/eggdrop/venv'
sys.executable='/home/bot/eggdrop/venv/bin/python'
sys.prefix='/home/bot/eggdrop/venv'
sys.path =['/usr/lib/python311.zip', '/usr/lib/python3.11', '/usr/lib/python3.11/lib-dynload', '/home/bot/eggdrop/venv/lib/python3.11/site-packages', '.']
```