### PR TITLE
Cleanup includes

### DIFF
--- a/src/compat/explicit_bzero.c
+++ b/src/compat/explicit_bzero.c
@@ -47,7 +47,6 @@
 #ifndef __STDC_WANT_LIB_EXT1__ /* SunOS */
 # define __STDC_WANT_LIB_EXT1__ 1
 #endif
-#include <string.h>
 #include "main.h"
 
 /* LCOV_EXCL_START */

--- a/src/compat/inet_aton.c
+++ b/src/compat/inet_aton.c
@@ -89,11 +89,7 @@ static const char rcsid[] = "$Id: inet_addr.c,v 1.5 2005/04/27 04:56:19 sra Exp 
 #endif /* LIBC_SCCS and not lint */
 
 #include <sys/param.h>
-
-#include <netinet/in.h>
 #include <arpa/inet.h>
-
-#include <ctype.h>
 
 /*
  * Check whether "cp" is a valid ascii representation

--- a/src/compat/inet_aton.h
+++ b/src/compat/inet_aton.h
@@ -24,9 +24,6 @@
 #define _EGG_COMPAT_INET_ATON_H
 
 #include "src/main.h"
-#ifdef HAVE_SYS_SOCKET_H
-#  include <sys/socket.h>
-#endif
 #include <netinet/in.h>
 #include <arpa/inet.h>
 

--- a/src/compat/inet_aton.h
+++ b/src/compat/inet_aton.h
@@ -24,7 +24,6 @@
 #define _EGG_COMPAT_INET_ATON_H
 
 #include "src/main.h"
-#include <netinet/in.h>
 #include <arpa/inet.h>
 
 #ifndef HAVE_INET_ATON

--- a/src/compat/snprintf.c
+++ b/src/compat/snprintf.c
@@ -80,8 +80,6 @@
  *
  **************************************************************/
 
-#include <string.h>
-#include <ctype.h>
 #include <sys/types.h>
 
 #ifndef HAVE_VSNPRINTF

--- a/src/dns.c
+++ b/src/dns.c
@@ -26,7 +26,6 @@
 
 #include "main.h"
 #include <netdb.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include "dns.h"
 #ifdef EGG_TDNS

--- a/src/dns.c
+++ b/src/dns.c
@@ -26,7 +26,6 @@
 
 #include "main.h"
 #include <netdb.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include "dns.h"

--- a/src/mem.c
+++ b/src/mem.c
@@ -29,7 +29,6 @@
 #include "main.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <errno.h>
 
 #include "mod/modvals.h"

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -20,8 +20,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <ctype.h>
-
 static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 

--- a/src/mod/pbkdf2.mod/tclpbkdf2.c
+++ b/src/mod/pbkdf2.mod/tclpbkdf2.c
@@ -8,7 +8,6 @@
  */
 
 #include <openssl/err.h>
-#include <string.h>
 
 static char *pbkdf2_encrypt(const char *);
 

--- a/src/mod/server.mod/isupport.c
+++ b/src/mod/server.mod/isupport.c
@@ -21,9 +21,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <ctype.h>
-#include <string.h>
-#include <strings.h>
 #include "src/mod/module.h"
 #include "server.h"
 

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -23,7 +23,6 @@
 #undef answer /* before resolv.h because it could collide with src/mod/module.h
                * (dietlibc) */
 #include <resolv.h> /* base64 encode b64_ntop() and base64 decode b64_pton() */
-#include <string.h>
 #ifdef TLS
   #include <openssl/err.h>
 #endif

--- a/src/mod/server.mod/tclisupport.c
+++ b/src/mod/server.mod/tclisupport.c
@@ -21,8 +21,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <ctype.h>
-
 int tcl_isupport STDOBJVAR;
 static int tcl_isupport_get STDOBJVAR;
 static int tcl_isupport_isset STDOBJVAR;

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -27,7 +27,6 @@
 #include <errno.h>
 #include "src/mod/module.h"
 
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/stat.h>
 

--- a/src/mod/uptime.mod/Makefile
+++ b/src/mod/uptime.mod/Makefile
@@ -28,12 +28,12 @@ distclean: clean
 
 #safety hash
 ../uptime.o: .././uptime.mod/uptime.c .././uptime.mod/uptime.h \
- .././uptime.mod/../module.h ../../../src/main.h ../../../config.h \
+ ../../../src/mod/module.h ../../../src/main.h ../../../config.h \
  ../../../eggint.h ../../../lush.h ../../../src/lang.h \
  ../../../src/eggdrop.h ../../../src/compat/in6.h ../../../src/flags.h \
  ../../../src/cmdt.h ../../../src/tclegg.h ../../../src/tclhash.h \
  ../../../src/chan.h ../../../src/users.h ../../../src/compat/compat.h \
  ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
  ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
- ../../../src/compat/strlcpy.h .././uptime.mod/../modvals.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
  ../../../src/tandem.h .././uptime.mod/../server.mod/server.h

--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -37,7 +37,6 @@
 
 #include "../server.mod/server.h"
 #include <netdb.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -34,7 +34,6 @@
 
 #include "uptime.h"
 #include "src/mod/module.h"
-
 #include "../server.mod/server.h"
 #include <netdb.h>
 #include <arpa/inet.h>

--- a/src/mod/uptime.mod/uptime.c
+++ b/src/mod/uptime.mod/uptime.c
@@ -33,7 +33,8 @@
 #define MAKING_UPTIME
 
 #include "uptime.h"
-#include "../module.h"
+#include "src/mod/module.h"
+
 #include "../server.mod/server.h"
 #include <netdb.h>
 #include <netinet/in.h>
@@ -41,7 +42,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/net.c
+++ b/src/net.c
@@ -33,7 +33,6 @@
 #if HAVE_SYS_SELECT_H
 #  include <sys/select.h>
 #endif
-#include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <errno.h>

--- a/src/net.c
+++ b/src/net.c
@@ -29,7 +29,6 @@
 #include "main.h"
 #include "modules.h"
 #include <limits.h>
-#include <string.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #if HAVE_SYS_SELECT_H

--- a/src/net.c
+++ b/src/net.c
@@ -30,7 +30,6 @@
 #include "modules.h"
 #include <limits.h>
 #include <netdb.h>
-#include <sys/socket.h>
 #if HAVE_SYS_SELECT_H
 #  include <sys/select.h>
 #endif

--- a/src/tcluser.c
+++ b/src/tcluser.c
@@ -23,7 +23,6 @@
 
 #include "main.h"
 #include "modules.h"
-#include "string.h"
 
 extern Tcl_Interp *interp;
 extern struct userrec *userlist;

--- a/src/users.c
+++ b/src/users.c
@@ -34,7 +34,6 @@
 #include "tandem.h"
 
 #include <errno.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 
 extern struct dcc_t *dcc;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Simple cleanup of includes that are already included in `main.h`

Additional description (if needed):
`main.h` is included by `src/mod/module.h` and so on.

Test cases demonstrating functionality (if applicable):
No functional change