### PR TITLE
Wait for ssl handshake to finish before testing / writing to socket

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1402,7 +1402,11 @@ void dequeue_sockets()
   tv.tv_usec = 0;               /* we only want to see if it's ready for writing, no need to actually wait.. */
   for (i = 0; i < td->MAXSOCKS; i++)
     if (!(socklist[i].flags & (SOCK_UNUSED | SOCK_TCL)) &&
-        (socklist[i].handler.sock.outbuf != NULL)) {
+        (socklist[i].handler.sock.outbuf != NULL)
+#ifdef TLS
+	&& !(socklist[i].ssl && !SSL_is_init_finished(socklist[i].ssl))
+#endif
+                                                 ) {
       if (socklist[i].sock > maxfd)
         maxfd = socklist[i].sock;
       FD_SET(socklist[i].sock, &wfds);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Wait for ssl handshake to finish before testing / writing to socket

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Connecting plain to an ssl bot port
Before:
```
[17:14:44] net: connect! sock 5
[17:14:44] TLS: attempting SSL negotiation...
[17:14:44] TLS: handshake start: before SSL initialization
[17:14:44] TLS: accept loop: before SSL initialization
[17:14:44] TLS: awaiting more reads
[17:14:44] TLS: handshake in progress
[17:14:44] TLS: awaiting more reads
[17:14:44] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[17:14:44] Telnet connection: localhost.home.arpa/46045
[17:14:44] net: eof!(write) socket 9 (Broken pipe,32)
[17:14:44] EOF ident connection
[17:14:44] TLS: awaiting more reads
[17:14:45] TLS: awaiting more reads
[17:14:45] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:46] TLS: awaiting more reads
[17:14:46] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:47] TLS: awaiting more reads
[17:14:47] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:48] TLS: awaiting more reads
[17:14:48] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:49] TLS: awaiting more reads
[17:14:49] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:50] TLS: awaiting more reads
[17:14:50] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:51] TLS: awaiting more reads
[17:14:51] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:52] TLS: awaiting more reads
[17:14:52] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:53] TLS: awaiting more reads
[17:14:53] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:54] TLS: awaiting more reads
[17:14:54] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:55] TLS: awaiting more reads
[17:14:55] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:56] TLS: awaiting more reads
[17:14:56] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:57] TLS: awaiting more reads
[17:14:57] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:58] TLS: awaiting more reads
[17:14:58] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:14:59] TLS: awaiting more reads
[17:14:59] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:00] TLS: awaiting more reads
[17:15:00] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:01] TLS: awaiting more reads
[17:15:01] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:02] TLS: awaiting more reads
[17:15:02] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:03] TLS: awaiting more reads
[17:15:03] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:04] TLS: awaiting more reads
[17:15:04] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:05] TLS: awaiting more reads
[17:15:05] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:06] TLS: awaiting more reads
[17:15:06] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:07] TLS: awaiting more reads
[17:15:07] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:08] TLS: awaiting more reads
[17:15:08] dequeue_sockets(): errno = 11 (Resource temporarily unavailable) on 7
[17:15:09] TLS: alert during write: fatal (decode error).
[17:15:09] TLS: awaiting more writes
[17:15:09] net: sockread(): SSL_read() error = error:0A000126:SSL routines::unexpected eof while reading (1)
[17:15:09] net: eof!(read) socket 7
[17:15:09] Lost telnet connection to telnet@localhost.home.arpa/46045
```
After:
```
[17:13:31] net: connect! sock 5
[17:13:31] TLS: attempting SSL negotiation...
[17:13:31] TLS: handshake start: before SSL initialization
[17:13:31] TLS: accept loop: before SSL initialization
[17:13:31] TLS: awaiting more reads
[17:13:31] TLS: handshake in progress
[17:13:31] TLS: awaiting more reads
[17:13:31] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[17:13:31] Telnet connection: localhost.home.arpa/59967
[17:13:31] net: eof!(write) socket 9 (Broken pipe,32)
[17:13:31] EOF ident connection
[17:13:31] TLS: awaiting more reads
[17:13:46] TLS: alert during write: fatal (decode error).
[17:13:46] TLS: awaiting more writes
[17:13:46] net: sockread(): SSL_read() error = error:0A000126:SSL routines::unexpected eof while reading (1)
[17:13:46] net: eof!(read) socket 7
[17:13:46] Lost telnet connection to telnet@localhost.home.arpa/59967
```
