### PR TITLE
Fix and enhance memory usage regarding log table

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -312,6 +312,14 @@ void tell_verbose_status(int idx)
                "Threaded DNS core is disabled.\n"
 #endif
                "Socket table: %d/%d\n", threaddata()->MAXSOCKS, max_socks);
+  int j = 0;
+  int k = max_logs * sizeof(log_t);
+  for (int i = 0; i < max_logs; i++) {
+    if (logs[i].filename)
+      j++;
+    k += logs[i].szlast_len;
+  }
+  dprintf(idx, "Log table: %d/%d %d bytes\n", j, max_logs, k);
 }
 
 /* Show all internal state variables

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -313,13 +313,13 @@ void tell_verbose_status(int idx)
 #endif
                "Socket table: %d/%d\n", threaddata()->MAXSOCKS, max_socks);
   int j = 0;
-  int k = max_logs * sizeof(log_t);
+  size_t k = max_logs * sizeof(log_t);
   for (int i = 0; i < max_logs; i++) {
     if (logs[i].filename)
       j++;
     k += logs[i].szlast_len;
   }
-  dprintf(idx, "Log table: %d/%d %d bytes\n", j, max_logs, k);
+  dprintf(idx, "Log table: %d/%d %zu bytes\n", j, max_logs, k);
 }
 
 /* Show all internal state variables

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -414,6 +414,11 @@ void chanprog()
         nfree(logs[i].chname);
         logs[i].chname = NULL;
       }
+      if (logs[i].szlast != NULL) {
+        nfree(logs[i].szlast);
+        logs[i].szlast = NULL;
+        logs[i].szlast_len = 0;
+      }
       if (logs[i].f != NULL) {
         fclose(logs[i].f);
         logs[i].f = NULL;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -544,7 +544,7 @@ typedef struct {
   char *szlast;                 /* for 'Last message repeated n times'
                                  * stuff in misc.c/putlog() <cybah>         */
   int szlast_len;               /* sizeof szlast                            */
-  int repeats;                  /* number of times szLast has been repeated */
+  int repeats;                  /* number of times szlast has been repeated */
   unsigned int flags;           /* other flags <rtc>                        */
   FILE *f;                      /* existing file                            */
 } log_t;

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -541,8 +541,9 @@ typedef struct {
   char *filename;
   unsigned int mask;            /* what to send to this log                 */
   char *chname;                 /* which channel                            */
-  char szlast[LOGLINELEN];      /* for 'Last message repeated n times'
+  char *szlast;                 /* for 'Last message repeated n times'
                                  * stuff in misc.c/putlog() <cybah>         */
+  int szlast_len;               /* sizeof szlast                            */
   int repeats;                  /* number of times szLast has been repeated */
   unsigned int flags;           /* other flags <rtc>                        */
   FILE *f;                      /* existing file                            */
@@ -732,6 +733,13 @@ enum {
 #ifndef STRINGIFY
 #  define STRINGIFY(x) STRINGIFY1(x)
 #  define STRINGIFY1(x) #x
+#endif
+
+#ifndef MIN
+  #define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+#ifndef MAX
+  #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
 #ifdef EGG_TDNS

--- a/src/misc.c
+++ b/src/misc.c
@@ -95,20 +95,9 @@ void init_misc()
 
   if (max_logs < 1)
     max_logs = 1;
-  if (logs)
-    logs = nrealloc(logs, max_logs * sizeof(log_t));
-  else
-    logs = nmalloc(max_logs * sizeof(log_t));
-  for (; last < max_logs; last++) {
-    logs[last].filename = logs[last].chname = NULL;
-    logs[last].mask = 0;
-    logs[last].f = NULL;
-    /* Added by cybah  */
-    logs[last].szlast[0] = 0;
-    logs[last].repeats = 0;
-    /* Added by rtc  */
-    logs[last].flags = 0;
-  }
+  logs = nrealloc(logs, max_logs * sizeof(log_t));
+  memset(logs + last, 0, (max_logs - last) * sizeof(log_t));
+  last = max_logs;
 }
 
 
@@ -587,7 +576,7 @@ void putlog (int type, char *chname, const char *format, ...)
           /* Check if this is the same as the last line added to
            * the log. <cybah>
            */
-          if (!strcasecmp(out + tsl, logs[i].szlast))
+          if (logs[i].szlast && !strcasecmp(out + tsl, logs[i].szlast))
             /* It is a repeat, so increment repeats */
             logs[i].repeats++;
           else {
@@ -607,7 +596,17 @@ void putlog (int type, char *chname, const char *format, ...)
                */
             }
             fputs(out, logs[i].f);
-            strlcpy(logs[i].szlast, out + tsl, LOGLINEMAX);
+            size_t l = strlen(out + tsl);
+            if (l > logs[i].szlast_len) {
+              if (!logs[i].szlast_len) {
+                logs[i].szlast_len = MIN(MAX(l, 128), LOGLINELEN);
+                logs[i].szlast = nrealloc(logs[i].szlast, logs[i].szlast_len);
+              } else if (logs[i].szlast_len < LOGLINELEN) {
+                logs[i].szlast_len = MIN(MAX(l, logs[i].szlast_len << 1), LOGLINELEN);
+                logs[i].szlast = nrealloc(logs[i].szlast, logs[i].szlast_len);
+              }
+            }
+            strlcpy(logs[i].szlast, out + tsl, logs[i].szlast_len);
           }
         }
       }

