### PR TITLE
Do not silently truncate eggdrop settings

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -283,8 +283,10 @@ static char *tcl_eggstr(ClientData cdata, Tcl_Interp *irp,
     }
     s = (char *) Tcl_GetVar2(interp, name1, name2, 0);
     if (s != NULL) {
-      if (strlen(s) > abs(st->max))
+      if (strlen(s) > abs(st->max)) {
+        putlog(LOG_MISC, "*", "warning: value for %s truncated to %i chars", name1, abs(st->max));
         s[abs(st->max)] = 0;
+      }
       if (st->str == botnetnick)
         botnet_change(s);
       else if (st->str == logfile_suffix)

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -284,7 +284,7 @@ static char *tcl_eggstr(ClientData cdata, Tcl_Interp *irp,
     s = (char *) Tcl_GetVar2(interp, name1, name2, 0);
     if (s != NULL) {
       if (strlen(s) > abs(st->max)) {
-        putlog(LOG_MISC, "*", "warning: value for %s truncated to %i chars", name1, abs(st->max));
+        putlog(LOG_MISC, "*", "WARNING: Value for %s truncated to %i chars", name1, abs(st->max));
         s[abs(st->max)] = 0;
       }
       if (st->str == botnetnick)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Do not silently truncate eggdrop settings

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
```
.set firewall aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbba
[06:20:56] #-HQ# set firewall aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbba
[06:20:56] warning: value for firewall truncated to 120 chars
Ok, set.
```