### PR TITLE
Fix function types

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2577,7 +2577,7 @@ int stripmodes(char *s)
   return res;
 }
 
-char *stripmasktype(int x)
+const char *stripmasktype(int x)
 {
   static char s[20];
   char *p = s;

--- a/src/flags.c
+++ b/src/flags.c
@@ -138,7 +138,7 @@ int logmodes(char *s)
   return res;
 }
 
-char *masktype(int x)
+const char *masktype(int x)
 {
   static char s[27];            /* Change this if you change the levels */
   char *p = s;

--- a/src/misc.c
+++ b/src/misc.c
@@ -179,7 +179,7 @@ int egg_strcatn(char *dst, const char *src, size_t max)
   return tmpmax - max;
 }
 
-int my_strcpy(char *a, char *b)
+int my_strcpy(char *a, const char *b)
 {
   char *c = b;
 

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -265,7 +265,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define interp (*(Tcl_Interp **)(global[128]))
 #define now (*(time_t*)global[129])
 #define findanyidx ((int (*)(int))global[130])
-#define findchan ((struct chanset_t *(*)(char *))global[131])
+#define findchan ((struct chanset_t *(*)(const char *))global[131])
 /* 132 - 135 */
 #define cmd_die (global[132])
 #define days ((void (*)(time_t,time_t,char *))global[133])
@@ -374,8 +374,8 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 /* 216 - 219 */
 #define fcopyfile ((int (*) (FILE *, char *))global[216])
 #define copyfilef ((int (*) (char *, FILE *))global[217])
-#define rfc_casecmp ((int(*)(char *, char *))(*(Function**)(global[218])))
-#define rfc_ncasecmp ((int(*)(char *, char *, int *))(*(Function**)(global[219])))
+#define rfc_casecmp ((int(*)(const char *, const char *))(*(Function**)(global[218])))
+#define rfc_ncasecmp ((int(*)(const char *, const char *, int *))(*(Function**)(global[219])))
 /* 220 - 223 */
 #define global_exempts (*(maskrec **)(global[220]))
 #define global_invites (*(maskrec **)(global[221]))

--- a/src/mod/server.mod/isupport.c
+++ b/src/mod/server.mod/isupport.c
@@ -103,7 +103,7 @@ static int keycmp(const char *key1, const char *key2, size_t key2len) {
     - truncate into allowed range if outside allowed range?
     - default value to use if outside allowed range
  */
-int isupport_parseint(char *key, char *value, int min, int max, int truncate, int defaultvalue, int *dst)
+int isupport_parseint(const char *key, const char *value, int min, int max, int truncate, int defaultvalue, int *dst)
 {
   long result;
   char *tmp;

--- a/src/proto.h
+++ b/src/proto.h
@@ -226,7 +226,7 @@ void debug_mem_to_dcc(int);
 
 /* misc.c */
 int egg_strcatn(char *, const char *, size_t);
-int my_strcpy(char *, char *);
+int my_strcpy(char *, const char *);
 void putlog(int type, char *chname, const char *format, ...) ATTRIBUTE_FORMAT(printf,3,4);
 void check_logsize(void);
 void splitc(char *, char *, char);

--- a/src/proto.h
+++ b/src/proto.h
@@ -103,7 +103,7 @@ void tell_verbose_status(int);
 void tell_settings(int);
 int logmodes(char *);
 int isowner(char *);
-char *masktype(int);
+const char *masktype(int);
 char *maskname(int);
 void reaffirm_owners(void);
 void add_hq_user(void);
@@ -124,7 +124,7 @@ int check_dcc_attrs(struct userrec *, int);
 int check_dcc_chanattrs(struct userrec *, char *, int, int);
 int check_int_range(char *value, int min, int max);
 int stripmodes(char *);
-char *stripmasktype(int);
+const char *stripmasktype(int);
 char *check_validpass(struct userrec *, char *);
 void cmd_die(struct userrec *, int, char *);
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix function types

Additional description (if needed):
Some function types in eggdrop did not match.
Like a function parameter is declared as `const char*` in one place, but `char*` in another place.

Test cases demonstrating functionality (if applicable):
Fixes undefined behavior like:
```
.rehash
[19:42:49] tcl: builtin dcc call: *dcc:rehash -HQ 1 
[19:42:49] #-HQ# rehash
Rehashing.
[19:42:49] Writing user file...
.././console.mod/console.c:110:27: runtime error: call to function masktype through pointer to incorrect function type 'const char *(*)(int)'
/home/michael/projects/eggdrop/src/flags.c:142: note: masktype defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior .././console.mod/console.c:110:27 
.././console.mod/console.c:111:15: runtime error: call to function stripmasktype through pointer to incorrect function type 'const char *(*)(int)'
/home/michael/projects/eggdrop/src/cmds.c:2581: note: stripmasktype defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior .././console.mod/console.c:111:15 
```