--- a/src/misc.c
+++ b/src/misc.c
@@ -86,6 +86,8 @@ int expmem_misc()
     for (item = current->first; item; item = item->next)
       tot += sizeof(struct help_list_t) + strlen(item->name) + 1;
   }
+  for (int i = 0; i < max_logs; i++)
+    tot += logs[i].szlast_len;
   return tot + (max_logs * sizeof(log_t));
 }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -608,7 +608,8 @@ void putlog (int type, char *chname, const char *format, ...)
                 logs[i].szlast = nrealloc(logs[i].szlast, logs[i].szlast_len);
               }
             }
-            strlcpy(logs[i].szlast, out + tsl, logs[i].szlast_len);
+            if (logs[i].szlast)
+              strlcpy(logs[i].szlast, out + tsl, logs[i].szlast_len);
           }
         }
       }

--- a/src/misc.c
+++ b/src/misc.c
@@ -598,7 +598,7 @@ void putlog (int type, char *chname, const char *format, ...)
                */
             }
             fputs(out, logs[i].f);
-            size_t l = strlen(out + tsl);
+            size_t l = strlen(out + tsl) + 1;
             if (l > logs[i].szlast_len) {
               if (!logs[i].szlast_len) {
                 logs[i].szlast_len = MIN(MAX(l, 128), LOGLINELEN);

--- a/src/mod/server.mod/sasl.c
+++ b/src/mod/server.mod/sasl.c
@@ -540,9 +540,6 @@ static int gotauthenticate(char *from, char *msg)
   char error_msg[1050]; /* snprintf() truncation should be tolerable */
   int server_msg_plain_len;
 #endif
-  #ifndef MAX
-  #define MAX(a,b) (((a)>(b))?(a):(b))
-  #endif
   char client_msg_b64[((MAX((sizeof client_msg_plain), 400) + 2) / 3) << 2] = "";
 
   fixcolon(msg); /* Because Inspircd does its own thing */

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1342,9 +1342,6 @@ static int tryauthenticate(char *from, char *msg)
   char *s;
   /* 400-byte chunk, see: https://ircv3.net/specs/extensions/sasl-3.1.html
    * base64 padding */
-  #ifndef MAX
-    #define MAX(a,b) (((a)>(b))?(a):(b))
-  #endif
   unsigned char dst[((MAX((sizeof src), 400) + 2) / 3) << 2] = "";
 #ifdef HAVE_EVP_PKEY_GET1_EC_KEY
   int olen;

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -107,6 +107,11 @@ static int tcl_logfile STDVAR
           logs[i].f = NULL;
         }
         logs[i].flags = 0;
+        if (logs[i].szlast != NULL) {
+          nfree(logs[i].szlast);
+          logs[i].szlast = NULL;
+          logs[i].szlast_len = 0;
+        }
       } else {
         logs[i].chname = nmalloc(strlen(argv[2]) + 1);
         strcpy(logs[i].chname, argv[2]);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance memory usage regarding log table - Fix regression since eggdrop 1.9.0rc1

Additional description (if needed):
This PR not only fixes the regression since eggdrop 1.9.0rc1, but makes eggdrop even better than before regarding amount of memory allocation for log table
During eggdrop startup, memory for log tables is allocated:
https://github.com/eggheads/eggdrop/blob/341477a3fba56ec1b3f5a5b67fee3dec35878f2c/src/misc.c#L92-L101
about `max-logs * LOGLINELEN` bytes
default `max-logs` is `20`
`LOGLINELEN` was rised from `1024` to `9000` since eggdrop 1.9.0rc1
`20 * 9000 = 180 kbytes`
Users probably raise `max-logs` to `100` or more in their configuration files so they wont have to care about it anymore, not aware of the memory usage implications.

This PR makes eggdrop to still allocate memory for `max-logs` log tables. but only about 56 bytes per table / logfile static. `szlast` (last log messages to track repeats) will be allocated (grow) dynamically until `LOGLINELEN`.

`.status` will now show the log table information, similar to socket table (and memory table, if debug enabled)

Add MIN() and MAX() to eggdrop.h

Test cases demonstrating functionality (if applicable):
```
$ grep max-logs BotA.conf 
set max-logs 100
```
Before:
```
[michael@zen ~]$ ps u|grep egg
michael   861664  0.0  0.0  18556 13664 pts/4    S+   04:41   0:00 ./eggdrop -t BotA.conf
```
After:
```
[michael@zen ~]$ ps u|grep egg
michael   862487  0.0  0.0  17668 12956 pts/4    S+   04:42   0:00 ./eggdrop -t BotA.conf

.status
Log table: 1/100 5728 bytes
```