### PR TITLE
Add yet another tcl search path for macOS

### DIFF
--- a/doc/COMPILE-GUIDE
+++ b/doc/COMPILE-GUIDE
@@ -219,9 +219,11 @@ Last revised: May 14, 2023
         brew update
         brew install openssl
 
-      Tell configure where to find tcl and openssl:
+      Tell configure where to find tcl and / or openssl in case it could not
+      autodetect:
 
         ./configure --with-tcl=/System/Volumes/Data/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh -with-sslinc=/usr/local/Cellar/openssl@3/3.0.7/include --with-ssllib=/usr/local/Cellar/openssl@3/3.0.7/lib
+
 
     E. AIX
       Follow the standard compile process in Section A. To compile dynamically

--- a/m4/tcl.m4
+++ b/m4/tcl.m4
@@ -155,6 +155,7 @@ AC_DEFUN([TEA_PATH_TCLCONFIG], [
 			`ls -d /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/Library/Frameworks/Tcl.framework 2>/dev/null` \
 			`ls -d /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/Network/Library/Frameworks/Tcl.framework 2>/dev/null` \
 			`ls -d /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework 2>/dev/null` \
+			`ls -d /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks 2>/dev/null` \
 			; do
 		    if test -f "$i/Tcl.framework/tclConfig.sh" ; then
 			ac_cv_c_tclconfig="`(cd $i/Tcl.framework; pwd)`"


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add yet another tcl search path for macOS

Additional description (if needed):
On my newly installed macOS, eggdrop still doesnt find `tclConfig.sh`
Even after #1649
When i looked for it, i found Tcl is installed but Xcode (where eggdrop searches) is not:
```
$ ls -la /Applications
total 0
drwxrwxr-x   5 root  admin  160 Jul 19 04:41 .
drwxr-xr-x  20 root  wheel  640 Jul 19 04:41 ..
-rw-r--r--   1 root  wheel    0 Jul 19 04:41 .localized
lrwxr-xr-x@  1 root  wheel   54 Jul 19 04:41 Safari.app -> ../System/Cryptexes/App/System/Applications/Safari.app
drwxr-xr-x   3 root  wheel   96 Jul 19 04:41 Utilities
```
So this PR adds yet another search path, and voila, looks like eggdrop is not dependent on Xcode anymore :)

Test cases demonstrating functionality (if applicable):
```
$ uname -a
Darwin michaels-iMac-Pro.local 22.6.0 Darwin Kernel Version 22.6.0: Mon Jun 24 01:25:37 PDT 2024; root:xnu-8796.141.3.706.2~1/RELEASE_X86_64 x86_64
```

This is macOS 13.6.8

```
configure: Autoconfiguring Tcl with tclConfig.sh
checking for correct TEA configuration... ok (TEA 3.10)
configure: configuring Eggdrop 1.10.0
checking for Tcl configuration... found /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh
checking for existence of /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh... loading
checking platform... unix
checking for sin... yes
checking for main in -lieee... no
checking for main in -linet... no
checking for net/errno.h... no
checking for connect... yes
checking for gethostbyname... yes
checking for Tcl linker... ${CC} -dynamiclib ${CFLAGS} ${LDFLAGS} -Wl,-single_module
checking for Tcl version... 8.5.9
checking for Tcl library flags... -F/System/Library/Frameworks -framework Tcl -lpthread -framework CoreFoundation
checking for Tcl header flags... -iwithsysroot /System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers
checking whether C compiler accepts -Og... yes
checking for system IPv6 support... yes
checking for struct in6_addr... yes
checking for the in6addr_any constant... yes
checking for the in6addr_loopback constant... yes
checking for struct sockaddr_in6... yes
checking whether to enable TLS support... no
configure: creating ./config.status
config.status: creating Makefile
config.status: creating doc/Makefile
config.status: creating scripts/Makefile
config.status: creating src/Makefile
config.status: creating src/compat/Makefile
config.status: creating src/md5/Makefile
config.status: creating src/mod/Makefile
config.status: creating config.h
config.status: executing eggint.h commands
config.status: creating eggint.h : __EGGINT_H
config.status: executing replace-if-changed commands
creating lush.h
config.status: executing catch-make-rebuild commands

Operating System: Darwin 22.6.0
IPv6 Support: yes
Tcl version: 8.5.9 (threaded)
```

and it fully compiled :)