### PR TITLE
Do not add channel with bogus option

### DIFF
--- a/src/mod/channels.mod/tclchan.c
+++ b/src/mod/channels.mod/tclchan.c
@@ -2169,12 +2169,15 @@ static int tcl_channel_add(Tcl_Interp *irp, char *newname, char *options)
     ret = TCL_ERROR;
   }
   Tcl_Free((char *) item);
-  if (join && !channel_inactive(chan) && module_find("irc", 0, 0)) {
-    if (chan->key_prot[0])
-      dprintf(DP_SERVER, "JOIN %s %s\n", chan->dname, chan->key_prot);
-    else
-      dprintf(DP_SERVER, "JOIN %s\n", chan->dname);
-  }
+  if (ret == TCL_OK) {
+    if (join && !channel_inactive(chan) && module_find("irc", 0, 0)) {
+      if (chan->key_prot[0])
+        dprintf(DP_SERVER, "JOIN %s %s\n", chan->dname, chan->key_prot);
+      else
+        dprintf(DP_SERVER, "JOIN %s\n", chan->dname);
+    }
+  } else
+    remove_channel(chan);
   return ret;
 }
 


### PR DESCRIPTION
Found by: [fred0r](https://github.com/fred0r)
Patch by: michaelortmann
Fixes: #974

One-line summary:
Do not add channel with bogus option

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Before:
```
.+chan #bogusfoo +bogusbar
[04:46:39] tcl: builtin dcc call: *dcc:+chan -HQ 1 #bogusfoo +bogusbar
[04:46:39] [!s] JOIN #bogusfoo
Invalid channel or channel options.
[04:46:39] [s->] JOIN #bogusfoo
[...]
```
After:
```
.+chan #bogusfoo +bogusbar
[04:47:40] tcl: builtin dcc call: *dcc:+chan -HQ 1 #bogusfoo +bogusbar
Invalid channel or channel options.
.channel #bogusfoo
[04:47:43] tcl: builtin dcc call: *dcc:channel -HQ 1 #bogusfoo
No such channel.
```