### PR TITLE
(WIP) Add new feature: irc server public key fingerprint pinning

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1081,6 +1081,8 @@ server add you.need.to.change.this 6667
 server add another.example.com 6669 password
 server add 2001:db8:618:5c0:263:: 6669 password
 server add ssl.example.net +7000
+# For tls ports the servers public key sha256 fingerprint can be pinned:
+server add example.org +6697,55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88:55:88
 
 #### CAP Features ####
 # This section controls IRCv3 capabilities supported natively by Eggdrop. You

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -352,6 +352,9 @@ struct dcc_t {
     struct dupwait_info *dupwait;
     int ident_sock;
     void *other;
+#ifdef TLS
+    char *fingerprint;
+#endif
   } u;                          /* Special use depending on type        */
 };
 

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1040,6 +1040,12 @@ static int add_server(const char *name, const char *port, const char *pass)
     x->port = atoi(port);
 #ifdef TLS
   x->ssl = (port[0] == '+') ? 1 : 0;
+  char *fingerprint;
+  if (x->ssl && (fingerprint = strchr(port + 1, ',')) && fingerprint[1]) {
+    x->fingerprint = nmalloc(strlen(fingerprint) + 1);
+    strcpy(x->fingerprint, fingerprint + 1);
+  } else
+    x->fingerprint = NULL;
 #endif
   return 0;
 }

