### PR TITLE
Fix format truncation

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -603,14 +603,14 @@ struct dcc_table DCC_FORK_BOT = {
  */
 static int dcc_bot_check_digest(int idx, char *remote_digest)
 {
-  char digest_string[33];       /* 32 for digest in hex + null */
+  char digest_string[35]; /* 32 for digest in hex + null, but also used for (1) */
   unsigned char digest[16];
   int i, ret;
   char *password = get_bot_pass(dcc[idx].user);
 
   if (!password)
     return 1;
-  snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
+  snprintf(digest_string, sizeof digest_string, "<%lx%lx@", (long) getpid(), /* (1) */
            (unsigned long) dcc[idx].timeval);
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && defined(HAVE_EVP_MD5)
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix format truncation

Additional description (if needed):
Found with `gcc  -Wformat-truncation=2`:
```
gcc -std=gnu99 -Wformat-truncation=2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include  -c dcc.c
dcc.c: In function ‘dcc_bot_check_digest’:
dcc.c:613:39: warning: ‘@’ directive output may be truncated writing 1 byte into a region of size between 0 and 30 -Wformat-truncation=]
  613 |   snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
      |                                       ^
dcc.c:613:3: note: ‘snprintf’ output between 5 and 35 bytes into a destination of size 33
  613 |   snprintf(digest_string, 33, "<%lx%lx@", (long) getpid(),
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  614 |            (unsigned long) dcc[idx].timeval);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Test cases demonstrating functionality (if applicable):
