### PR TITLE
Fix connect(), select non block sock for write instead of read

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -586,7 +586,7 @@ int open_telnet_raw(int sock, sockname_t *addr)
       tv.tv_usec = 0;
       FD_ZERO(&sockset);
       FD_SET(sock, &sockset);
-      select(sock + 1, &sockset, NULL, NULL, &tv);
+      select(sock + 1, NULL, &sockset, NULL, &tv);
       res_len = sizeof(res);
       getsockopt(sock, SOL_SOCKET, SO_ERROR, &res, &res_len);
       if (res == EINPROGRESS) /* Operation now in progress */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix connect(), select non block sock for write instead of read, win back 1 sec

Additional description (if needed):
Fix regression from #122 / eggdrop 1.8

Test cases demonstrating functionality (if applicable):
Link 2 bots via ssl
On BotB i do `.link BotA`
Following output is from BotB
Before:
```
[19:50:27] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[19:50:28] TLS: attempting SSL negotiation...
```
There is a block of 1 sec between those 2 lines. exactly 1 sec. caused by a `select()` running into a 1 sec timeout. You can check via `strace -tt`.
After:
```
[19:48:50] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[19:48:50] TLS: attempting SSL negotiation...
```

Now the same with PR [millisec](https://github.com/michaelortmann/eggdrop/tree/millisec) #1087 applied to log with millisecond resolution and with share bot, to show the gain of 2 seconds during connect:
Before:
```
.link BotA
[02:12:37.879] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[02:12:37.879] #-HQ# link BotA
[02:12:37.879] Linking to BotA at 127.0.0.1:3343 ...
[**02:12:37.879**] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[**02:12:38.879**] TLS: attempting SSL negotiation...
[02:12:38.880] TLS: setting the server name indication (SNI) to 127.0.0.1 successful
[02:12:38.880] TLS: handshake start: before SSL initialization
[02:12:38.880] TLS: connect loop: before SSL initialization
[02:12:38.881] TLS: connect loop: SSLv3/TLS write client hello
[02:12:38.881] TLS: awaiting more reads
[02:12:38.881] TLS: handshake in progress
[02:12:38.886] TLS: connect loop: SSLv3/TLS write client hello
[02:12:38.886] TLS: connect loop: SSLv3/TLS read server hello
[02:12:38.886] TLS: connect loop: TLSv1.3 read encrypted extensions
[02:12:38.886] TLS: connect loop: SSLv3/TLS read server certificate request
[02:12:38.886] TLS: peer certificate warning: self-signed certificate
[02:12:38.886] TLS: peer certificate warning: self-signed certificate
[02:12:38.886] TLS: connect loop: SSLv3/TLS read server certificate
[02:12:38.886] TLS: connect loop: TLSv1.3 read server certificate verify
[02:12:38.886] TLS: connect loop: SSLv3/TLS read finished
[02:12:38.886] TLS: connect loop: SSLv3/TLS write change cipher spec
[02:12:38.886] TLS: connect loop: SSLv3/TLS write client certificate
[02:12:38.890] TLS: connect loop: SSLv3/TLS write certificate verify
[02:12:38.890] TLS: connect loop: SSLv3/TLS write finished
[02:12:38.890] TLS: handshake successful. Secure connection established.
[02:12:38.890] TLS: certificate subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:12:38.890] TLS: certificate issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:12:38.890] TLS: certificate SHA1 Fingerprint: 2F:C0:42:2A:FE:50:F1:F0:A1:FC:B5:46:7C:88:94:76:CA:3D:FA:AF
[02:12:38.890] TLS: certificate SHA-256 Fingerprint: 0F:94:89:F9:3D:9B:F5:ED:42:A1:6E:F6:83:81:89:30:27:DA:96:92:EC:4F:0D:3C:6F:7B:F0:DB:69:DB:0E:D5
[02:12:38.890] TLS: certificate valid from Dec 23 01:54:39 2024 GMT to Dec 23 01:54:39 2025 GMT
[02:12:38.890] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[02:12:38.890] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[02:12:38.890] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[02:12:38.890] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:12:38.891] TLS: connect loop: SSL negotiation finished successfully
[02:12:38.891] TLS: connect loop: SSL negotiation finished successfully
[02:12:38.891] TLS: connect loop: SSLv3/TLS read server session ticket
[02:12:38.891] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:12:38.891] TLS: connect loop: SSL negotiation finished successfully
[02:12:38.891] TLS: connect loop: SSL negotiation finished successfully
[02:12:38.891] TLS: connect loop: SSLv3/TLS read server session ticket
[02:12:38.891] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:12:38.891] Received challenge from BotA... sending response ...
[02:12:38.891] Linked to BotA.
[**02:12:38.891**] Downloading user file from BotA
[**02:12:39.892**] TLS: attempting SSL negotiation...
[02:12:39.893] TLS: not setting the server name indication (SNI) because host is an empty string
[02:12:39.893] TLS: handshake start: before SSL initialization
[02:12:39.893] TLS: connect loop: before SSL initialization
[02:12:39.893] TLS: connect loop: SSLv3/TLS write client hello
[02:12:39.893] TLS: awaiting more reads
[02:12:39.893] TLS: handshake in progress
[02:12:39.897] TLS: connect loop: SSLv3/TLS write client hello
[02:12:39.897] TLS: connect loop: SSLv3/TLS read server hello
[02:12:39.897] TLS: connect loop: TLSv1.3 read encrypted extensions
[02:12:39.897] TLS: connect loop: SSLv3/TLS read server certificate request
[02:12:39.897] TLS: peer certificate warning: self-signed certificate
[02:12:39.897] TLS: peer certificate warning: self-signed certificate
[02:12:39.897] TLS: connect loop: SSLv3/TLS read server certificate
[02:12:39.897] TLS: connect loop: TLSv1.3 read server certificate verify
[02:12:39.897] TLS: connect loop: SSLv3/TLS read finished
[02:12:39.897] TLS: connect loop: SSLv3/TLS write change cipher spec
[02:12:39.897] TLS: connect loop: SSLv3/TLS write client certificate
[02:12:39.901] TLS: connect loop: SSLv3/TLS write certificate verify
[02:12:39.901] TLS: connect loop: SSLv3/TLS write finished
[02:12:39.901] TLS: handshake successful. Secure connection established.
[02:12:39.901] TLS: certificate subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:12:39.901] TLS: certificate issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:12:39.901] TLS: certificate SHA1 Fingerprint: 2F:C0:42:2A:FE:50:F1:F0:A1:FC:B5:46:7C:88:94:76:CA:3D:FA:AF
[02:12:39.901] TLS: certificate SHA-256 Fingerprint: 0F:94:89:F9:3D:9B:F5:ED:42:A1:6E:F6:83:81:89:30:27:DA:96:92:EC:4F:0D:3C:6F:7B:F0:DB:69:DB:0E:D5
[02:12:39.901] TLS: certificate valid from Dec 23 01:54:39 2024 GMT to Dec 23 01:54:39 2025 GMT
[02:12:39.901] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[02:12:39.901] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[02:12:39.901] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[02:12:39.901] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[02:12:39.901] net: connect! sock 9
[02:12:39.901] TLS: connect loop: SSL negotiation finished successfully
[02:12:39.901] TLS: connect loop: SSL negotiation finished successfully
[02:12:39.901] TLS: connect loop: SSLv3/TLS read server session ticket
[02:12:39.901] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[02:12:39.901] TLS: connect loop: SSL negotiation finished successfully
[02:12:39.901] TLS: connect loop: SSL negotiation finished successfully
[02:12:39.901] TLS: connect loop: SSLv3/TLS read server session ticket
[02:12:39.901] TLS: Received close notify during read
[02:12:39.901] net: SSL_read(): received shutdown sock 9
[02:12:39.910] Userfile loaded, unpacking...
[02:12:39.910] Userlist transfer complete; switched over.
```

Total time spend to link bot: 2.031 sec

After:
```
.link BotA
[02:16:51.041] tcl: builtin dcc call: *dcc:link -HQ 1 BotA
[02:16:51.041] #-HQ# link BotA
[02:16:51.041] Linking to BotA at 127.0.0.1:3343 ...
[02:16:51.041] net: open_telnet_raw(): idx 3 host 127.0.0.1 ip 127.0.0.1 port 3343 ssl 1
[02:16:51.041] TLS: attempting SSL negotiation...
[02:16:51.042] TLS: setting the server name indication (SNI) to 127.0.0.1 successful
[02:16:51.042] TLS: handshake start: before SSL initialization
[02:16:51.042] TLS: connect loop: before SSL initialization
[02:16:51.042] TLS: connect loop: SSLv3/TLS write client hello
[02:16:51.042] TLS: awaiting more reads
[02:16:51.042] TLS: handshake in progress
[02:16:51.047] TLS: connect loop: SSLv3/TLS write client hello
[02:16:51.047] TLS: connect loop: SSLv3/TLS read server hello
[02:16:51.047] TLS: connect loop: TLSv1.3 read encrypted extensions
[02:16:51.047] TLS: connect loop: SSLv3/TLS read server certificate request
[02:16:51.047] TLS: peer certificate warning: self-signed certificate
[02:16:51.047] TLS: peer certificate warning: self-signed certificate
[02:16:51.047] TLS: connect loop: SSLv3/TLS read server certificate
[02:16:51.047] TLS: connect loop: TLSv1.3 read server certificate verify
[02:16:51.047] TLS: connect loop: SSLv3/TLS read finished
[02:16:51.047] TLS: connect loop: SSLv3/TLS write change cipher spec
[02:16:51.047] TLS: connect loop: SSLv3/TLS write client certificate
[02:16:51.051] TLS: connect loop: SSLv3/TLS write certificate verify
[02:16:51.051] TLS: connect loop: SSLv3/TLS write finished
[02:16:51.051] TLS: handshake successful. Secure connection established.
[02:16:51.051] TLS: certificate subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:16:51.051] TLS: certificate issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:16:51.051] TLS: certificate SHA1 Fingerprint: 2F:C0:42:2A:FE:50:F1:F0:A1:FC:B5:46:7C:88:94:76:CA:3D:FA:AF
[02:16:51.051] TLS: certificate SHA-256 Fingerprint: 0F:94:89:F9:3D:9B:F5:ED:42:A1:6E:F6:83:81:89:30:27:DA:96:92:EC:4F:0D:3C:6F:7B:F0:DB:69:DB:0E:D5
[02:16:51.051] TLS: certificate valid from Dec 23 01:54:39 2024 GMT to Dec 23 01:54:39 2025 GMT
[02:16:51.051] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[02:16:51.051] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[02:16:51.051] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[02:16:51.051] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:16:51.052] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.052] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.052] TLS: connect loop: SSLv3/TLS read server session ticket
[02:16:51.052] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:16:51.052] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.052] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.052] TLS: connect loop: SSLv3/TLS read server session ticket
[02:16:51.052] sockread EAGAIN: 7 11 (Resource temporarily unavailable)
[02:16:51.052] Received challenge from BotA... sending response ...
[02:16:51.052] Linked to BotA.
[02:16:51.052] Downloading user file from BotA
[02:16:51.052] TLS: attempting SSL negotiation...
[02:16:51.054] TLS: not setting the server name indication (SNI) because host is an empty string
[02:16:51.054] TLS: handshake start: before SSL initialization
[02:16:51.054] TLS: connect loop: before SSL initialization
[02:16:51.054] TLS: connect loop: SSLv3/TLS write client hello
[02:16:51.054] TLS: awaiting more reads
[02:16:51.054] TLS: handshake in progress
[02:16:51.057] TLS: connect loop: SSLv3/TLS write client hello
[02:16:51.057] TLS: connect loop: SSLv3/TLS read server hello
[02:16:51.057] TLS: connect loop: TLSv1.3 read encrypted extensions
[02:16:51.057] TLS: connect loop: SSLv3/TLS read server certificate request
[02:16:51.057] TLS: peer certificate warning: self-signed certificate
[02:16:51.057] TLS: peer certificate warning: self-signed certificate
[02:16:51.057] TLS: connect loop: SSLv3/TLS read server certificate
[02:16:51.057] TLS: connect loop: TLSv1.3 read server certificate verify
[02:16:51.057] TLS: connect loop: SSLv3/TLS read finished
[02:16:51.057] TLS: connect loop: SSLv3/TLS write change cipher spec
[02:16:51.057] TLS: connect loop: SSLv3/TLS write client certificate
[02:16:51.061] TLS: connect loop: SSLv3/TLS write certificate verify
[02:16:51.061] TLS: connect loop: SSLv3/TLS write finished
[02:16:51.061] TLS: handshake successful. Secure connection established.
[02:16:51.061] TLS: certificate subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:16:51.061] TLS: certificate issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd
[02:16:51.061] TLS: certificate SHA1 Fingerprint: 2F:C0:42:2A:FE:50:F1:F0:A1:FC:B5:46:7C:88:94:76:CA:3D:FA:AF
[02:16:51.061] TLS: certificate SHA-256 Fingerprint: 0F:94:89:F9:3D:9B:F5:ED:42:A1:6E:F6:83:81:89:30:27:DA:96:92:EC:4F:0D:3C:6F:7B:F0:DB:69:DB:0E:D5
[02:16:51.061] TLS: certificate valid from Dec 23 01:54:39 2024 GMT to Dec 23 01:54:39 2025 GMT
[02:16:51.061] TLS: cipher used: TLS_AES_256_GCM_SHA384, 256 of 256 secret bits used for cipher, TLSv1.3
[02:16:51.061] TLS: cipher details: TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
[02:16:51.061] TLS: diffie–hellman ephemeral key used: X25519, bits 253
[02:16:51.061] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[02:16:51.061] net: connect! sock 9
[02:16:51.061] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.061] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.061] TLS: connect loop: SSLv3/TLS read server session ticket
[02:16:51.061] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[02:16:51.061] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.061] TLS: connect loop: SSL negotiation finished successfully
[02:16:51.061] TLS: connect loop: SSLv3/TLS read server session ticket
[02:16:51.061] sockread EAGAIN: 9 11 (Resource temporarily unavailable)
[02:16:51.061] TLS: Received close notify during read
[02:16:51.061] net: SSL_read(): received shutdown sock 9
[02:16:51.062] Userfile loaded, unpacking...
[02:16:51.062] Userlist transfer complete; switched over.
```

Total time spend to link bot: 0.021 sec

In other words, we are 96 times faster and no io_uring was harmed during the making of this PR.