### PR TITLE
Fix: syncing channel does not trigger event handlers

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2112,7 +2112,10 @@ static int gotjoin(char *from, char *channame)
           else
             putlog(LOG_JOIN | LOG_MISC, chan->dname, "%s joined %s.", nick,
                    chname);
-          reset_chan_info(chan, (CHAN_RESETALL & ~CHAN_RESETTOPIC), 1);
+          reset_chan_info(chan, (CHAN_RESETALL & ~CHAN_RESETTOPIC &
+            (chan->channel.members == 1 ? ~CHAN_RESETWHO : CHAN_RESETALL)), /* do not remove myself again */
+            1);
+
         } else {
           struct chanuserrec *cr;
 


### PR DESCRIPTION
Found by: [wilkowy](https://github.com/wilkowy)
Patch by: michaelortmann
Fixes: #599 

One-line summary:
Fix: syncing channel does not trigger event handlers

Additional description (if needed):
When the bot joins a chan, `gotjoin()` creates a member for the channel member list and then it resets the chan with flags `CHAN_RESETALL`, removing that member again. This PR unsets flag `CHAN_RESETWHO` for this very case, when the member list contains 1 member, which is the bot itself that just got created.

Test cases demonstrating functionality (if applicable):
scripts/599.tcl :
```
proc wilktest:user_kick {nick uhost hand chan whom why} {
	putlog "#DEBUG# user_kick $nick $uhost $hand $chan $whom $why"
	if {[isbotnick $whom]} {
		putlog "#DEBUG# user_kick - me"
		return
	}
	return
}

proc wilktest:chan_mode {nick uhost hand chan mode whom} {
	putlog "#DEBUG# chan_mode $nick $uhost $hand $chan $mode $whom / [isbotnick $whom] [botisop $chan] [wasop $whom $chan] [isop $whom $chan]"
	return
}

bind kick - * wilktest:user_kick
bind mode - *+o* wilktest:chan_mode
```
eggdrop.conf:
`source scripts/599.tcl`
start eggdrop and `.+chan #testchan` and let it join a server
on another irc client, join #testchan before the bot and as soon as the bot joins the channel op it
Before:
The bot will see the op, but not trigger tcl:
`[12:59:22] [@] :testuser!~michael@localhost MODE #testchan +o BotA`
After:
```
[13:00:50] #testchan: mode change '+o BotA' by testuser!~michael@localhost
[13:00:50] triggering bind wilktest:chan_mode
[13:00:50] #DEBUG# chan_mode testuser ~michael@localhost * #testchan +o BotA / 1 1 0 1
```