### PR TITLE
Add .clangd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ eggdrop
 EGGMOD.stamp
 mod.xlibs
 __pycache__
+.clangd


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add `.clangd` to `.gitignore`

Additional description (if needed):
For development i use a `.clangd` file, and i want it to be ignored by git.

Test cases demonstrating functionality (if applicable):
If youre curious ;) my `.clangd` looks like this:
```
CompileFlags:
  Add: [-Wall, -Wno-deprecated-non-prototype, -I/home/michael/usr/src/eggdrop, -DHAVE_CONFIG_H]
```