### PR TITLE
More / new typo fixes

### DIFF
--- a/doc/sphinx_source/install/readme.rst
+++ b/doc/sphinx_source/install/readme.rst
@@ -94,7 +94,7 @@ System Pre-Requisites
 
   Before you can compile Eggdrop, Tcl must be installed on your system. Many systems have Tcl installed on them by default (you can check by trying the command "tclsh"; if you are given a '%' for a prompt, it is, and you can type 'exit' to exit the Tcl shell. However, Eggdrop also requires the Tcl development header files to be installed. They can often be installed via an OS package manager, usually called something similar to 'tcl-dev' for the package name. You can also download Tcl source from `<https://www.tcl.tk/software/tcltk/download.html>`_. 
 
-  Eggdrop also requires openssl (and its development headers) in order to enable SSL/TLS protection of network data. The header files are often called something similar to 'libssl-dev'. While not advised, this requirement can be removed by compilling using ``./configure --disable-tls``, but you will not be able to connect to TLS-protected IRC servers nor utilize secure botnet communication.
+  Eggdrop also requires openssl (and its development headers) in order to enable SSL/TLS protection of network data. The header files are often called something similar to 'libssl-dev'. While not advised, this requirement can be removed by compiling using ``./configure --disable-tls``, but you will not be able to connect to TLS-protected IRC servers nor utilize secure botnet communication.
 
 Minimum Requirements
 --------------------

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -292,7 +292,7 @@ set userfile-perm 0600
 #   listen +5555 all
 #
 # To bind the listening port to a specific IP instead of all available, insert
-# a valid IP assigned to the host Eggdrop is running on infront of the port
+# a valid IP assigned to the host Eggdrop is running on in front of the port
 # (this replaces the listen-addr setting used prior to Eggdrop v1.9)
 #
 #   listen 1.2.3.4 3333 all


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
More / new typo fixes

Additional description (if needed):
compilling -> compiling
infront -> in front

Test cases demonstrating functionality (if applicable):
No functional change