### PR TITLE
More typo fixes and Roboto font

### DIFF
--- a/doc/sphinx_source/_static/eggdrop.css
+++ b/doc/sphinx_source/_static/eggdrop.css
@@ -2,7 +2,7 @@
 
 div.header .headertitle {
   margin-bottom: 0px;
-  font-family: "Palatino Linotype", serif;
+  font-family: "Roboto Slab", serif;
 }
 div.header .headertitle a {
   color: #2F2F2F;

--- a/doc/sphinx_source/_themes/eggdrop/theme.conf
+++ b/doc/sphinx_source/_themes/eggdrop/theme.conf
@@ -1,3 +1,7 @@
 [theme]
 inherit = agogo
 stylesheet = eggdrop.css
+
+[options]
+bodyfont = "Roboto", sans-serif
+headerfont = "Roboto Slab", serif

--- a/doc/sphinx_source/conf.py
+++ b/doc/sphinx_source/conf.py
@@ -105,7 +105,7 @@ html_theme = 'eggdrop'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {'headerfont':'"Open Sans", sans serif', 'headerlinkcolor':'87bdd8', 'headerbg':'#86AAD3', 'linkcolor':'#336699'}
+html_theme_options = {'headerfont':'"Roboto", sans serif', 'headerlinkcolor':'87bdd8', 'headerbg':'#86AAD3', 'linkcolor':'#336699'}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['_themes']

--- a/doc/sphinx_source/eggdrop.css
+++ b/doc/sphinx_source/eggdrop.css
@@ -2,7 +2,7 @@
 
 div.header .headertitle {
   margin-bottom: 0px;
-  font-family: "Palatino Linotype", serif;
+  font-family: "Roboto Slab", serif;
 }
 div.header .headertitle a {
   color: #2F2F2F;

--- a/doc/sphinx_source/install/readme.rst
+++ b/doc/sphinx_source/install/readme.rst
@@ -159,7 +159,7 @@ Command Line
 Auto-starting Eggdrop
 ---------------------
 
-Systems go down from time to time, taking your Eggdrop along with it. You may not be not around to restart it manually, so you can instead use features of the operating system to automatically restart Eggdrop should it quit for any reason. Eggdrop comes with an autobotchk shell script that can create either a systemd or crontab entry. The systemd option will monitor your Eggdrop and a) start it when the machine boots and b) restart the Eggdrop if it crashes for any reason. The (older) crontab option will check (by default) every 10 minutes to see if your Eggdrop is still running, and attempt to restart it if it is not.
+Systems go down from time to time, taking your Eggdrop along with it. You may not be around to restart it manually, so you can instead use features of the operating system to automatically restart Eggdrop should it quit for any reason. Eggdrop comes with an autobotchk shell script that can create either a systemd or crontab entry. The systemd option will monitor your Eggdrop and a) start it when the machine boots and b) restart the Eggdrop if it crashes for any reason. The (older) crontab option will check (by default) every 10 minutes to see if your Eggdrop is still running, and attempt to restart it if it is not.
 
     To auto-generate a systemd job, from the Eggdrop install directory, simply run::
 

--- a/doc/sphinx_source/modules/writing.rst
+++ b/doc/sphinx_source/modules/writing.rst
@@ -53,9 +53,9 @@ Note: This is for a simple module of 1 source file.
 Module requirements
 -------------------
 
-In most modules, all functions/variables (except global and MODULE_start)
-should be static. This will drastically reduce the size of modules on
-decent systems.
+In most modules, all functions and variables outside functions (except global
+and MODULE_start) should be static. This will drastically reduce the size of
+modules on decent systems.
 
 Throughout this step, MODULE refers to the module name. Note that
   "MODULE_NAME" should literally be "MODULE_NAME".

--- a/doc/sphinx_source/tutorials/userfilesharing.rst
+++ b/doc/sphinx_source/tutorials/userfilesharing.rst
@@ -47,4 +47,4 @@ Lastly, the +g flag is used on both bot records to indicate that Hubalicious is 
 
 One more commonly used flag is the `+a` flag. This flag specifies an alternate hub to connect to in case the primary hub goes down. The alternate hub should be linked to hub and maintain all channel userfiles the hub maintains to ensure there is no desynchronization while the hub bot is down. Should the hub bot go down, and assuming the `+h` flag is set for the hub on a leaf, the leafbost will automatically try to reconnect to the hub every minute, even if it makes a connection with the alternate hub in the meantime. An alternate hub is added the same as a hub, except swapping out the `h` for the `a`: `.botattr AltRock +agp`.
 
-Now that you have a hub and leaf bot successfully connected and sharing userfiles, you can repeat the `On the Leaf Bot`_ section to add additional leafs to your hub.
+Now that you have a hub and leaf bot successfully connected and sharing userfiles, you can repeat that `On the Leaf Bot`_ section to add additional leafs to your hub.

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@
  */
 /*
  * The author (Robey Pointer) can be reached at:  robey@netcom.com
- * NOTE: Robey is no long working on this code, there is a discussion
+ * NOTE: Robey is no longer working on this code, there is a discussion
  * list available at eggheads@eggheads.org.
  */
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
More doc fixes

Additional description (if needed):
not be not -> not be
the -> that
Update fonts to use Roboto* like eggheads.org
Fix writing.rst doc about static variables in modules

Test cases demonstrating functionality (if applicable):
