### PR TITLE
Fix compiler warning / discarded const qualifier

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -181,7 +181,7 @@ int egg_strcatn(char *dst, const char *src, size_t max)
 
 int my_strcpy(char *a, const char *b)
 {
-  char *c = b;
+  const char *c = b;
 
   while (*b)
     *a++ = *b++;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Followup to #1737

Additional description (if needed):
Fixes a regression (compiler warning) of #1737

Test cases demonstrating functionality (if applicable):
Fixes:
```
gcc -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include  -c misc.c
misc.c: In function ‘my_strcpy’:
misc.c:184:13: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  184 |   char *c = b;
      |             ^
```