### PR TITLE
(WIP) Fix type-aliasing-violation

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -59,8 +59,8 @@ static int serverror_quit;      /* Disconnect from server if ERROR
 static time_t lastpingcheck;    /* set when i unidle myself, cleared when
                                  * i get the response */
 static time_t server_online;    /* server connection time */
-static time_t server_cycle_wait;        /* seconds to wait before
-                                         * re-beginning the server list */
+static int server_cycle_wait;   /* seconds to wait before
+                                 * re-beginning the server list */
 static char botrealname[81];    /* realname of bot */
 static int server_timeout;      /* server timeout for connecting */
 static struct server_list *serverlist;  /* old-style queue, still used by


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix type-aliasing-violation

Additional description (if needed):
Found with clang 20.1.0rc1 -fsanitize=type

Here a time_t is interpreted as an int:
https://github.com/eggheads/eggdrop/blob/541e8ac17e549a40e177b5eea54e4abf24629a33/src/mod/server.mod/server.c#L62
https://github.com/eggheads/eggdrop/blob/541e8ac17e549a40e177b5eea54e4abf24629a33/src/tcl.c#L204

There are more such warnings, hence i flagged this PR WIP.

Test cases demonstrating functionality (if applicable):
No functional change