### PR TITLE
remove colon from accounts, modes

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1205,6 +1205,7 @@ static int got354(char *from, char *msg)
         }
         flags = newsplit(&msg);     /* Grab the flags */
         account = newsplit(&msg);   /* Grab the account name */
+        fixcolon(account);
         got352or4(chan, user, host, nick, flags, account);
       }
     }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -1957,13 +1957,12 @@ static int gotjoin(char *from, char *channame)
 
   strlcpy(uhost, from, sizeof buf);
   nick = splitnick(&uhost);
+  // :nick!user@host JOIN :#chan
   chname = newsplit(&channame);
+  fixcolon(chname);
   if (extjoin) {
     // :nick!user@host JOIN #chan account :realname
     account = newsplit(&channame);
-  } else {
-    // :nick!user@host JOIN :#chan
-    fixcolon(chname);
   }
   chan = findchan_by_dname(chname);
   if (!chan && chname[0] == '!') {

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -1014,6 +1014,7 @@ static int gotmode(char *from, char *origmsg)
       z = strlen(msg);
       if (msg[--z] == ' ')      /* I hate cosmetic bugs :P -poptix */
         msg[z] = 0;
+      fixcolon(msg);
       putlog(LOG_MODES, chan->dname, "%s: mode change '%s %s' by %s", ch, chg,
              msg, from);
       nick = splitnick(&from);


### PR DESCRIPTION
Found by: @Robby- 
Patch by: Geo

One-line summary:
Remove colons from trailing IRC command

Additional description (if needed):
Inspircd v3 started putting :'s on all trailing commands, even if they cannot have a space in them (accounts, nicks, etc). This broke how Eggdrop stored account names sent from WHOX, and nicknames contained in MODE commands.

This is a blunt-force and inelegant patch but it at least fixes the identified issues... there are probably more messages that are needed to be handled but not known at this time, and maybe a larger code revamp could be done. Just not today.

https://docs.inspircd.org/faq/#why-does-my-client-not-show-mode-changesopped-users-on-joinetc-correctly-when-using-inspircd-v3
