### PR TITLE
Fix code / doc about check_botnet_pings()

### DIFF
--- a/src/botnet.c
+++ b/src/botnet.c
@@ -1667,7 +1667,7 @@ struct dcc_table DCC_PRE_RELAY = {
   NULL
 };
 
-/* Once a minute, send 'ping' to each bot -- no exceptions
+/* Every 5 minutes, send 'ping' to each bot -- no exceptions
  */
 void check_botnet_pings()
 {

--- a/src/main.c
+++ b/src/main.c
@@ -594,10 +594,9 @@ static void core_secondly()
     if (i)
       putlog(LOG_MISC, "*", "(!) timer drift -- spun %i minute%s", i, i == 1 ? "" : "s");
     miltime = (nowtm.tm_hour * 100) + (nowtm.tm_min);
-    if (((int) (nowtm.tm_min / 5) * 5) == (nowtm.tm_min)) {     /* 5 min */
+    if (nowtm.tm_min % 5 == 0) { /* Every 5 minutes */
       call_hook(HOOK_5MINUTELY);
       check_botnet_pings();
-
       if (!miltime) {           /* At midnight */
         char s[25];
         int j;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix code/doc about check_botnet_pings()

Additional description (if needed):
code / doc was wrong about `check_botnet_pings()`. Its called every 5 minutes. Also lets just use modulo operation.

Test cases demonstrating functionality (if applicable):
No functional change