### PR TITLE
Crashfix jump server name and pass len handling

### DIFF
--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -56,11 +56,13 @@
 
 
 /* Handy string lengths */
-#define HOSTMAX     63            /* DNS RFC 1035, IRC RFC 2812          */
-#define UHOSTMAX    291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
-#define DIRMAX      512           /* paranoia                            */
-#define LOGLINEMAX  9000          /* for misc.c/putlog() <cybah>         */
-#define READMAX     16384         /* for read() and SSL_read()           */
+#define HOSTMAX          63            /* DNS RFC 1035, IRC RFC 2812          */
+#define UHOSTMAX         291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
+#define DIRMAX           512           /* paranoia                            */
+#define LOGLINEMAX       9000          /* for misc.c/putlog() <cybah>         */
+#define READMAX          16384         /* for read() and SSL_read()           */
+#define NEWSERVERMAX     256
+#define NEWSERVERPASSMAX 128
 
 /* Invalid characters */
 #define BADHANDCHARS "-,+*=:!.@#;$%&"

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -56,13 +56,11 @@
 
 
 /* Handy string lengths */
-#define HOSTMAX          63            /* DNS RFC 1035, IRC RFC 2812          */
-#define UHOSTMAX         291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
-#define DIRMAX           512           /* paranoia                            */
-#define LOGLINEMAX       9000          /* for misc.c/putlog() <cybah>         */
-#define READMAX          16384         /* for read() and SSL_read()           */
-#define NEWSERVERMAX     256
-#define NEWSERVERPASSMAX 128
+#define HOSTMAX     63            /* DNS RFC 1035, IRC RFC 2812          */
+#define UHOSTMAX    291 + NICKMAX /* 32 (ident) + 3 (\0, !, @) + NICKMAX */
+#define DIRMAX      512           /* paranoia                            */
+#define LOGLINEMAX  9000          /* for misc.c/putlog() <cybah>         */
+#define READMAX     16384         /* for read() and SSL_read()           */
 
 /* Invalid characters */
 #define BADHANDCHARS "-,+*=:!.@#;$%&"

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -1095,9 +1095,9 @@ static int msg_jump(char *nick, char *host, struct userrec *u, char *par)
       putlog(LOG_CMDS, "*", "(%s!%s) !%s! JUMP %s %d %s", nick, host,
              u->handle, s, port, par);
 #endif
-      strcpy(newserver, s);
+      strlcpy(newserver, s, NEWSERVERMAX);
       newserverport = port;
-      strcpy(newserverpass, par);
+      strlcpy(newserverpass, par, NEWSERVERPASSMAX);
     } else
       putlog(LOG_CMDS, "*", "(%s!%s) !%s! JUMP", nick, host, u->handle);
     dprintf(-serv, "NOTICE %s :%s\n", nick, IRC_JUMP);

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -32,9 +32,9 @@ static Function *global = NULL;
 
 static int ctcp_mode;
 static int serv;                /* sock # of server currently */
-static char newserver[121];     /* new server? */
+static char newserver[NEWSERVERMAX]; /* new server? */
 static int newserverport;       /* new server port? */
-static char newserverpass[121]; /* new server password? */
+static char newserverpass[NEWSERVERPASSMAX]; /* new server password? */
 static time_t trying_server;    /* trying to connect to a server right now? */
 static int server_lag;          /* how lagged (in seconds) is the server? */
 static char altnick[NICKLEN];   /* possible alternate nickname to use */

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -23,12 +23,14 @@
 #ifndef _EGG_MOD_SERVER_SERVER_H
 #define _EGG_MOD_SERVER_SERVER_H
 
-#define CAPMAX       499    /*  (512 - "CAP REQ :XXX\r\n")     */
-#define CLITAGMAX    4096   /* Max size for IRCv3 message-tags sent by client*/
-#define TOTALTAGMAX  8191   /* @ + Server tag len + ; + Client tag len + ' ' */
-#define MSGMAX       511    /* Max size of IRC message line    */
-#define SENDLINEMAX  CLITAGMAX + MSGMAX
-#define RECVLINEMAX  TOTALTAGMAX + MSGMAX
+#define CAPMAX           499    /*  (512 - "CAP REQ :XXX\r\n")     */
+#define CLITAGMAX        4096   /* Max size for IRCv3 message-tags sent by client*/
+#define TOTALTAGMAX      8191   /* @ + Server tag len + ; + Client tag len + ' ' */
+#define MSGMAX           511    /* Max size of IRC message line    */
+#define SENDLINEMAX      CLITAGMAX + MSGMAX
+#define RECVLINEMAX      TOTALTAGMAX + MSGMAX
+#define NEWSERVERMAX     256
+#define NEWSERVERPASSMAX 128
 
 #define check_tcl_ctcp(a,b,c,d,e,f) check_tcl_ctcpr(a,b,c,d,e,f,H_ctcp)
 #define check_tcl_ctcr(a,b,c,d,e,f) check_tcl_ctcpr(a,b,c,d,e,f,H_ctcr)

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2205,7 +2205,7 @@ static void server_resolve_failure(int);
  */
 static void connect_server(void)
 {
-  char pass[sizeof newserverpass], botserver[sizeof newserver], s[1024];
+  char pass[NEWSERVERPASSMAX], botserver[NEWSERVERMAX], s[1024];
 #ifdef IPV6
   char buf[sizeof(struct in6_addr)];
 #endif

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -2205,7 +2205,7 @@ static void server_resolve_failure(int);
  */
 static void connect_server(void)
 {
-  char pass[121], botserver[UHOSTLEN], s[1024];
+  char pass[sizeof newserverpass], botserver[sizeof newserver], s[1024];
 #ifdef IPV6
   char buf[sizeof(struct in6_addr)];
 #endif
@@ -2217,9 +2217,9 @@ static void connect_server(void)
   empty_msgq();
   if (newserverport) {          /* Jump to specified server */
     curserv = -1;             /* Reset server list */
-    strcpy(botserver, newserver);
+    strlcpy(botserver, newserver, sizeof botserver);
     botserverport = newserverport;
-    strcpy(pass, newserverpass);
+    strlcpy(pass, newserverpass, sizeof pass);
     newserver[0] = 0;
     newserverport = 0;
     newserverpass[0] = 0;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
Due to eggdrops mod API, we cannot use `sizeof` in irc.mod for strings defined in server.mod. I guess this is the reason those `strcpy()`s were not converted to `strlcpy()`s before.

Test cases demonstrating functionality (if applicable):
`/msg BotA jump hunter2 aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaaabbbbbbbbbba.edu`

```
[08:27:50] [@] :testuser!~michael@localhost PRIVMSG BotA :jump hunter2 aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaaabbbbbbbbbba.edu
[08:27:50] pbkdf2 method SHA256 rounds 16000, user 10.718ms sys 6.447ms
[08:27:50] (testuser!~michael@localhost) !testuser! JUMP aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaaabbbbbbbbbba.edu 6667 
=================================================================
==28916==ERROR: AddressSanitizer: global-buffer-overflow on address 0x78eb664f6b79 at pc 0x78eb69ef6a02 bp 0x7ffdedec78b0 sp 0x7ffdedec7058
WRITE of size 127 at 0x78eb664f6b79 thread T0
    #0 0x78eb69ef6a01 in strcpy /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:563
    #1 0x78eb64d84943 in msg_jump .././irc.mod/msgcmds.c:1098
[...]
```