### PR TITLE
Crash fix .restart with python.mod

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -876,7 +876,7 @@ static void mainloop(int toplevel)
         if (strcmp(p->name, "eggdrop") && strcmp(p->name, "encryption") &&
             strcmp(p->name, "encryption2") && strcmp(p->name, "uptime")) {
           f++;
-          debug1("stagnant module %s", p->name);
+          putlog(LOG_MISC, "*", "stagnant module %s", p->name);
         }
       }
       if (f != 0) {

--- a/src/mod/python.mod/Makefile.in
+++ b/src/mod/python.mod/Makefile.in
@@ -41,6 +41,5 @@ distclean: clean
  ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
  ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
  ../../../src/mod/modvals.h ../../../src/tandem.h \
- ../../../src/mod/irc.mod/irc.h ../../../src/mod/server.mod/server.h \
- .././python.mod/python.h .././python.mod/pycmds.c \
- .././python.mod/tclpython.c
+ ../../../src/mod/server.mod/server.h .././python.mod/python.h \
+ .././python.mod/pycmds.c .././python.mod/tclpython.c

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -154,7 +154,7 @@ char *python_start(Function *global_funcs)
       return "This module requires Eggdrop 1.9.0 or later.";
     }
     if ((s = init_python()))
-    return s;
+      return s;
   }
 
   /* Add command table to bind list */

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -33,7 +33,6 @@
 #undef days
 #include <Python.h>
 #include <datetime.h>
-#include "src/mod/irc.mod/irc.h"
 #include "src/mod/server.mod/server.h"
 #include "python.h"
 


### PR DESCRIPTION
Found by: aleksandrov89
Patch by: michaelortmann
Fixes: #1701 

One-line summary:


Additional description (if needed):
Removed the dependency on irc.mod in python.mod
Fixed python mod start func, because its called on .restart
Additionally raised log level for stagnant modules, for it will likely crash

Test cases demonstrating functionality (if applicable):
.restart with python.mod loaded wont crash anymore