### PR TITLE
Fix Darwin / macOS make error / dynamic module loading

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -622,14 +622,17 @@ AC_DEFUN([EGG_CHECK_MODULE_SUPPORT],
       WEIRD_OS="no"
     ;;
     Darwin)
-      # We should support Mac OS X (at least 10.1 and later) now.
-      # Use rld on < 10.1.
-      if test "$ac_cv_func_NSLinkModule" = no; then
-        LOAD_METHOD="rld"
+      # In Mac OS X 10.4, dlopen was rewritten to be a native part of dyld.
+      AC_MSG_CHECKING([darwin version >= 9 with native dlopen])
+      darwin_major_version=`echo $egg_cv_var_system_release | cut -d. -f1`
+      if test $darwin_major_version -ge 9; then
+        AC_MSG_RESULT([yes])
+      else
+        AC_MSG_RESULT([no])
+        LOAD_METHOD="dyld"
+        EGG_DARWIN_BUNDLE
+        EGG_APPEND_VAR(MODULE_XLIBS, $BUNDLE)
       fi
-      LOAD_METHOD="dyld"
-      EGG_DARWIN_BUNDLE
-      EGG_APPEND_VAR(MODULE_XLIBS, $BUNDLE)
     ;;
     Haiku)
       WEIRD_OS="no"

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -627,6 +627,7 @@ AC_DEFUN([EGG_CHECK_MODULE_SUPPORT],
       darwin_major_version=`echo $egg_cv_var_system_release | cut -d. -f1`
       if test $darwin_major_version -ge 9; then
         AC_MSG_RESULT([yes])
+        WEIRD_OS="no"
       else
         AC_MSG_RESULT([no])
         LOAD_METHOD="dyld"


### PR DESCRIPTION
Found by: [barracuda156](https://github.com/barracuda156)
Patch by: [michaelortmann](https://github.com/michaelortmann)
Fixes: #1662

One-line summary:
Use the usual dlopen method, if darwin version >= 9 with native dlopen

Additional description (if needed):
**run `misc/runautotools` when merging (and `misc/runautotools -f` when testing this PR)**

Also for darwin >= 9 switched default built type from static to dynamic and dropped the `WEIRD_OS` mark
Also removed dead old code:
https://github.com/eggheads/eggdrop/blob/028e756076537d7199e152fec29f70db669f67ae/aclocal.m4#L628-L630
rld was overwritten with dyld all the time
also rld is kinda pre posix 2001

Test cases demonstrating functionality (if applicable):
I tested on
`Darwin michaels-iMac-Pro.local 22.6.0 Darwin Kernel Version 22.6.0: Thu Dec  5 23:45:11 PST 2024; root:xnu-8796.141.3.709.7~4/RELEASE_X86_64 x86_64`
which is macOS Ventura 13.7.3
`make eggdrop`
to test dynamic loading of modules successfully.