### PR TITLE
Fix log of outgoing botnet message

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -454,30 +454,24 @@ static void free_dcc_bot_(int n, void *x)
 static void out_dcc_bot(int idx, char *buf, void *x)
 {
   size_t len = strlen(buf);
-  /* We don't really use x here, so "use it" for the compiler */
-  (void)x;
 
   if (raw_log) {
     /* strip \n from end as putlog appends this */
     char *p = buf, *fnd = NULL;
-
     if (len && buf[len - 1] == '\n') {
       /* Make a copy as buf could be const */
-      fnd = nmalloc(len + 1);
-      strcpy(fnd, buf);
+      fnd = nmalloc(len);
+      memcpy(fnd, buf, len - 1);
+      fnd[len - 1] = 0;
       p = fnd;
     }
-
     if (!strncmp(p, "s ", 2))
       putlog(LOG_BOTSHROUT, "*", "{b->%s} %s", dcc[idx].nick, p + 2);
     else
       putlog(LOG_BOTNETOUT, "*", "[b->%s] %s", dcc[idx].nick, p);
-
     if (fnd)
       nfree(fnd);
-
   }
-
   tputs(dcc[idx].sock, buf, len);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix log of outgoing botnet message

Additional description (if needed):
Fix annoying new line
Fix regression since eggdrop 1.9.2rc1 / #1100

Test cases demonstrating functionality (if applicable):
`.console +*`
On BotB:
`.link BotA`
Following log is on BotA
Before:
```
[08:22:34] [b->BotB] *hello!

[08:22:34] [b->BotB] version 1100006 32 eggdrop v1.10.0+compilecleaning <I.didn't.edit.my.config.file.net>

[08:22:34] [b<-BotB] version 1100006 32 eggdrop v1.10.0+compilecleaning <I.didn't.edit.my.config.file.net>
```
After:
```
[09:40:16] [b->BotB] *hello!
[09:40:16] [b->BotB] version 1100006 32 eggdrop v1.10.0+compilecleaning <I.didn't.edit.my.config.file.net>
[09:40:16] [b<-BotB] version 1100006 32 eggdrop v1.10.0+compilecleaning <I.didn't.edit.my.config.file.net>
```