### PR TITLE
Enhance .help resolving

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1247,6 +1247,13 @@ void tellhelp(int idx, char *file, struct flag_record *flags, int fl)
 
   if (f)
     lines = display_tellhelp(idx, file, f, flags);
+  else if (!strstr(file, " module")) {
+    char file_module[1024];
+    snprintf(file_module, sizeof file_module, "%s module", file);
+    f = resolve_help(HELP_DCC | fl, file_module);
+    if (f)
+      lines = display_tellhelp(idx, file_module, f, flags);
+  }
   if (!lines && !(fl & HELP_TEXT))
     dprintf(idx, "%s\n", IRC_NOHELP2);
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
`.help <module>` fill now be resolved like it was `.help <module> module`

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Before:
```
.help irc
[19:21:20] tcl: builtin dcc call: *dcc:help -HQ 1 irc
[19:21:20] #-HQ# help irc
No help available on that.
```
After:
```
.help irc
[19:20:44] tcl: builtin dcc call: *dcc:help -HQ 1 irc
[19:20:44] #-HQ# help irc
###  irc module
   This module controls the bots interaction on IRC. It allows the bot to join
[...]
```