### PR TITLE
DOC : Correct mod-path variable

### DIFF
--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -589,7 +589,7 @@ Modules
 
 After the core settings, you should start loading modules. Modules are
 loaded by the command "loadmodule <module>". Eggdrop looks for modules
-in the directory you specified by the module-path setting in the files
+in the directory you specified by the mod-path setting in the files
 and directories section.
 
 Please note that for different configurations, different modules are needed.


### PR DESCRIPTION
Found by: CrazyCat
Patch by: CrazyCat

One-line summary: In Modules section, path was referenced as module-path when it's mod-path
