### PR TITLE
Fix and enhance error logging

### DIFF
--- a/src/mod/ident.mod/ident.c
+++ b/src/mod/ident.mod/ident.c
@@ -161,10 +161,8 @@ static void ident_oidentd()
       }
     }
     fclose(fd);
-  } else {
-    putlog(LOG_MISC, "*", "IDENT: oident.conf missing, or error opening "
-            "for reading");
-  }
+  } else if (errno != ENOENT)
+    putlog(LOG_MISC, "*", "IDENT error: fopen(%s): %s", path, strerror(errno));
   /* To minimize a known race condition, this code is called now */
   servidx = -1;
   for (i = 0; i < dcc_total; i++)

--- a/src/net.c
+++ b/src/net.c
@@ -547,7 +547,7 @@ int open_telnet_raw(int sock, sockname_t *addr)
   socklen_t res_len;
   fd_set sockset;
   struct timeval tv;
-  int i, j, rc, res;
+  int i, j, rc, errno_tmp, res;
   struct threaddata *td = threaddata();
 
   for (i = 0; i < dcc_total; i++)
@@ -576,7 +576,9 @@ int open_telnet_raw(int sock, sockname_t *addr)
    * rc < 0 and errno == EINPROGRESS)
    */
   if (dcc[i].status & STAT_SERV) {
+    errno_tmp = errno;
     check_tcl_event("ident");
+    errno = errno_tmp;
   }
   if (rc < 0) {
     if (errno == EINPROGRESS) {


### PR DESCRIPTION
Found by: [tuvok81](https://github.com/tuvok81)
Patch by: michaelortmann
Fixes: #1742

One-line summary:


Additional description (if needed):
if `.oidentd.conf` doesnt exist (yet), eggdrop will create it. This case is not an error and should not be logged as one.

(oops, i removed some additional description  here by accident post merge)

Test cases demonstrating functionality (if applicable):
```
loadmodule ident
set ident-method 0
```
Before:
```
rm ~/.oidentd.conf
$ ./eggdrop -t BotA.conf
[...]
[14:11:46] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 6697 ssl 1
[14:11:46] IDENT: oident.conf missing, or error opening for reading
[14:11:46] Failed connect to 127.0.0.1 (No such file or directory)
```
After:
```
rm ~/.oidentd.conf
$ ./eggdrop -t BotA.conf
[...]
[14:12:32] net: open_telnet_raw(): idx 4 host 127.0.0.1 ip 127.0.0.1 port 6697 ssl 1
[14:12:32] net: attempted socket connection refused: 127.0.0.1:6697
[14:12:32] Failed connect to 127.0.0.1 (Connection refused)
```