### PR TITLE
Add SecBSD support

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -618,7 +618,7 @@ AC_DEFUN([EGG_CHECK_MODULE_SUPPORT],
     SunOS)
         WEIRD_OS="no"
     ;;
-    FreeBSD|OpenBSD|NetBSD|DragonFly)
+    FreeBSD|OpenBSD|NetBSD|DragonFly|SecBSD)
       WEIRD_OS="no"
     ;;
     Darwin)
@@ -797,7 +797,7 @@ AC_DEFUN([EGG_CHECK_OS],
         SHLIB_LD="$CC -G -z text"
       fi
     ;;
-    FreeBSD|DragonFly|OpenBSD|NetBSD)
+    FreeBSD|OpenBSD|NetBSD|DragonFly|SecBSD)
       SHLIB_CC="$CC -fPIC"
       SHLIB_LD="$CC -shared"
     ;;

--- a/doc/BUG-REPORT
+++ b/doc/BUG-REPORT
@@ -58,10 +58,10 @@ DO NOT SEND HTML E-MAIL TO THE LISTS.
 3.1) OS type:
      ( ) BeOS
      ( ) Cygwin
-     ( ) Darwin/Mac OS X
+     ( ) Darwin / Mac OS X
      ( ) Dell SVR4
      ( ) DragonFly BSD
-     ( ) FreeBSD/TrueOS
+     ( ) FreeBSD / TrueOS
      ( ) Haiku
      ( ) HP-UX
      ( ) IRIX
@@ -69,11 +69,11 @@ DO NOT SEND HTML E-MAIL TO THE LISTS.
      ( ) Lynx
      ( ) NetBSD
      ( ) NeXT
-     ( ) OpenBSD
+     ( ) OpenBSD / SecBSD
      ( ) OSF/Tru64
      ( ) QNX
      ( ) SINIX
-     ( ) Solaris/SunOS/OpenIndiana
+     ( ) Solaris / SunOS / OpenIndiana
      ( ) Ultrix
      ( ) Windows Subsystem for Linux (WSL)
      ( ) Other - Which? _____________


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add SecBSD to aclocal.m4 so it drops WEIRD_OS mark and builds dynamic by default

Additional description (if needed):
**Please run `misc/runautotools` when merging**

Test cases demonstrating functionality (if applicable):
```
$ ./configure
[...]
Operating System: SecBSD 1.6
IPv6 Support: yes
Tcl version: 8.6.16 (threaded)
SSL/TLS Support: yes (LibreSSL 4.0.0)
Threaded DNS core: yes

If you experience any problems compiling Eggdrop, please read the
compile guide, found in doc/COMPILE-GUIDE.

Type 'make config' to configure the modules, or type 'make iconfig'
to interactively choose which modules to compile.

$ make install
[...]
Installation completed.
```