--- a/src/mod/server.mod/server.h
+++ b/src/mod/server.mod/server.h
@@ -109,11 +109,11 @@
 
 struct server_list {
   struct server_list *next;
-
   char *name;
   int port;
 #ifdef TLS
   int ssl;
+  char *fingerprint;
 #endif
   char *pass;
   char *realname;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1966,20 +1966,20 @@ static void connect_server(void)
 
 #ifdef IPV6
     if (inet_pton(AF_INET6, botserver, buf)) {
-      len += egg_snprintf(s, sizeof s, "%s [%s]", IRC_SERVERTRY, botserver);
+      len += snprintf(s, sizeof s, "%s [%s]", IRC_SERVERTRY, botserver);
     } else {
 #endif
-     len += egg_snprintf(s, sizeof s, "%s %s", IRC_SERVERTRY, botserver);
+     len += snprintf(s, sizeof s, "%s %s", IRC_SERVERTRY, botserver);
 #ifdef IPV6
     }
 #endif
 
 #ifdef TLS
-    len += egg_snprintf(s + len, sizeof s - len, ":%s%d",
+    len += snprintf(s + len, sizeof s - len, ":%s%d",
             use_ssl ? "+" : "", botserverport);
     dcc[servidx].ssl = use_ssl;
 #else
-    len += egg_snprintf(s + len, sizeof s - len, ":%d", botserverport);
+    len += snprintf(s + len, sizeof s - len, ":%d", botserverport);
 #endif
     putlog(LOG_SERV, "*", "%s", s);
     dcc[servidx].port = botserverport;
@@ -2003,6 +2003,11 @@ static void connect_server(void)
     dcc[servidx].u.dns->dns_type = RES_IPBYHOST;
     dcc[servidx].u.dns->type = &SERVER_SOCKET;
     dcc[servidx].status |= STAT_SERV;
+#ifdef TLS
+    printf("DEBUG: here fingerprint needs to be set to dcc_t entry, so, that tls.c:ssl_info()->sock->dcc->fingerprint can be used, not implemented yet\n");
+    // if (fingerprint)
+    //   dcc[servidx].u.fingerprint = fingerprint;
+#endif
 
     if (server_cycle_wait)
       /* Back to 1st server & set wait time.

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1975,11 +1975,11 @@ static void connect_server(void)
 #endif
 
 #ifdef TLS
-    len += snprintf(s + len, sizeof s - len, ":%s%d",
+    len += snprintf(s + len, sizeof s - len, ":%s%u",
             use_ssl ? "+" : "", botserverport);
     dcc[servidx].ssl = use_ssl;
 #else
-    len += snprintf(s + len, sizeof s - len, ":%d", botserverport);
+    len += snprintf(s + len, sizeof s - len, ":%u", botserverport);
 #endif
     putlog(LOG_SERV, "*", "%s", s);
     dcc[servidx].port = botserverport;

--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -1975,8 +1975,8 @@ static void connect_server(void)
 #endif
 
 #ifdef TLS
-    len += snprintf(s + len, sizeof s - len, ":%s%u",
-            use_ssl ? "+" : "", botserverport);
+    len += snprintf(s + len, sizeof s - len, ":%s%u", use_ssl ? "+" : "",
+                    botserverport);
     dcc[servidx].ssl = use_ssl;
 #else
     len += snprintf(s + len, sizeof s - len, ":%u", botserverport);

--- a/src/tls.c
+++ b/src/tls.c
@@ -648,7 +648,7 @@ static void ssl_showcert(X509 *cert, const int loglev)
   } else
     putlog(loglev, "*", "TLS: cannot get issuer name from certificate!");
 
-  /* Fingerprints */
+  /* Certificate fingerprints */
   if (X509_digest(cert, EVP_sha1(), md, &len)) {
     buf = OPENSSL_buf2hexstr(md, len);
     putlog(loglev, "*", "TLS: certificate SHA1 Fingerprint: %s", buf);
@@ -656,10 +656,9 @@ static void ssl_showcert(X509 *cert, const int loglev)
   }
   if (X509_digest(cert, EVP_sha256(), md, &len)) {
     buf = OPENSSL_buf2hexstr(md, len);
-    putlog(loglev, "*", "TLS: certificate SHA-256 Fingerprint: %s", buf);
+    putlog(loglev, "*", "TLS: certificate SHA256 Fingerprint: %s", buf);
     OPENSSL_free(buf);
   }
-
 
   /* Validity time */
   from = ssl_printtime(X509_get_notBefore(cert));
@@ -667,6 +666,13 @@ static void ssl_showcert(X509 *cert, const int loglev)
   putlog(loglev, "*", "TLS: certificate valid from %s to %s", from, to);
   nfree(from);
   nfree(to);
+
+  /* Public key fingerprint */
+  if (X509_pubkey_digest(cert, EVP_sha256(), md, &len)) {
+    buf = OPENSSL_buf2hexstr(md, len);
+    putlog(loglev, "*", "TLS: public key SHA256 Fingerprint: %s", buf);
+    OPENSSL_free(buf);
+  }
 }
 
 /* Certificate validation callback
@@ -768,6 +774,24 @@ static void ssl_info(const SSL *ssl, int where, int ret)
     /* Callback for completed handshake. Cheaper and more convenient than
        using H_tls */
     sock = SSL_get_fd(ssl);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    cert = SSL_get0_peer_certificate(ssl);
+#else
+    cert = SSL_get_peer_certificate(ssl);
+#endif
+
+    /* Verify public key fingerprint */
+    int idx = findanyidx(sock);
+    if (dcc[idx].u.fingerprint) {
+      unsigned char md[EVP_MAX_MD_SIZE];
+      unsigned int len;
+      if (X509_pubkey_digest(cert, EVP_sha256(), md, &len)) {
+        char *fingerprint2 = OPENSSL_buf2hexstr(md, len);
+        OPENSSL_free(fingerprint2);
+      }
+      printf("DEBUG: Verifying public key fingerprint not implemented yet: %s\n", dcc[idx].u.fingerprint);
+    }
+
     if (data->cb)
       data->cb(sock);
     /* Call TLS binds. We allow scripts to take over or disable displaying of
@@ -778,9 +802,11 @@ static void ssl_info(const SSL *ssl, int where, int ret)
     putlog(data->loglevel, "*", "TLS: handshake successful. Secure connection "
            "established.");
 
-    if ((cert = SSL_get_peer_certificate(ssl))) {
+    if (cert) {
       ssl_showcert(cert, LOG_DEBUG);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
       X509_free(cert);
+#endif
     }
     else
       putlog(data->loglevel, "*", "TLS: peer did not present a certificate");

--- a/src/tls.c
+++ b/src/tls.c
@@ -790,6 +790,11 @@ static void ssl_info(const SSL *ssl, int where, int ret)
         OPENSSL_free(fingerprint2);
       }
       printf("DEBUG: Verifying public key fingerprint not implemented yet: %s\n", dcc[idx].u.fingerprint);
+      // if (crypto_verify(fingerprint, fingerprint2)); /* verify not successful */
+      //   MAYBE THIS IS NOT THE RIGHT PLACE AT ALL TO VERIFY AND/OR SHUTDOWN THEN connection
+      //   MAYBE WE NEED TO DO IT AT A LATER POINT? BUT WE WANT MOST LOGIC / PROCEEDIGN TO STOP HERE ALREADY
+      //   SSL_shutdown(ssl);
+      //   close(sock);
     }
 
     if (data->cb)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Add irc server public key fingerprint pinning

Additional description (if needed):
Similar to irssi `-tls_pinned_pubkey`
Also fix deprecation of `SSL_get_peer_certificate()` since openssl 3.0 

Test cases demonstrating functionality (if applicable):
