### PR TITLE
Revert adding -fsanitize=address

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1249,7 +1249,6 @@ AC_DEFUN([EGG_DEBUG_DEFAULTS],
 
   debug_cflags_debug="-g3 -DDEBUG"
   AX_CHECK_COMPILE_FLAG([-Og], [debug_cflags_debug="-Og $debug_cflags_debug"])
-  AX_CHECK_COMPILE_FLAG([-fsanitize=address], [debug_cflags_debug="$debug_cflags_debug -fsanitize=address"])
   debug_cflags_debug_assert="-DDEBUG_ASSERT"
   debug_cflags_debug_mem="-DDEBUG_MEM"
   debug_cflags_debug_dns="-DDEBUG_DNS"


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Revert adding -fsanitize=address

Additional description (if needed):
Fix make bug, see test case below, introduced by #1644
So we can only add -Og, not -fsanitize=address
Due to the current ordering of eggdrop CFLAGS/DEBUGFLAGS, it is a good idea to remove it anyway, because currently -fsanitize=address is appended after USER CFLAGS.

Test cases demonstrating functionality (if applicable):
```
$ uname -a
Linux alpine320 6.6.33-0-lts #1-Alpine SMP PREEMPT_DYNAMIC Thu, 13 Jun 2024 07:49:22 +0000 x86_64 Linux
$ ./configure
[...]
checking whether C compiler accepts -fsanitize=address... yes
[...]
$ make
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -Og -g3 -DDEBUG -fsanitize=address -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS -lpthread -o ../eggdrop bg.o botcmd.o botmsg.o botnet.o chanprog.o cmds.o dcc.o dccutil.o dns.o flags.o language.o match.o main.o mem.o misc.o misc_file.o modules.o net.o rfc1459.o tcl.o tcldcc.o tclhash.o tclmisc.o tcluser.o tls.o userent.o userrec.o users.o  -L/usr/lib -ltcl8.6  -lz -lpthread -lssl -lcrypto  md5/md5c.o compat/*.o `cat mod/mod.xlibs`
/usr/lib/gcc/x86_64-alpine-linux-musl/13.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find libasan_preinit.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/13.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lasan: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:48: link] Error 1
make[2]: Leaving directory '/home/michael/usr/src/eggdrop/src'
make[1]: *** [Makefile:57: ../eggdrop] Error 2
make[1]: Leaving directory '/home/michael/usr/src/eggdrop/src'
make: *** [Makefile:251: debug] Error 2
```
