### PR TITLE
Fix make error - enhance portability

### DIFF
--- a/src/compat/inet_aton.c
+++ b/src/compat/inet_aton.c
@@ -106,8 +106,8 @@ int egg_inet_aton(const char *cp, struct in_addr *addr) {
   u_long val;
   int base, n;
   char c;
-  u_int8_t parts[4];
-  u_int8_t *pp = parts;
+  uint8_t parts[4];
+  uint8_t *pp = parts;
   int digit;
 
   c = *cp;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix make error, see test case below (enhance portability)

Additional description (if needed):
Replaced u_int8_t with uint8_t, which is the way to go, its C99
Found on an older sun box

Test cases demonstrating functionality (if applicable):
```
$ make
[...]
inet_aton.c: In function `egg_inet_aton':
inet_aton.c:109: error: `u_int8_t' undeclared (first use in this function)
inet_aton.c:109: error: (Each undeclared identifier is reported only once
inet_aton.c:109: error: for each function it appears in.)
inet_aton.c:109: error: syntax error before "parts"
inet_aton.c:110: error: `pp' undeclared (first use in this function)
inet_aton.c:110: error: `parts' undeclared (first use in this function)
make[2]: *** [Makefile:40: inet_aton.o] Error 1
make[2]: Leaving directory '/export/home/michael/usr/src/eggdrop-1.10.0rc1/src/compat'
make[1]: *** [Makefile:74: compatibility] Error 2
make[1]: Leaving directory '/export/home/michael/usr/src/eggdrop-1.10.0rc1/src'
make: *** [Makefile:243: eggdrop] Error 2
```