### PR TITLE
(RFC) Crashfix: Do not feed certain bogus utf8 into python bindings

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -875,7 +875,43 @@ int check_tcl_bind(tcl_bind_list_t *tl, const char *match,
            * specified because we want to trigger all binds in a stack.
            */
 
+          if (!strncmp(tc->func_name, "*python:", strlen("*python:"))) {
+            const uint8_t* b = (const uint8_t*) match;
+	    int utf8_error = 0;
+            while (*b) {
+              if (!(*b & 0x80))
+                b++;
+              else if ((*b & 0xe0) == 0xc0) {
+                if (b[1] == 0) {
+                  utf8_error = 1;
+                  break;
+                }
+                b += 2;
+              } else if ((*b & 0xf0) == 0xe0) {
+                if (b[1] == 0 || b[2] == 0) {
+                  utf8_error = 1;
+                  break;
+                }
+                b += 3;
+              } else if ((*b & 0xf8) == 0xf0) {
+                if (b[1] == 0 || b[2] == 0 || b[3] == 0) {
+                  utf8_error = 1;
+                  break;
+                }
+                b += 4;
+              } else {
+                utf8_error = 1;
+                break;
+              }
+            }
+            if (utf8_error) {
+              putlog(LOG_MISC, "*", "bogus utf8, python bind \"%s\" not triggered\n", tc->func_name);
+              continue;
+            }
+          }
+
           tc->hits++;
+
           x = trigger_bind(tc->func_name, param, tm->mask);
 
           if (match_type & BIND_ALTER_ARGS) {


### PR DESCRIPTION
Found by: [BigBadWouf](https://github.com/BigBadWouf)
Patch by: [michaelortmann](https://github.com/michaelortmann)
Fixes: #1711

One-line summary:
Should fix certain crashes like the one reported via #1711

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Instead of crashing, log like:
```
[08:22:27] [@] :testuser!~michael@localhost PRIVMSG #foo :
                                                          [08:22:27] bogus utf8, python bind "*python:pubm:74062bafa29" not triggered
```