### PR TITLE
Fix telnet mode / esc codes for stdout

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -678,7 +678,7 @@ void add_hq_user()
     dcc[term_z].user->flags = USER_EXEMPT | USER_FRIEND | USER_JANITOR |
                               USER_HALFOP | USER_MASTER | USER_OWNER | USER_OP |
                               USER_PARTY | USER_BOTMAST | USER_UNSHARED |
-                              USER_VOICE | USER_XFER;
+                              USER_VOICE | USER_XFER | USER_HIGHLITE;
     /* Add to permowner list if there's place */
     if (strlen(owner) + sizeof EGG_BG_HANDLE < sizeof owner)
       strcat(owner, " " EGG_BG_HANDLE);

--- a/src/main.c
+++ b/src/main.c
@@ -1175,10 +1175,10 @@ int main(int arg_c, char **arg_v)
     dcc[term_z].u.chat->con_flags = conmask | EGG_BG_CONMASK;
     dcc[term_z].status = STAT_ECHO;
     if (isatty(dcc[term_z].sock)) {
-      putlog(LOG_DEBUG, "*", "stdout is a tty");
+      debug0("stdout is a tty");
       dcc[term_z].status |= STAT_TELNET;
     } else {
-      putlog(LOG_DEBUG, "*", "stdout is no tty");
+      debug0("stdout is no tty");
       dcc[term_z].u.chat->strip_flags = STRIP_ALL;
     }
     strcpy(dcc[term_z].nick, EGG_BG_HANDLE);

--- a/src/main.c
+++ b/src/main.c
@@ -1172,8 +1172,14 @@ int main(int arg_c, char **arg_v)
     dcc[term_z].sock = STDOUT;
     dcc[term_z].timeval = now;
     dcc[term_z].u.chat->con_flags = conmask | EGG_BG_CONMASK;
-    dcc[term_z].u.chat->strip_flags = STRIP_ALL;
     dcc[term_z].status = STAT_ECHO;
+    if (isatty(dcc[term_z].sock)) {
+      putlog(LOG_DEBUG, "*", "stdout is a tty");
+      dcc[term_z].status |= STAT_TELNET;
+    } else {
+      putlog(LOG_DEBUG, "*", "stdout is no tty");
+      dcc[term_z].u.chat->strip_flags = STRIP_ALL;
+    }
     strcpy(dcc[term_z].nick, EGG_BG_HANDLE);
     strcpy(dcc[term_z].host, "llama@console");
     add_hq_user();


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix telnet mode / esc codes for stdout

Additional description (if needed):
Enable telnet mode / do not strip esc codes if stdout is a tty

Dont you worry, even your moms vt100 from 1978 supports the esc codes / telnet codes we use.

This issue is user facing. It has been bothering me for a long time.

Test cases demonstrating functionality (if applicable):
left side: before, right side: after
https://imgur.com/a/N24vu08

in other words:
Start the bot into dcc chat simulation (HQ), like:
`./eggdrop -t bot.conf`
Before:
HQs telnet mode will be off. so for example HQ via tty will not see bold text in motd.
After:
if eggdrop detects stdout is a tty, it will enable telnet mode. so HQ will see bold text in motd.