### PR TITLE
Cleanup tcl_boot()

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1353,8 +1353,7 @@ static int tcl_boot STDVAR
   if (strchr(who, '@') != NULL) {
     char whonick[HANDLEN + 1];
 
-    splitc(whonick, who, '@');
-    whonick[HANDLEN] = 0;
+    splitcn(whonick, who, '@', sizeof whonick);
     if (!strcasecmp(who, botnetnick))
       strlcpy(who, whonick, sizeof who);
     else if (remote_boots > 0) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Cleanup tcl_boot()

Additional description (if needed):

Test cases demonstrating functionality (if applicable):
I cant demo a real bug, but better safe than sorry. Plus its a nice cleanup anyway.