### PR TITLE
Fix check for sasl / sasl-mechanism config value check

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2508,27 +2508,6 @@ char *server_start(Function *global_funcs)
   my_tcl_strings[0].buf = botname;
   add_tcl_strings(my_tcl_strings);
   add_tcl_ints(my_tcl_ints);
-  if (sasl) {
-    if ((sasl_mechanism < 0) || (sasl_mechanism >= SASL_MECHANISM_NUM)) {
-      fatal("ERROR: sasl-mechanism is not set to an allowed value, please check"
-            " it and try again", 0);
-    }
-#ifdef TLS
-#ifndef HAVE_EVP_PKEY_GET1_EC_KEY
-    if (sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) {
-      fatal("ERROR: NIST256 functionality missing from your TLS libs, please "
-            "choose a different SASL method", 0);
-    }
-#endif /* HAVE_EVP_PKEY_GET1_EC_KEY */
-#else  /* TLS */
-    if ((sasl_mechanism == SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE) ||
-            (sasl_mechanism == SASL_MECHANISM_EXTERNAL)) {
-      fatal("ERROR: The selected SASL authentication method requires TLS "
-            "libraries which are not installed on this machine. Please "
-            "choose the PLAIN method in your config.", 0);
-    }
-#endif /* TLS */
-  }
   add_tcl_commands(my_tcl_cmds);
   add_tcl_coups(my_tcl_coups);
   add_hook(HOOK_SECONDLY, (Function) server_secondly);

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1906,6 +1906,10 @@ static int gotcap(char *from, char *msg) {
           }
 
           if ((sasl) && (!strcasecmp(current->name, "sasl")) && (current->enabled)) {
+            if ((sasl_mechanism < 0) || (sasl_mechanism >= SASL_MECHANISM_NUM)) {
+              return sasl_error("ERROR: sasl-mechanism is not set to an"
+                                " allowed value, please check it and try again");
+            }
             putlog(LOG_DEBUG, "*", "SASL: Starting authentication process");
             if (current->value && !checkvalue(current->value, SASL_MECHANISMS[sasl_mechanism])) {
               snprintf(buf, sizeof buf,


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
The sasl variable checked here:
https://github.com/eggheads/eggdrop/blob/76b8a0caee9ffbd6621989f840033c709a0e15d0/src/mod/server.mod/server.c#L2511
is not loaded yet at this point in time, so its always false and the checks are not applied
instead the check for an allowed sasl-mechanism value was missing here:
https://github.com/eggheads/eggdrop/blob/76b8a0caee9ffbd6621989f840033c709a0e15d0/src/mod/server.mod/servmsg.c#L1910
which could result in out of bounds access to `SASL_MECHANISMS[]`

Test cases demonstrating functionality (if applicable):
Fixes then following crash when eggdrop is compiled with address sanitizer and configures with a bogus sasl-mechanism value:
```
[02:42:46] SASL: Starting authentication process
=================================================================
==167937==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f5ef05f5e60 at pc 0x7f5ef05d4e3c bp 0x7ffc65f46e40 sp 0x7ffc65f46e30
READ of size 8 at 0x7f5ef05f5e60 thread T0
    #0 0x7f5ef05d4e3b in gotcap .././server.mod/servmsg.c:1910
    #1 0x7f5ef05b8015 in server_raw .././server.mod/server.c:1410
    #2 0x64fed92bc11a in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:332
    #3 0x7f5ef167e7ff in TclNRRunCallbacks /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:4539
    #4 0x7f5ef16807e4 in TclEvalEx /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:5408
    #5 0x7f5ef1681096 in Tcl_EvalEx /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:5073
    #6 0x7f5ef16810b9 in Tcl_Eval /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:6001
    #7 0x7f5ef16816df in Tcl_VarEvalVA /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:7001
    #8 0x7f5ef16817bd in Tcl_VarEval /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:7032
    #9 0x64fed92cbd15 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:745
    #10 0x64fed92ce60b in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:879
    #11 0x7f5ef05b4752 in check_tcl_raw .././server.mod/servmsg.c:202
    #12 0x7f5ef05c7474 in server_activity .././server.mod/servmsg.c:1269
    #13 0x64fed92a573c in mainloop main.c:787
    #14 0x64fed92a77c5 in main main.c:1213
    #15 0x7f5ef0e34e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #16 0x7f5ef0e34ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #17 0x64fed924f3e4 in _start (/home/michael/eggdrop/eggdrop-1.10.0+0x483e4) (BuildId: dff13046839dd86805df3b1eb5d947c1cfc4e010)

0x7f5ef05f5e60 is located 32 bytes before global variable 'my_tcl_cmds' defined in '.././server.mod/tclserv.c:643:17' (0x7f5ef05f5e80) of size 240
0x7f5ef05f5e60 is located 8 bytes after global variable 'SASL_MECHANISMS' defined in '.././server.mod/server.c:161:13' (0x7f5ef05f5e40) of size 24
SUMMARY: AddressSanitizer: global-buffer-overflow .././server.mod/servmsg.c:1910 in gotcap
Shadow bytes around the buggy address:
  0x7f5ef05f5b80: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x7f5ef05f5c00: 00 00 00 00 00 00 00 00 f9 f9 f9 f9 00 00 00 00
  0x7f5ef05f5c80: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x7f5ef05f5d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f5ef05f5d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7f5ef05f5e00: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9[f9]f9 f9 f9
  0x7f5ef05f5e80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f5ef05f5f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9
  0x7f5ef05f5f80: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f5ef05f6000: 00 00 00 00 00 00 00 00 f9 f9 f9 f9 00 00 00 00
  0x7f5ef05f6080: 00 00 00 00 f9 f9 f9 f9 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==167937==ABORTING
```