### PR TITLE
Sleep less

### DIFF
--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -915,9 +915,7 @@ static int msg_die(char *nick, char *host, struct userrec *u, char *par)
   else
     nuke_server(par);
   write_userfile(-1);
-  /* Give the server 0.5s time to understand */
-  const struct timespec req = { 0, 500000000L };
-  nanosleep(&req, NULL);
+  sleep(1); /* Give the server time to understand. 1s has proven more than enough. */
   egg_snprintf(s, sizeof s, "DEAD BY REQUEST OF %s!%s", nick, host);
   fatal(s, 0);
   return 1;

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -915,7 +915,9 @@ static int msg_die(char *nick, char *host, struct userrec *u, char *par)
   else
     nuke_server(par);
   write_userfile(-1);
-  sleep(1);                     /* Give the server time to understand */
+  /* Give the server 0.5s time to understand */
+  const struct timespec req = { 0, 500000000L };
+  nanosleep(&req, NULL);
   egg_snprintf(s, sizeof s, "DEAD BY REQUEST OF %s!%s", nick, host);
   fatal(s, 0);
   return 1;

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2102,7 +2102,7 @@ static void server_die()
     dprintf(-serv, "%s\n", msg);
     if (raw_log)
       putlog(LOG_SRVOUT, "*", "[->] %s", msg);
-    sleep(2); /* Give the server 2s time to understand */
+    sleep(1); /* Give the server time to understand. 1s should be enough. */
   }
   nuke_server(NULL);
 }

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -2102,7 +2102,7 @@ static void server_die()
     dprintf(-serv, "%s\n", msg);
     if (raw_log)
       putlog(LOG_SRVOUT, "*", "[->] %s", msg);
-    sleep(3);                   /* Give the server time to understand */
+    sleep(2); /* Give the server 2s time to understand */
   }
   nuke_server(NULL);
 }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Sleep less - improve responsiveness user experience

Additional description (if needed):
Lower amount of time we sleep() in some exit/quit situations.
I would favor to remove all such sleeps ;)
But because of historical reasons, lets just lower the amount here.
I checked ircii, irssi and weechat and there is no single sleep in them longer than 2 secs.
mirc removed any sleep a long time ago: https://forums.mirc.com/ubbthreads.php/topics/251851/exit-and-quit-message
Also i argue: why do we sleep in some situations, when in others we dont need to, like `.jump` does not sleep:
```
.jump 127.0.0.1
18:04:33.309994 write(8, "QUIT :changing servers\n", 23) = 23
18:04:33.310534 close(8)                = 0
```

Test cases demonstrating functionality (if applicable):
2 sleeps were modified, so i checked both situations:
1. `/msg <bot> die <passwd>`
2. `kill <pid_of_bot>`