### PR TITLE
Crashfix: PART

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2240,7 +2240,7 @@ exit:
  */
 static int gotpart(char *from, char *msg)
 {
-  char *nick, *chname, *key;
+  char *nick, *chname, uhost[UHOSTLEN], *key;
   struct chanset_t *chan;
   struct userrec *u;
   memberlist *m;
@@ -2255,9 +2255,13 @@ static int gotpart(char *from, char *msg)
     return 0;
   }
   if (chan && !channel_pending(chan)) {
+    strlcpy(uhost, from, sizeof uhost);
     nick = splitnick(&from);
     m = ismember(chan, nick);
-    u = get_user_from_member(m);
+    if (m)
+      u = get_user_from_member(m);
+    else
+      u = get_user_by_host(uhost);
     if (!channel_active(chan)) {
       /* whoa! */
       putlog(LOG_MISC, chan->dname,

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2258,6 +2258,7 @@ static int gotpart(char *from, char *msg)
     strlcpy(uhost, from, sizeof uhost);
     nick = splitnick(&from);
     m = ismember(chan, nick);
+    // TODO: check account from rawt account-tags
     if (m)
       u = get_user_from_member(m);
     else

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2280,7 +2280,8 @@ static int gotpart(char *from, char *msg)
     if (!chan)
       return 0;
 
-    killmember(chan, nick);
+    if (m)
+      killmember(chan, nick);
     if (msg[0])
       putlog(LOG_JOIN, chan->dname, "%s (%s) left %s (%s).", nick, from,
              chan->dname, msg);


### PR DESCRIPTION
Found by: BigBadWouf
Patch by: michaelortmann
Fixes: #1708

One-line summary:
Crashfix `gotpart()`: If `ismember()` returns `0`, fallback to `get_user_by_host()`

Additional description (if needed):
`ismember()` can returns `0` while the bot has not (yet) synched the channel, like when it just joined
This bug affects eggdrop version 1.10.0, older versions are not affected

Test cases demonstrating functionality (if applicable):
Fixes the following crash:
```
[22:08:48] [@] :testuser!~michael@localhost PART #test666
[22:08:48] * Please report problem to https://github.com/eggheads/eggdrop/issues
[22:08:48] * Check doc/BUG-REPORT on how to do so.
[22:08:48] * Last bind (may not be related): evnt:init_server
[22:08:48] * Wrote DEBUG
[22:08:48] * SEGMENT VIOLATION -- CRASHING!
Segmentation fault (core dumped)
```