### PR TITLE
Fix memory leak

### DIFF
--- a/src/userrec.c
+++ b/src/userrec.c
@@ -332,6 +332,8 @@ void clear_masks(maskrec *m)
     temp = m->next;
     if (m->mask)
       nfree(m->mask);
+    if (m->user)
+      nfree(m->user);
     if (m->desc)
       nfree(m->desc);
     nfree(m);


### PR DESCRIPTION
Found by: michaelortmann (or Mystery-X if this fixes #1545)
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix memory leak
Seen with `.rehash`, looks like its triggered by userfile reloading
malloc is here: https://github.com/eggheads/eggdrop/blob/0f5599e1fafa97454dc7a8b147c6076638e95ba8/src/users.c#L232
missing free is here: https://github.com/eggheads/eggdrop/blob/0f5599e1fafa97454dc7a8b147c6076638e95ba8/src/userrec.c#L327-L339
This is the first PR candidate to likely fix #1545

Additional description (if needed):
Looks like this bug is in eggdrop since the dawn of time


Test cases demonstrating functionality (if applicable):
Fixes the following memory leak:
```
.rehash
.die
==771949==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 12 byte(s) in 3 object(s) allocated from:
    #0 0x71fe610fd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x56af86065bd6 in n_malloc /home/michael/projects/eggdrop/src/mem.c:342
    #2 0x56af8610567b in _user_malloc /home/michael/projects/eggdrop/src/userrec.c:58
    #3 0x56af8611405e in addmask_fully /home/michael/projects/eggdrop/src/users.c:232
    #4 0x56af861148ab in restore_chanban /home/michael/projects/eggdrop/src/users.c:270
    #5 0x56af8611a24a in readuserfile /home/michael/projects/eggdrop/src/users.c:740
    #6 0x56af85fc4b05 in chanprog /home/michael/projects/eggdrop/src/chanprog.c:431
    #7 0x56af8606464c in main main.c:1074
    #8 0x71fe5fe34e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #9 0x71fe5fe34ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #10 0x56af85f784c4 in _start (/home/michael/eggdrop/eggdrop-1.10.0+0x2724c4) (BuildId: e944f3d030c3fbed482206c3ec75adfc5d13fefd)

SUMMARY: AddressSanitizer: 12 byte(s) leaked in 3 allocation(s).
```