### PR TITLE
Fix python thread

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -615,10 +615,14 @@ int tclthreadmainloop(int zero)
   return (i == -5);
 }
 
+struct threaddata *td_main = 0;
+
 struct threaddata *threaddata()
 {
   static Tcl_ThreadDataKey tdkey;
   struct threaddata *td = Tcl_GetThreadData(&tdkey, sizeof(struct threaddata));
+  if (!(td->mainloopfunc) && td_main) /* python thread */
+    return td_main;
   return td;
 }
 
@@ -638,6 +642,8 @@ void init_threaddata(int mainthread)
   td->blocktime.tv_usec = 0;
   td->MAXSOCKS = 0;
   increase_socks_max();
+  if (mainthread)
+    td_main = td;
 }
 
 /* workaround for Tcl that does not support unicode outside BMP (3 byte utf-8 characters) */


### PR DESCRIPTION
Found by: Empus
Patch by: thommey and michaelortmann
Fixes: 

One-line summary:
Fixes `[20:20:20] !!! writing to nonexistent socket: 9` when using `putlog()` or other functions using sockets not available via thread local storage returned via `threaddata()` in python thread

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
test.py:
```
import threading
import time
 
from eggdrop.tcl import putlog
 
def run_task():
    def bg_task():
       putlog("Inside background task bg_task()")
       time.sleep(5)
       putlog("Inside background task bg_task() 2")
 
    try:
        thread = threading.Thread(target=bg_task)
        putlog("Starting thread...")
        thread.start()
        putlog("Thread started successfully")
    except Exception as e:
        putlog(f"Thread failed to start: {e}")
 
putlog("Loaded Python thread test.")
```
Terminal 1:
```
$ ./eggdrop -nt BotA.conf
[...]
[20:39:30] tcl: builtin dcc call: *dcc:tcl testuser 9 pysource test.py
[20:39:30] tcl: evaluating .tcl pysource test.py
[20:39:30] Loaded Python thread test.
[20:39:30] tcl: evaluated .tcl pysource test.py, user 3.303ms sys 0.000ms
[20:39:38] tcl: builtin dcc call: *dcc:python testuser 9 run_task()
[20:39:38] Starting thread...
[20:39:38] Inside background task bg_task()
[20:39:38] Thread started successfully
[20:39:43] Inside background task bg_task() 2
```

Terminal 2:
```
$ telnet 127.0.0.1 3333
[...]
.tcl pysource test.py
[20:39:30] tcl: builtin dcc call: *dcc:tcl testuser 9 pysource test.py
[20:39:30] tcl: evaluating .tcl pysource test.py
[20:39:30] Loaded Python thread test.
[20:39:30] tcl: evaluated .tcl pysource test.py, user 3.303ms sys 0.000ms
Tcl: 
.python run_task()
[20:39:38] tcl: builtin dcc call: *dcc:python testuser 9 run_task()
[20:39:38] Starting thread...
[20:39:38] Inside background task bg_task()
[20:39:38] Thread started successfully
Python: None
[20:39:43] Inside background task bg_task() 2
```
