### PR TITLE
Fix pbkdf2 mod make error

### DIFF
--- a/src/mod/pbkdf2.mod/pbkdf2.c
+++ b/src/mod/pbkdf2.mod/pbkdf2.c
@@ -10,6 +10,7 @@
 #include "src/mod/module.h"
 
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL /* 1.0.0 */
+static Function *global = NULL; /* before tclpbkdf2.c */
 #include "tclpbkdf2.c"
 
 #define MODULE_NAME "encryption2"
@@ -20,8 +21,6 @@
 
 /* Salt string length */
 #define PBKDF2_SALT_LEN 16 /* DO NOT TOUCH! */
-
-static Function *global = NULL;
 
 /* Cryptographic hash function used. openssl list -digest-algorithms */
 static char pbkdf2_method[28] = "SHA256";


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix pbkdf2 mod make error

Additional description (if needed):
This bug affects eggdrop version 1.10.0rc1 and higher.
Regression by #1569
Seen under NetBSD 9.3

Test cases demonstrating functionality (if applicable):
Fixes then following make error under NetBSD 9.3 and similar systems:
```
gcc -fPIC -g -O2 -pipe -Wall -I. -I../../.. -I../../..  -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/pkg/include  -DMAKING_MODS -c .././pbkdf2.mod/pbkdf2.c && mv -f pbkdf2.o ../
In file included from .././pbkdf2.mod/pbkdf2.c:10:0:
.././pbkdf2.mod/tclpbkdf2.c: In function 'tcl_pbkdf2':
../../../src/mod/module.h:511:64: error: 'global' undeclared (first use in this function); did you mean '_locale'?
 # define explicit_bzero ((void (*) (void *const, const size_t))global[311])
                                                                ^
.././pbkdf2.mod/tclpbkdf2.c:57:5: note: in expansion of macro 'explicit_bzero'
     explicit_bzero(buf_hex, digestlen * 2);
     ^~~~~~~~~~~~~~
../../../src/mod/module.h:511:64: note: each undeclared identifier is reported only once for each function it appears in
 # define explicit_bzero ((void (*) (void *const, const size_t))global[311])
                                                                ^
.././pbkdf2.mod/tclpbkdf2.c:57:5: note: in expansion of macro 'explicit_bzero'
     explicit_bzero(buf_hex, digestlen * 2);
     ^~~~~~~~~~~~~~
*** Error code 1

Stop.
make[2]: stopped in /home/michael/usr/src/eggdrop/src/mod/pbkdf2.mod
*** Error code 1

Stop.
make[1]: stopped in /home/michael/usr/src/eggdrop/src/mod
*** Error code 1

Stop.
make: stopped in /home/michael/usr/src/eggdrop
```