### PR TITLE
Fix got353() userhost-in-names

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1264,7 +1264,7 @@ static int got353(char *from, char *msg)
   struct chanset_t *chan = NULL;
   int i;
 
-  if ((current = find_capability("userhost-in-names")) && (current->enabled)) {
+  if ((current = find_capability("userhost-in-names")) && current->enabled) {
     strlcpy(prefixchars, isupport_get_prefixchars(), sizeof prefixchars);
     newsplit(&msg);
     newsplit(&msg); /* Get rid of =, @, or * symbol */

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1258,12 +1258,13 @@ static int gotchghost(char *from, char *msg) {
  */
 static int got353(char *from, char *msg)
 {
+  struct capability *current;
   char prefixchars[64];
   char *nameptr, *chname, *uhost, *nick, *p, *host = NULL;
   struct chanset_t *chan = NULL;
   int i;
 
-  if (find_capability("userhost-in-names")) {
+  if ((current = find_capability("userhost-in-names")) && (current->enabled)) {
     strlcpy(prefixchars, isupport_get_prefixchars(), sizeof prefixchars);
     newsplit(&msg);
     newsplit(&msg); /* Get rid of =, @, or * symbol */


### PR DESCRIPTION
Found by: Robby and michaelortmann
Patch by: michaelortmann
Fixes: #1604

One-line summary:
Fixes a channel member list corruption regression

Additional description (if needed):
`got353()` check for capability userhost-in-names was wrong. It checked only, if this cap is available. But it must also check, if it is enabled.

This bug affects eggdrop version 1.10.0rc1 and higher.

It is triggered, when the server supports CAP userhost-in-names and eggdrop doesnt request this CAP. In such case it would handle a 353 numeric from server as if userhost-in-names was negotiatad successfully and would then end up attempting to split the server message into `nick!host`. Without userhost-in-names CAP active, there is no `!host` part. In then end this would lead to adding a new member with empty nick into the channel member list.

Test cases demonstrating functionality (if applicable):
Tested with and without the following line in `eggdrop.conf`:
`set cap-request "userhost-in-names" `
**Test 1 - with cap request** 
```
[02:37:29] CAP: ACK : account-notify extended-join sasl userhost-in-names
[...]
[02:37:29] [@] :zen.home.arpa 001 BotA :Welcome to the StaticBox Internet Relay Chat Network BotA
[02:37:29] [!s] WHOIS BotA
[02:37:29] triggering bind quotepong_unbind
[02:37:29] triggered bind quotepong_unbind, user 0.005ms sys 0.004ms
[02:37:29] triggering bind evnt:init_server
[02:37:29] [!m] MODE BotA +i-ws
[02:37:29] triggered bind evnt:init_server, user 0.007ms sys 0.005ms
[02:37:29] [!s] JOIN #foo
[02:37:29] [@] :zen.home.arpa 002 BotA :Your host is zen.home.arpa[0.0.0.0/6697], running version solanum-1.0-dev
[02:37:29] [@] :zen.home.arpa 003 BotA :This server was created Sat Oct 19 2024 at 07:54:13 CEST
[02:37:29] [@] :zen.home.arpa 004 BotA zen.home.arpa solanum-1.0-dev DGMQRSZagiloswz CFILPQbcefgijklmnopqrstvz bkloveqjfI
[02:37:29] [@] :zen.home.arpa 005 BotA ETRACE WHOX FNC KNOCK CALLERID=g MONITOR=100 SAFELIST ELIST=CMNTU CHANTYPES=#& EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLPQcgimnprstz :are supported by this server
[02:37:29] [@] :zen.home.arpa 005 BotA CHANLIMIT=#&:15 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 NETWORK=StaticBox STATUSMSG=@+ CASEMAPPING=rfc1459 NICKLEN=30 MAXNICKLEN=31 CHANNELLEN=50 TOPICLEN=390 DEAF=D :are supported by this server
[02:37:29] [@] :zen.home.arpa 005 BotA TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: :are supported by this server
[02:37:29] [@] :zen.home.arpa 251 BotA :There are 0 users and 1 invisible on 1 servers
[02:37:29] [@] :zen.home.arpa 255 BotA :I have 1 clients and 0 servers
[02:37:29] [@] :zen.home.arpa 265 BotA 1 1 :Current local users 1, max 1
[02:37:29] [@] :zen.home.arpa 266 BotA 1 1 :Current global users 1, max 1
[02:37:29] [@] :zen.home.arpa 250 BotA :Highest connection count: 1 (1 clients) (42 connections received)
[02:37:29] [@] :zen.home.arpa 375 BotA :- zen.home.arpa Message of the Day - 
[02:37:29] [@] :zen.home.arpa 372 BotA :- This is solanum MOTD you might replace it, but if not your friends will
[02:37:29] [@] :zen.home.arpa 372 BotA :- laugh at you.
[02:37:29] [@] :zen.home.arpa 376 BotA :End of /MOTD command.
[02:37:29] [@] :BotA MODE BotA :+Zi
[02:37:29] [!s] WHOIS BotA
[02:37:31] [m->] MODE BotA +i-ws
[02:37:37] [s->] WHOIS BotA
[02:37:37] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[02:37:37] [@] :zen.home.arpa 312 BotA BotA zen.home.arpa :solanum test server
[02:37:37] [@] :zen.home.arpa 671 BotA BotA :is using a secure connection [TLSv1.3, TLS_AES_256_GCM_SHA384]
[02:37:37] [@] :zen.home.arpa 276 BotA BotA :has client certificate fingerprint SPKI:SHA2-256:2303a1f0ad426bcefdd664009de242b8f64a86792dcf73eb6f6c37afdc8f6829
[02:37:37] [@] :zen.home.arpa 317 BotA BotA 8 1736300249 :seconds idle, signon time
[02:37:37] [@] :zen.home.arpa 318 BotA BotA :End of /WHOIS list.
[02:37:39] [s->] JOIN #foo
[02:37:39] [@] :BotA!~BotA@localhost JOIN #foo * :A deranged product of evil coders
[02:37:39] BotA joined #foo.
[02:37:39] [!m] MODE #foo +b
[02:37:39] [m->] MODE #foo +b
[02:37:39] [!m] MODE #foo +e
[02:37:39] [m->] MODE #foo +e
[02:37:39] [!m] MODE #foo +I
[02:37:39] [!m] MODE #foo
[02:37:39] [!m] WHO #foo c%chnufat,222
[02:37:39] [@] :zen.home.arpa MODE #foo +nt
[02:37:39] #foo: mode change '+nt ' by zen.home.arpa
[02:37:39] [@] :zen.home.arpa 353 BotA = #foo :@BotA!~BotA@localhost
[02:37:39] [@] :zen.home.arpa 366 BotA #foo :End of /NAMES list.
[02:37:39] [@] :zen.home.arpa 368 BotA #foo :End of Channel Ban List
[02:37:39] [@] :zen.home.arpa 349 BotA #foo :End of Channel Exception List
[02:37:41] [m->] MODE #foo +I
[02:37:41] [@] :zen.home.arpa 347 BotA #foo :End of Channel Invite List
[02:37:43] [m->] MODE #foo
[02:37:43] [@] :zen.home.arpa 324 BotA #foo +nt
[02:37:43] [@] :zen.home.arpa 329 BotA #foo 1736300259
[02:37:45] [m->] WHO #foo c%chnufat,222
[02:37:45] [@] :zen.home.arpa 354 BotA 222 #foo ~BotA localhost BotA H@ 0
[02:37:45] [@] :zen.home.arpa 315 BotA #foo :End of /WHO list.
[02:37:51] [s->] WHOIS BotA
[02:37:51] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[02:37:51] [@] :zen.home.arpa 319 BotA BotA :@#foo
[02:37:51] [@] :zen.home.arpa 312 BotA BotA zen.home.arpa :solanum test server
[02:37:51] [@] :zen.home.arpa 671 BotA BotA :is using a secure connection [TLSv1.3, TLS_AES_256_GCM_SHA384]
[02:37:51] [@] :zen.home.arpa 276 BotA BotA :has client certificate fingerprint SPKI:SHA2-256:2303a1f0ad426bcefdd664009de242b8f64a86792dcf73eb6f6c37afdc8f6829
[02:37:51] [@] :zen.home.arpa 317 BotA BotA 22 1736300249 :seconds idle, signon time
[02:37:51] [@] :zen.home.arpa 318 BotA BotA :End of /WHOIS list.
.channel
[02:38:06] tcl: builtin dcc call: *dcc:channel -HQ 1 
[02:38:06] #-HQ# (#foo) channel
Channel #foo, 1 member, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME  HANDLE    ACCOUNT    JOIN   IDLE         USER@HOST
@BotA      *         *         02:37                <- it's me!
End of channel info.
```
**Test 2 - with cap request**
```
[02:48:53] CAP: ACK : account-notify extended-join sasl
[...]
[02:48:54] [@] :zen.home.arpa 001 BotA :Welcome to the StaticBox Internet Relay Chat Network BotA
[02:48:54] [!s] WHOIS BotA
[02:48:54] triggering bind quotepong_unbind
[02:48:54] triggered bind quotepong_unbind, user 0.010ms sys 0.000ms
[02:48:54] triggering bind evnt:init_server
[02:48:54] [!m] MODE BotA +i-ws
[02:48:54] triggered bind evnt:init_server, user 0.015ms sys 0.000ms
[02:48:54] [!s] JOIN #foo
[02:48:54] [@] :zen.home.arpa 002 BotA :Your host is zen.home.arpa[0.0.0.0/6697], running version solanum-1.0-dev
[02:48:54] [@] :zen.home.arpa 003 BotA :This server was created Sat Oct 19 2024 at 07:54:13 CEST
[02:48:54] [@] :zen.home.arpa 004 BotA zen.home.arpa solanum-1.0-dev DGMQRSZagiloswz CFILPQbcefgijklmnopqrstvz bkloveqjfI
[02:48:54] [@] :zen.home.arpa 005 BotA ETRACE WHOX FNC KNOCK CALLERID=g MONITOR=100 SAFELIST ELIST=CMNTU CHANTYPES=#& EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLPQcgimnprstz :are supported by this server
[02:48:54] [@] :zen.home.arpa 005 BotA CHANLIMIT=#&:15 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 NETWORK=StaticBox STATUSMSG=@+ CASEMAPPING=rfc1459 NICKLEN=30 MAXNICKLEN=31 CHANNELLEN=50 TOPICLEN=390 DEAF=D :are supported by this server
[02:48:54] [@] :zen.home.arpa 005 BotA TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: :are supported by this server
[02:48:54] [@] :zen.home.arpa 251 BotA :There are 0 users and 1 invisible on 1 servers
[02:48:54] [@] :zen.home.arpa 255 BotA :I have 1 clients and 0 servers
[02:48:54] [@] :zen.home.arpa 265 BotA 1 1 :Current local users 1, max 1
[02:48:54] [@] :zen.home.arpa 266 BotA 1 1 :Current global users 1, max 1
[02:48:54] [@] :zen.home.arpa 250 BotA :Highest connection count: 1 (1 clients) (44 connections received)
[02:48:54] [@] :zen.home.arpa 375 BotA :- zen.home.arpa Message of the Day - 
[02:48:54] [@] :zen.home.arpa 372 BotA :- This is solanum MOTD you might replace it, but if not your friends will
[02:48:54] [@] :zen.home.arpa 372 BotA :- laugh at you.
[02:48:54] [@] :zen.home.arpa 376 BotA :End of /MOTD command.
[02:48:54] [@] :BotA MODE BotA :+Zi
[02:48:54] [!s] WHOIS BotA
[02:48:56] [m->] MODE BotA +i-ws
[02:49:00] [!s] JOIN #foo
[02:49:02] [s->] WHOIS BotA
[02:49:02] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[02:49:02] [@] :zen.home.arpa 312 BotA BotA zen.home.arpa :solanum test server
[02:49:02] [@] :zen.home.arpa 671 BotA BotA :is using a secure connection [TLSv1.3, TLS_AES_256_GCM_SHA384]
[02:49:02] [@] :zen.home.arpa 276 BotA BotA :has client certificate fingerprint SPKI:SHA2-256:2303a1f0ad426bcefdd664009de242b8f64a86792dcf73eb6f6c37afdc8f6829
[02:49:02] [@] :zen.home.arpa 317 BotA BotA 8 1736300934 :seconds idle, signon time
[02:49:02] [@] :zen.home.arpa 318 BotA BotA :End of /WHOIS list.
[02:49:04] [s->] JOIN #foo
[02:49:04] [@] :BotA!~BotA@localhost JOIN #foo * :A deranged product of evil coders
[02:49:04] BotA joined #foo.
[02:49:04] [!m] MODE #foo +b
[02:49:04] [m->] MODE #foo +b
[02:49:04] [!m] MODE #foo +e
[02:49:04] [m->] MODE #foo +e
[02:49:04] [!m] MODE #foo +I
[02:49:04] [!m] MODE #foo
[02:49:04] [!m] WHO #foo c%chnufat,222
[02:49:04] [@] :zen.home.arpa MODE #foo +nt
[02:49:04] #foo: mode change '+nt ' by zen.home.arpa
[02:49:04] [@] :zen.home.arpa 353 BotA = #foo :@BotA
[02:49:04] [@] :zen.home.arpa 366 BotA #foo :End of /NAMES list.
[02:49:04] [@] :zen.home.arpa 368 BotA #foo :End of Channel Ban List
[02:49:04] [@] :zen.home.arpa 349 BotA #foo :End of Channel Exception List
[02:49:06] [m->] MODE #foo +I
[02:49:06] [@] :zen.home.arpa 347 BotA #foo :End of Channel Invite List
[02:49:08] [m->] MODE #foo
[02:49:08] [@] :zen.home.arpa 324 BotA #foo +nt
[02:49:08] [@] :zen.home.arpa 329 BotA #foo 1736300944
[02:49:10] [m->] WHO #foo c%chnufat,222
[02:49:10] [@] :zen.home.arpa 354 BotA 222 #foo ~BotA localhost BotA H@ 0
[02:49:10] [@] :zen.home.arpa 315 BotA #foo :End of /WHO list.
[02:49:16] [s->] WHOIS BotA
[02:49:16] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[02:49:16] [@] :zen.home.arpa 319 BotA BotA :@#foo
[02:49:16] [@] :zen.home.arpa 312 BotA BotA zen.home.arpa :solanum test server
[02:49:16] [@] :zen.home.arpa 671 BotA BotA :is using a secure connection [TLSv1.3, TLS_AES_256_GCM_SHA384]
[02:49:16] [@] :zen.home.arpa 276 BotA BotA :has client certificate fingerprint SPKI:SHA2-256:2303a1f0ad426bcefdd664009de242b8f64a86792dcf73eb6f6c37afdc8f6829
[02:49:16] [@] :zen.home.arpa 317 BotA BotA 22 1736300934 :seconds idle, signon time
[02:49:16] [@] :zen.home.arpa 318 BotA BotA :End of /WHOIS list.
[02:49:18] [s->] JOIN #foo
[02:50:00] [m->] PING :1736301000
[02:50:00] [@] :zen.home.arpa PONG zen.home.arpa :1736301000
.channel
[02:50:51] tcl: builtin dcc call: *dcc:channel -HQ 1 
[02:50:51] #-HQ# (#foo) channel
Channel #foo, 1 member, mode +tn:
(n = owner, m = master, o = op, d = deop, b = bot)
 NICKNAME  HANDLE    ACCOUNT    JOIN   IDLE         USER@HOST
@BotA      *         *         02:49                <- it's me!
End of channel info.
```