### PR TITLE
strncpy() + manual NULL terminating -> strlcpy()

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -88,8 +88,7 @@ void addbot(char *who, char *from, char *next, char flag, int vernum, int ssl)
     ptr = &((*ptr)->next);
   }
   ptr2 = nmalloc(sizeof(tand_t));
-  strncpy(ptr2->bot, who, HANDLEN);
-  ptr2->bot[HANDLEN] = 0;
+  strlcpy(ptr2->bot, who, sizeof ptr2->bot);
   ptr2->share = flag;
   ptr2->ver = vernum;
   ptr2->next = *ptr;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
`strncpy()` + manual `NULL` terminating -> `strlcpy()`

Additional description (if needed):
Old code uses `strncpy()` combined with manual `NULL` terminating.
This is exactly what `strlcpy()` is good for.
So lets replace the few remaining `strncpys()` and test each of those code pathes.

Test cases demonstrating functionality (if applicable):
1st commit was tested by linking 2 bots. In this case `addbot()` is called and the new code is executed. `HANDLEN + 1` == `sizeof ptr2->bot` == `33`.