### PR TITLE
Minimal fix for Wformat-overflow, because #548 is postponed

### DIFF
--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -68,7 +68,7 @@ typedef struct PackUp {
   unsigned long ontime;
   unsigned long now2;
   unsigned long sysup;
-  char string[3];
+  char string[FLEXIBLE_ARRAY_MEMBER];
 } PackUp;
 
 PackUp upPack;
@@ -213,7 +213,7 @@ static int send_uptime(void)
     upPack.sysup = htonl(st.st_ctime);
 
   len = sizeof(upPack) + strlen(botnetnick) + strlen(servhost) +
-        strlen(uptime_version);
+        strlen(uptime_version) + 8;
   mem = (PackUp *) nmalloc(len);
   egg_bzero(mem, len); /* mem *should* be completely filled before it's
                              * sent to the server.  But belt-and-suspenders


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: 

One-line summary:
Minimal fix for Wformat-overflow, because #548 is postponed

Additional description (if needed):
No change to raw uptime packet len and content

Test cases demonstrating functionality (if applicable):
Fixes following compiler warning:
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include -Og -g3 -DDEBUG -fsanitize=address -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././uptime.mod/uptime.c && mv -f uptime.o ../
.././uptime.mod/uptime.c: In function ‘send_uptime’:
.././uptime.mod/uptime.c:223:3: warning: ‘%s’ directive writing up to 323 bytes into a region of size 2 [-Wformat-overflow=]
  223 |   printf("DEBUG: %i %i\n", len, sprintf(mem->string, "%s %s %s", botnetnick, servhost, uptime_version));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.././uptime.mod/uptime.c:223:3: note: ‘sprintf’ output 3 or more bytes (assuming 373) into a destination of size 3
```
