### PR TITLE
Fix add_note()

### DIFF
--- a/src/botmsg.c
+++ b/src/botmsg.c
@@ -812,8 +812,6 @@ int add_note(char *to, char *from, char *msg, int idx, int echo)
   }
 
   /* Might be form "sock:nick" */
-  splitc(ssf, from, ':');
-  rmspace(ssf);
   splitc(ss, to, ':');
   rmspace(ss);
   if (!ss[0])


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
```
*** Pirate has changed the topic on channel #scummbar to Have No ReSt
<Pirate> handle cutlass:
<Pirate> note booty map
<Captain> rehash
<Pirate> strip corpse
```

Eggdrop handles/nicks can contain `:` characters as long as it is not the first character. `add_note()` tries to split its function parameter `from`, which can be such a `dcc[idx].nick`, into `sock:nick` at a `:` character. It cannot distinguish whether `from` is a nick containing `:` or whether `from` is of the form `sock:nick`. This is irreparable code. It is also probably dead code, I could not find a caller passing `sock:nick` as a `from` parameter. It splits the `from` parameter in place and destroys the original nick. This PR fixes the situation by removing this irreparably dead and treacherous code.

Test cases demonstrating functionality (if applicable):