### PR TITLE
Crashfix: Fix 2 string terminations

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1377,7 +1377,7 @@ void tputs(int z, char *s, unsigned int len)
     inhere = 1;
 
     putlog(LOG_MISC, "*", "!!! writing to nonexistent socket: %d", z);
-    s[strlen(s) - 1] = 0;
+    s[len - 1] = 0;
     putlog(LOG_MISC, "*", "!-> '%s'", s);
 
     inhere = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Fixes the following 2 issues:
**1.**
Before:
```
==484279==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x78d88df4c280 at pc 0x78d8914f6a02 bp 0x7ffcaa5c7e50 sp 0x7ffcaa5c75f8
WRITE of size 967 at 0x78d88df4c280 thread T0
    #0 0x78d8914f6a01 in strcpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:563
    #1 0x78d88c9265bd in gotnotice .././server.mod/servmsg.c:718
    #2 0x78d88c8f788b in server_raw .././server.mod/server.c:1410
    #3 0x568b3f6148e0 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:332
    #4 0x78d89127e7ff in TclNRRunCallbacks /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:4539
    #5 0x78d8912807e4 in TclEvalEx /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:5408
    #6 0x78d891281096 in Tcl_EvalEx /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:5073
    #7 0x78d8912810b9 in Tcl_Eval /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:6001
    #8 0x78d8912816df in Tcl_VarEvalVA /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:7001
    #9 0x78d8912817bd in Tcl_VarEval /usr/src/debug/tcl/tcl8.6.14/generic/tclBasic.c:7032
    #10 0x568b3f630b24 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:745
    #11 0x568b3f635e6e in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:879
    #12 0x78d88c8f2c36 in check_tcl_raw .././server.mod/servmsg.c:202
    #13 0x78d88c91cd52 in server_activity .././server.mod/servmsg.c:1269
    #14 0x568b3f5e8d24 in mainloop main.c:787
    #15 0x568b3f5ebe43 in main main.c:1213
    #16 0x78d890034e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #17 0x78d890034ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #18 0x568b3f53d484 in _start (/home/michael/eggdrop/eggdrop-1.10.0+0x216484) (BuildId: 1a9b352f6ffbbc5269ca3149783ede67585b1833)

Address 0x78d88df4c280 is located in stack of thread T0 at offset 640 in frame
    #0 0x78d88c925fa8 in gotnotice .././server.mod/servmsg.c:694

  This frame has 5 object(s):
    [32, 40) 'uhost' (line 695)
    [64, 72) 'ctcp' (line 695)
    [96, 104) 'msg' (line 693)
    [128, 640) 'ctcpbuf' (line 695)
    [704, 1216) 'buf' (line 695) <== Memory access at offset 640 partially underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:563 in strcpy
Shadow bytes around the buggy address:
  0x78d88df4c000: f1 f1 f1 f1 00 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2
  0x78d88df4c080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x78d88df4c280:[f2]f2 f2 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00
  0x78d88df4c300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x78d88df4c480: 00 00 00 00 00 00 00 00 f3 f3 f3 f3 f3 f3 f3 f3
  0x78d88df4c500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==484279==ABORTING
```
After:
`[19:22:02] Warning: Got NOTICE CTCP reply longer than 512 bytes: Bogus server?`
**2.:**
```
==476094==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50200001fb1c at pc 0x762644676ef1 bp 0x7ffe7619d0c0 sp 0x7ffe7619c868
READ of size 13 at 0x50200001fb1c thread T0
    #0 0x762644676ef0 in strlen /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x59232a0935b7 in tputs /home/michael/projects/eggdrop/src/net.c:1380
    #2 0x76263fafba29 in write_to_server .././server.mod/server.c:173
    #3 0x76263fb0f4cd in deq_msg .././server.mod/server.c:251
    #4 0x76263fb3431f in server_secondly .././server.mod/server.c:2034
    #5 0x59232a06d425 in mainloop main.c:742
    #6 0x59232a070e43 in main main.c:1213
    #7 0x762643234e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #8 0x762643234ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #9 0x592329fc2484 in _start (/home/michael/eggdrop/eggdrop-1.10.0+0x216484) (BuildId: 1a9b352f6ffbbc5269ca3149783ede67585b1833)

0x50200001fb1c is located 0 bytes after 12-byte region [0x50200001fb10,0x50200001fb1c)
allocated by thread T0 here:
    #0 0x7626446fd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x59232a073457 in n_malloc /home/michael/projects/eggdrop/src/mem.c:342

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x50200001f880: fa fa fd fd fa fa 00 03 fa fa fd fd fa fa fd fd
  0x50200001f900: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fd
  0x50200001f980: fa fa 00 03 fa fa fd fd fa fa fd fa fa fa fd fd
  0x50200001fa00: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fd
  0x50200001fa80: fa fa fd fd fa fa 00 01 fa fa fd fd fa fa fd fa
=>0x50200001fb00: fa fa 00[04]fa fa 00 07 fa fa fa fa fa fa fa fa
  0x50200001fb80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50200001fc00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50200001fc80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50200001fd00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x50200001fd80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==476094==ABORTING
```