### PR TITLE
Raise CHANNELLEN to the maximum of 200 chars defined by rfc1459

### DIFF
--- a/src/botcmd.c
+++ b/src/botcmd.c
@@ -341,9 +341,10 @@ static void remote_tell_who(int idx, char *nick, int chan)
       strncat(s, c->dname, ssize);
 
       /* check if we need to trunc, normally only for first chans on the line.
-       * CHANNELLEN is 80, so we likely won't ever hit this *now*, but if we
-       * ever change that for some reason (twitch? ircv3 stuff?) this is still
-       * a good check to have, 'just in case'
+       * CHANNELLEN is 200 and channel names rarely exceed 50 chars, so we
+       * likely won't ever hit this *now*, but if we ever change that for some
+       * reason (twitch? ircv3 stuff?) this is still a good check to have,
+       * 'just in case'
        */
       if (i > ssize) {
         unsigned int trunc = 4;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -49,9 +49,10 @@
  *       You should leave this at 32 characters and modify nick-len in the
  *       configuration file instead.
  */
-#define CHANNELLEN 80 /* FIXME see issue #3 and issue #38 and rfc1459 <= 200 */
-#define HANDLEN    32 /* valid values 9->NICKMAX                             */
-#define NICKMAX    32 /* valid values HANDLEN->32                            */
+#define CHANNELLEN 200 /* rfc1459 defines "Channels names are strings [...]
+                        * of length up to 200 characters.                   */
+#define HANDLEN    32  /* valid values 9->NICKMAX                           */
+#define NICKMAX    32  /* valid values HANDLEN->32                          */
 #define USERLEN    10
 
 


### PR DESCRIPTION
Found by: pseudo (see #38)
Patch by: michaelortmann
Fixes: #38

One-line summary:
Raise CHANNELLEN to the maximum of 200 chars defined by rfc1459 and used by networks like undernet

Additional description (if needed):
Its a big bad bug to if eggdrop cant deal with channels with channelnames longer than 80 chars.

Test cases demonstrating functionality (if applicable):
At least themajor network undernet supports the max channel name len of 200.
