### PR TITLE
Fix uptime mod status report indention

### DIFF
--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -104,9 +104,9 @@ static void uptime_report(int idx, int details)
     next_update_at = ctime(&next_update);
     next_update_at[strlen(next_update_at) - 1] = 0;
 
-    dprintf(idx, "      %d uptime packet%s sent\n", uptimecount,
+    dprintf(idx, "    %d uptime packet%s sent\n", uptimecount,
             (uptimecount != 1) ? "s" : "");
-    dprintf(idx, "      Approximately %-.2f hours until next update "
+    dprintf(idx, "    Approximately %-.2f hours until next update "
             "(at %s)\n", delta_seconds / 3600.0, next_update_at);
   }
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix uptime mod status report indention

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`.status all`
Before:
```
  Module: uptime, v 1.4
      0 uptime packets sent
      Approximately 6.47 hours until next update (at Thu Feb  6 17:35:09 2025)
  Module: console, v 1.3
  Module: notes, v 2.2
    Notes can be stored in: BotA.notes
    Using 0 bytes of memory
```
After:
```
  Module: uptime, v 1.4
    0 uptime packets sent
    Approximately 6.63 hours until next update (at Thu Feb  6 17:46:22 2025)
  Module: console, v 1.3
  Module: notes, v 2.2
    Notes can be stored in: BotB.notes
    Using 0 bytes of memory
```