### PR TITLE
Fix compiler warning for make static

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -695,7 +695,6 @@ int module_register(char *name, Function *funcs, int major, int minor)
 
 const char *module_load(char *name)
 {
-  size_t len;
   module_entry *p;
   char *e;
   Function f;
@@ -704,6 +703,7 @@ const char *module_load(char *name)
 #endif
 
 #ifndef STATIC
+  size_t len;
   char workbuf[PATH_MAX];
 #  ifdef MOD_USE_SHL
   shl_t hand;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix compiler warning for make static

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Fixes the following compiler warning:
```
$ make static
[...]
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include -DSTATIC  -c modules.c
modules.c: In function ‘module_load’:
modules.c:698:10: warning: unused variable ‘len’ [-Wunused-variable]
  698 |   size_t len;
      |          ^~~
```