### PR TITLE
Fix python.mod make error

### DIFF
--- a/src/mod/python.mod/configure.ac
+++ b/src/mod/python.mod/configure.ac
@@ -1,6 +1,6 @@
 dnl configure.ac: this file is processed by autoconf to produce ./configure.
 
-AC_PREREQ(2.69)
+AC_PREREQ(2.71)
 
 sinclude(../eggmod.m4)
 builtin(include,../../../m4/python.m4)

--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -20,10 +20,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
-#include <datetime.h>
-#include <tcl.h>
-#include "src/mod/module.h"
 
 typedef struct {
   PyObject_HEAD

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -36,7 +36,6 @@
 #include "src/mod/server.mod/server.h"
 #include "python.h"
 
-//static PyObject *pymodobj;
 static PyObject *pirp, *pglobals;
 
 #undef global

--- a/src/mod/python.mod/python.h
+++ b/src/mod/python.mod/python.h
@@ -1,4 +1,3 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#define PY_OK 0
 #undef putserv


### PR DESCRIPTION
Found by: ek
Patch by: michaelortmann
Fixes: #1748

One-line summary:


Additional description (if needed):
The fix is line https://github.com/eggheads/eggdrop/pull/1749/files#diff-70b09a468949878ad0452b979de72b38b34986629934e77ab916a108e8a62fe9L25
The rest of the PR is cleanup.

Test cases demonstrating functionality (if applicable):
I cannot repeat Issue #1748 here. But this PR fixes the underlying issue, see successful test report in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=283584.