### PR TITLE
Add size-bounded splitcn() to module API

### DIFF
--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -528,6 +528,7 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 /* 324 - 327 */
 #define find_member_from_nick ((memberlist * (*) (char *))global[324])
 #define get_user_from_member ((struct userrec * (*) (memberlist *))global[325])
+#define splitcn ((void (*)(char *, char *, char, size_t))global[326])
 
 
 /* hostmasking */

--- a/src/modules.c
+++ b/src/modules.c
@@ -626,6 +626,7 @@ Function global_table[] = {
 /* 324 - 327 */
   (Function) find_member_from_nick,
   (Function) get_user_from_member,
+  (Function) splitcn,
 };
 
 void init_modules(void)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add size-bounded splitcn() to module API

Additional description (if needed):
I want to use this function in modules like https://github.com/michaelortmann/botnetop.mod

Test cases demonstrating functionality (if applicable):
