### PR TITLE
Fix .tcl server add/remove arg parsing

### DIFF
--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -604,7 +604,7 @@ static int tcl_server STDVAR {
     }
   } else if (!strcmp(argv[1], "remove")) {
     if (argc < 3) {
-      Tcl_SetResult(irp, "wrong # args: should be \"server remove host ?port? ?password?\"", TCL_STATIC);
+      Tcl_SetResult(irp, "wrong # args: should be \"server remove host ?port?\"", TCL_STATIC);
       return TCL_ERROR;
     }
     ret = del_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "");

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -582,6 +582,10 @@ static int tcl_server STDVAR {
 
   BADARGS(2, 5, " subcommand ?host ?port? ?password?");
   if (!strcmp(argv[1], "add")) {
+    if (argc < 3) {
+      Tcl_SetResult(irp, "Subcommand add needs at least a server host", TCL_STATIC);
+      return TCL_ERROR;
+    }
     ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");
     if (!ret) {
       server = Tcl_NewListObj(0, NULL);
@@ -599,6 +603,10 @@ static int tcl_server STDVAR {
       Tcl_SetObjResult(irp, server);
     }
   } else if (!strcmp(argv[1], "remove")) {
+    if (argc < 3) {
+      Tcl_SetResult(irp, "Subcommand remove needs at least a server host", TCL_STATIC);
+      return TCL_ERROR;
+    }
     ret = del_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "");
   } else if (!strcmp(argv[1], "list")) {
     Tcl_Obj *servers = Tcl_NewListObj(0, NULL);

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -583,7 +583,7 @@ static int tcl_server STDVAR {
   BADARGS(2, 5, " subcommand ?host ?port? ?password?");
   if (!strcmp(argv[1], "add")) {
     if (argc < 3) {
-      Tcl_SetResult(irp, "wrong # args: should be \"server add host ?port? ?password?\"", TCL_STATIC);
+      Tcl_SetResult(irp, "wrong # args: should be \"server add host ?port ?password??\"", TCL_STATIC);
       return TCL_ERROR;
     }
     ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");

--- a/src/mod/server.mod/tclserv.c
+++ b/src/mod/server.mod/tclserv.c
@@ -583,7 +583,7 @@ static int tcl_server STDVAR {
   BADARGS(2, 5, " subcommand ?host ?port? ?password?");
   if (!strcmp(argv[1], "add")) {
     if (argc < 3) {
-      Tcl_SetResult(irp, "Subcommand add needs at least a server host", TCL_STATIC);
+      Tcl_SetResult(irp, "wrong # args: should be \"server add host ?port? ?password?\"", TCL_STATIC);
       return TCL_ERROR;
     }
     ret = add_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "", argc >= 5 && argv[4] ? argv[4] : "");
@@ -604,7 +604,7 @@ static int tcl_server STDVAR {
     }
   } else if (!strcmp(argv[1], "remove")) {
     if (argc < 3) {
-      Tcl_SetResult(irp, "Subcommand remove needs at least a server host", TCL_STATIC);
+      Tcl_SetResult(irp, "wrong # args: should be \"server remove host ?port? ?password?\"", TCL_STATIC);
       return TCL_ERROR;
     }
     ret = del_server(argv[2], argc >= 4 && argv[3] ? argv[3] : "");


### PR DESCRIPTION
Found by: [DasBrain](https://github.com/DasBrain)
Patch by: michaelortmann
Fixes: #1721

One-line summary:


Additional description (if needed):
**Before:**
`.tcl server add/remove` -> crash
**After:**
```
.tcl server add
Tcl error: wrong # args: should be "server add host ?port? ?password?"
.tcl server remove
Tcl error: wrong # args: should be "server remove host ?port? ?password?"
```