### PR TITLE
Fix .channel formatting

### DIFF
--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -750,7 +750,6 @@ static void cmd_channel(struct userrec *u, int idx, char *par)
           strftime(s, 6, "%H:%M", localtime(&(m->joined)));
       } else
         strlcpy(s, " --- ", sizeof s);
-      egg_snprintf(s, sizeof s, "%s!%s", m->nick, m->userhost);
       u = get_user_from_member(m);
       if (u == NULL)
         strlcpy(handle, "*", sizeof handle);


### PR DESCRIPTION
Fixes: #1672 

There was an erroneous (probably added by me) snprintf line in the .channel code that incorrectly changed the join time to the hostmask. This removes that line.

Looking back at this code, it could probably stand to be tightened up in a future release as #1679 starts to do, but is too much to include as an RC fix.