### PR TITLE
Crashfix unload irc.mod

### DIFF
--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1346,6 +1346,7 @@ static char *irc_close()
   rem_builtins(H_dcc, irc_dcc);
   rem_builtins(H_msg, C_msg);
   rem_builtins(H_raw, irc_raw);
+  rem_builtins(H_rawt, irc_rawt);
   rem_builtins(H_isupport, irc_isupport_binds);
   rem_tcl_commands(tclchan_cmds);
   rem_help_reference("irc.help");


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1704

One-line summary:
Crashfix unload `irc.mod` - Remove `rawt` in `irc_close()`

Additional description (if needed):
This bug affects eggdrop version 1.9.4rc1 and higher.
Regression by #1332
`add_builtins(H_rawt, irc_rawt);` also needs a corresponding `rem_builtins(H_rawt, irc_rawt);`
See https://github.com/eggheads/eggdrop/pull/1332/files#diff-73a7cf76a2abc5f287278f979cb65e796a66e0d074e4f991e634c1ab0bb87919R1455

Test cases demonstrating functionality (if applicable):
Before:
```
[21:02:28] [m->] MODE BotA +i-ws
.unload irc
[21:02:30] tcl: builtin dcc call: *dcc:unloadmod -HQ 1 irc
[21:02:30] [!m] JOIN 0
[21:02:30] De-Allocated bind table topc
[21:02:30] De-Allocated bind table splt
[21:02:30] De-Allocated bind table sign
[21:02:30] De-Allocated bind table rejn
[21:02:30] De-Allocated bind table part
[21:02:30] De-Allocated bind table nick
[21:02:30] De-Allocated bind table mode
[21:02:30] De-Allocated bind table kick
[21:02:30] De-Allocated bind table invt
[21:02:30] De-Allocated bind table join
[21:02:30] De-Allocated bind table pubm
[21:02:30] De-Allocated bind table pub
[21:02:30] De-Allocated bind table need
[21:02:30] De-Allocated bind table ircaway
[21:02:30] De-Allocated bind table account
[21:02:30] De-Allocated bind table chghost
[21:02:30] Module unloaded: irc
[21:02:30] #-HQ# unloadmod irc
Module unloaded: irc
[21:02:30] [m->] JOIN 0
[21:02:36] [s->] WHOIS BotA
[21:02:36] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[21:02:36] * Please report problem to https://github.com/eggheads/eggdrop/issues
[21:02:36] * Check doc/BUG-REPORT on how to do so.
[21:02:36] * Last bind (may not be related): evnt:init_server
[21:02:36] * Wrote DEBUG
[21:02:36] * SEGMENT VIOLATION -- CRASHING!
[...]
(gdb) bt full
#0  0x00007bdf9f1f4461 in ?? ()
No symbol table info available.
#1  0x00007bdf9f236445 in server_rawt (cd=0x7bdf9f1f4461, irp=0x58f4e9862e70, argc=5, argv=0x58f4e99b9170)
    at .././server.mod/server.c:1430
        unused = 0
        tagdict = 0x58f4e99bb5a0
        F = 0x7bdf9f1f4461
```
After:
```
[21:12:50] [m->] MODE BotA +i-ws
.unload irc
[21:12:51] tcl: builtin dcc call: *dcc:unloadmod -HQ 1 irc
[21:12:51] [!m] JOIN 0
[21:12:51] De-Allocated bind table topc
[21:12:51] De-Allocated bind table splt
[21:12:51] De-Allocated bind table sign
[21:12:51] De-Allocated bind table rejn
[21:12:51] De-Allocated bind table part
[21:12:51] De-Allocated bind table nick
[21:12:51] De-Allocated bind table mode
[21:12:51] De-Allocated bind table kick
[21:12:51] De-Allocated bind table invt
[21:12:51] De-Allocated bind table join
[21:12:51] De-Allocated bind table pubm
[21:12:51] De-Allocated bind table pub
[21:12:51] De-Allocated bind table need
[21:12:51] De-Allocated bind table ircaway
[21:12:51] De-Allocated bind table account
[21:12:51] De-Allocated bind table chghost
[21:12:51] Module unloaded: irc
[21:12:51] #-HQ# unloadmod irc
Module unloaded: irc
[21:12:52] [m->] JOIN 0
[21:12:58] [s->] WHOIS BotA
[21:12:58] [@] :zen.home.arpa 311 BotA BotA ~BotA localhost * :A deranged product of evil coders
[21:12:58] [@] :zen.home.arpa 312 BotA BotA zen.home.arpa :solanum test server
[21:12:58] [@] :zen.home.arpa 671 BotA BotA :is using a secure connection [TLSv1.3, TLS_AES_256_GCM_SHA384]
[21:12:58] [@] :zen.home.arpa 276 BotA BotA :has client certificate fingerprint SPKI:SHA2-256:2303a1f0ad426bcefdd664009de242b8f64a86792dcf73eb6f6c37afdc8f6829
[21:12:58] [@] :zen.home.arpa 317 BotA BotA 10 1736367168 :seconds idle, signon time
[21:12:58] [@] :zen.home.arpa 318 BotA BotA :End of /WHOIS list.
[21:13:00] [s->] JOIN #foo
```