### PR TITLE
Fix debug mem accounting for tcl.c

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -358,6 +358,7 @@ void add_cd_tcl_cmds(cd_tcl_cmd *table)
   while (table->name) {
     if (table->cdata) {
       info = nmalloc(sizeof *info);
+      strtot += sizeof(struct tcl_call_stringinfo);
       info->proc = table->callback;
       info->cd = table->cdata;
       Tcl_CreateObjCommand(interp, table->name, tcl_call_stringproc_cd, info, tcl_cleanup_stringinfo);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix debug mem accounting for tcl.c

Additional description (if needed):
Regression since eggdrop 1.9.0rc1


Test cases demonstrating functionality (if applicable):
make debug
start eggdrop
.debug
```
File 'tcl.c     ' accounted for 8432/8472 (debug follows:)
```