### PR TITLE
Fix mem leak

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2866,7 +2866,7 @@ static int irc_isupport(char *key, char *isset_str, char *value)
 
 static int gotrawt(char *from, char *msg, Tcl_Obj *tags) {
   Tcl_Obj *valueobj;
-  if (TCL_OK != Tcl_DictObjGet(interp, tags, Tcl_NewStringObj("account", -1), &valueobj)) {
+  if (TCL_OK != Tcl_DictObjGet(interp, tags, tcl_account, &valueobj)) {
     putlog(LOG_MISC, "*", "ERROR: irc:rawt called with invalid dictionary");
     return 0;
   }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -65,6 +65,8 @@ static int include_lk = 1;      /* For correct calculation in real_add_mode. */
 
 static char opchars[8];         /* the chars in a /who reply meaning op */
 
+static Tcl_Obj *tcl_account;
+
 #include "chan.c"
 #include "mode.c"
 #include "cmdsirc.c"
@@ -1347,6 +1349,7 @@ static char *irc_close()
   rem_builtins(H_msg, C_msg);
   rem_builtins(H_raw, irc_raw);
   rem_builtins(H_rawt, irc_rawt);
+  Tcl_DecrRefCount(tcl_account);
   rem_builtins(H_isupport, irc_isupport_binds);
   rem_tcl_commands(tclchan_cmds);
   rem_help_reference("irc.help");
@@ -1455,6 +1458,8 @@ char *irc_start(Function *global_funcs)
   add_builtins(H_dcc, irc_dcc);
   add_builtins(H_msg, C_msg);
   add_builtins(H_raw, irc_raw);
+  tcl_account = Tcl_NewStringObj("account", -1);
+  Tcl_IncrRefCount(tcl_account);
   add_builtins(H_rawt, irc_rawt);
   add_builtins(H_isupport, irc_isupport_binds);
   add_tcl_commands(tclchan_cmds);

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1223,6 +1223,7 @@ static void server_activity(int idx, char *tagmsg, int len)
   int ret;
   Tcl_Obj *tagdict = Tcl_NewDictObj();
 
+  Tcl_IncrRefCount(tagdict);
   if (trying_server) {
     strcpy(dcc[idx].nick, "(server)");
     putlog(LOG_SERV, "*", "Connected to %s", dcc[idx].host);
@@ -1268,6 +1269,7 @@ static void server_activity(int idx, char *tagmsg, int len)
   if (!ret) {
     check_tcl_raw(from, code, msgptr);
   }
+  Tcl_DecrRefCount(tagdict);
 }
 
 static int gotping(char *from, char *msg)

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -45,7 +45,6 @@ static int monitor_del (char *nick);
 static int monitor_show(Tcl_Obj *mlist, int mode, char *nick);
 static void monitor_clear();
 int account_notify = 1, extended_join = 1, account_tag = 0;
-Tcl_Obj *ncapeslist;
 
 /* We try to change to a preferred unique nick here. We always first try the
  * specified alternate nick. If that fails, we repeatedly modify the nick
@@ -2361,7 +2360,6 @@ static void server_resolve_success(int servidx)
   /* Start alternate nicks from the beginning */
   altnick_char = 0;
   check_tcl_event("preinit-server");
-  ncapeslist = Tcl_NewListObj(0, NULL);
   /* See if server supports CAP command */
   dprintf(DP_MODE, "CAP LS 302\n");
   if (pass[0])


### PR DESCRIPTION
Found by: @Robby-, [Mystery-X](https://github.com/Mystery-X) (if it is the same issue as #1545)
Patch by: thommey and michaelortmann
Fixes: 

One-line summary:
Fix mem leaks by fixing tcl ref counting (also preventing premature free) / tcl object instantiation

Additional description (if needed):
Could be related (or same issue) to #1545

3 regressions. 1st one since eggdrop 1.9.3 rc1. 2nd one since eggdrop 1.9.4 rc1, 3rd one since eggdrop 1.9.0 rc1.

3rd one was fixed by removing meanwhile unused variable `ncapeslist`.

The first 2 regressions could accumulate memory fast. the 3rd one was only barely noticeable.

Test cases demonstrating functionality (if applicable):
Fixes then following valgrind reports when tcl is compiled with `CFLAGS=-DPURIFY`:
**1.:**
```
==172800== 4,730,448 (1,290,192 direct, 3,440,256 indirect) bytes in 26,879 blocks are definitely lost in loss record 1,948 of 1,948
==172800==    at 0x48457A8: malloc (vg_replace_malloc.c:446)
==172800==    by 0x489B4C5: TclpAlloc (tclAlloc.c:699)
==172800==    by 0x48B5E21: Tcl_Alloc (tclCkalloc.c:1059)
==172800==    by 0x4967770: Tcl_NewDictObj (tclDictObj.c:1377)
==172800==    by 0x5B18711: server_activity (servmsg.c:1224)
==172800==    by 0x13EDF4: mainloop (main.c:787)
==172800==    by 0x140006: main (main.c:1213)
```
**2:**
```
==172800==    by 0x4A054AF: Tcl_NewStringObj (tclStringObj.c:274)
==172800==    by 0x5B42F75: gotrawt (chan.c:2869)
```
**3:**
```
==795488== 1,920 bytes in 40 blocks are definitely lost in loss record 1,875 of 1,938
==795488==    at 0x48457A8: malloc (vg_replace_malloc.c:446)
==795488==    by 0x489B4C5: TclpAlloc (tclAlloc.c:699)
==795488==    by 0x48B5E21: Tcl_Alloc (tclCkalloc.c:1059)
==795488==    by 0x49D543E: Tcl_NewListObj (tclListObj.c:220)
==795488==    by 0x5B19042: server_resolve_success (servmsg.c:2371)
```

Also i did send random server messages to the bot compiled with default flags and default tcl and i sampled the memory usage with ps every some seconds.
**Before:**
```
[michael@zen ~]$ ps uaxww|grep eggdr
michael   774328  0.6  0.0  18292 13896 pts/4    S+   09:51   0:00 ./eggdrop -t BotA.conf
[michael@zen ~]$ ps uaxww|grep eggdr
michael   774328  0.4  0.0  18696 14024 pts/4    S+   09:51   0:00 ./eggdrop -t BotA.conf
[michael@zen ~]$ ps uaxww|grep eggdr
michael   774328  0.5  0.0  19892 15048 pts/4    S+   09:51   0:00 ./eggdrop -t BotA.conf
[michael@zen ~]$ ps uaxww|grep eggdr
michael   774328  0.6  0.0  21660 16840 pts/4    S+   09:51   0:00 ./eggdrop -t BotA.conf
```
**After:**
```
[michael@zen ~]$ ps u|grep eggdr
michael   803856  0.8  0.0  18304 13716 pts/4    S+   22:25   0:00 ./eggdrop -t BotA.conf
```
after flooding the bot with megabytes of random messages:
```
Traffic since last restart
==========================
IRC:
  out: 5.72 KBytes (5.72 KBytes today)
   in: 55.18 MBytes (55.18 MBytes today)
```
memory usage is totally flat now:
```
[michael@zen ~]$ ps u|grep eggdr
michael   803856  0.8  0.0  18404 13716 pts/4    S+   22:25   0:02 ./eggdrop -t BotA.conf
```
and aside from then init-utf stuff no def. lost bytes in valgrind anymore