### PR TITLE
Fix things not working when there is a bind log

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -1240,13 +1240,19 @@ void check_tcl_die(char *reason)
 void check_tcl_log(int lv, char *chan, char *msg)
 {
   char mask[512];
+  Tcl_Obj* prev_result;
 
+  /* We have to store the old result, as check_tcl_bind may override it */
+  prev_result = Tcl_GetObjResult(interp);
+  Tcl_IncrRefCount(prev_result);
   egg_snprintf(mask, sizeof mask, "%s %s", chan, msg);
   Tcl_SetVar(interp, "_log1", masktype(lv), TCL_GLOBAL_ONLY);
   Tcl_SetVar(interp, "_log2", chan, TCL_GLOBAL_ONLY);
   Tcl_SetVar(interp, "_log3", msg, TCL_GLOBAL_ONLY);
   check_tcl_bind(H_log, mask, 0, " $::_log1 $::_log2 $::_log3",
                  MATCH_MASK | BIND_STACKABLE);
+  Tcl_SetObjResult(interp, prev_result);
+  Tcl_DecrRefCount(prev_result);
 }
 
 #ifdef TLS


### PR DESCRIPTION
When there is a `bind log`, a few things stop working, as they do not expect logging functions to change the Tcl interpreter result.

This fixes those issues by storing the result before triggering the log binds and restoring it after the call.

Things found to be broken:

* `.tcl` dcc command (empty result is shown)
* Tcl errors reported in bind.

And maybe a few more.

Found by: DasBrain
Patch by: DasBrain
Fixes: bind log, hopefully.

One-line summary:
Fix wrong Tcl results when there is a bind log.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
.tcl string cat foo
.tcl bind log * +|+ {string cat}
.tcl string cat foo