### PR TITLE
Fix for tcl 9.0

### DIFF
--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -378,7 +378,7 @@ static PyObject *py_dir(PyObject *self, PyObject *args) {
   int j;
   const char *info[] = {"info commands", "info procs"}, *s, *value;
   Tcl_Obj *tcl_list, **objv;
-  int objc;
+  Tcl_Size objc;
 
   py_list = PyList_New(0);
   for (i = 0; i < sizeof info / sizeof info[0]; i++) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Fixes the following `make` error with tcl 9.0:
```
gcc -fPIC -I/usr/include/python3.12 -I/usr/include/python3.12  -fno-strict-overflow -Wsign-compare -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -DNDEBUG -g -O3 -Wall -march=native -O2 -g3 -fsanitize=address,undefined,leak -Wall -DFORTIFY_SOURCE=3 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/home/michael/opt/tcl9.0.0/include -Og -g3 -DDEBUG -DDEBUG_ASSERT -DDEBUG_MEM -DDEBUG_DNS  -DMAKING_MODS -c .././python.mod/python.c && mv -f python.o ../
In file included from .././python.mod/python.c:46:
.././python.mod/pycmds.c: In function ‘py_dir’:
.././python.mod/pycmds.c:390:55: error: passing argument 3 of ‘Tcl_ListObjGetElements’ from incompatible pointer type [-Wincompatible-pointer-types]
  390 |       if (Tcl_ListObjGetElements(tclinterp, tcl_list, &objc, &objv) == TCL_ERROR)
      |                                                       ^~~~~
      |                                                       |
      |                                                       int *
In file included from /home/michael/opt/tcl9.0.0/include/tcl.h:2439,
                 from ../../../lush.h:4,
                 from ../../../src/main.h:42,
                 from ../../../src/mod/module.h:28,
                 from .././python.mod/python.c:29:
/home/michael/opt/tcl9.0.0/include/tclDecls.h:1785:61: note: expected ‘Tcl_Size *’ {aka ‘long int *’} but argument is of type ‘int *’
 1785 |                                 Tcl_Obj *listPtr, Tcl_Size *objcPtr,
      |                                                   ~~~~~~~~~~^~~~~~~
make[2]: *** [Makefile:19: ../python.o] Error 1
make[2]: Leaving directory '/home/michael/projects/eggdrop/src/mod/python.mod'
make[1]: *** [Makefile:60: python.mod_so] Error 2
make[1]: Leaving directory '/home/michael/projects/eggdrop/src/mod'
make: *** [Makefile:251: debug] Error 2
```