### PR TITLE
Fix leak for openssl > 3.0 and fix all openssl deprecations

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -297,7 +297,11 @@ void tell_verbose_status(int idx)
   #elif !defined HAVE_EVP_PKEY_GET1_EC_KEY && !defined HAVE_OPENSSL_MD5
                "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no elliptic curve or MD5 support)\n",
   #endif
+  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+          OpenSSL_version(OPENSSL_VERSION), MISC_HEADERVERSION);
+  #else
           SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);
+  #endif
 #else
   dprintf(idx, "TLS support is not available.\n");
 #endif

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -297,7 +297,7 @@ void tell_verbose_status(int idx)
   #elif !defined HAVE_EVP_PKEY_GET1_EC_KEY && !defined HAVE_OPENSSL_MD5
                "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no elliptic curve or MD5 support)\n",
   #endif
-  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
           OpenSSL_version(OPENSSL_VERSION), MISC_HEADERVERSION);
   #else
           SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);

--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -297,7 +297,7 @@ void tell_verbose_status(int idx)
   #elif !defined HAVE_EVP_PKEY_GET1_EC_KEY && !defined HAVE_OPENSSL_MD5
                "TLS library: %s (%s " OPENSSL_VERSION_TEXT ")\n             (no elliptic curve or MD5 support)\n",
   #endif
-  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
+  #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
           OpenSSL_version(OPENSSL_VERSION), MISC_HEADERVERSION);
   #else
           SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -786,7 +786,7 @@ static int tcl_status STDVAR
   if ((argc < 2) || !strcmp(argv[1], "tls")) {
     Tcl_AppendElement(irp, "tls");
 #ifdef TLS
-  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
     Tcl_AppendElement(irp, OpenSSL_version(OPENSSL_VERSION));
   #else
     Tcl_AppendElement(irp, SSLeay_version(SSLEAY_VERSION));

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -786,7 +786,11 @@ static int tcl_status STDVAR
   if ((argc < 2) || !strcmp(argv[1], "tls")) {
     Tcl_AppendElement(irp, "tls");
 #ifdef TLS
+  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+    Tcl_AppendElement(irp, OpenSSL_version(OPENSSL_VERSION));
+  #else
     Tcl_AppendElement(irp, SSLeay_version(SSLEAY_VERSION));
+  #endif
 #else
     Tcl_AppendElement(irp, "disabled");
 #endif

--- a/src/tclmisc.c
+++ b/src/tclmisc.c
@@ -786,7 +786,7 @@ static int tcl_status STDVAR
   if ((argc < 2) || !strcmp(argv[1], "tls")) {
     Tcl_AppendElement(irp, "tls");
 #ifdef TLS
-  #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
+  #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
     Tcl_AppendElement(irp, OpenSSL_version(OPENSSL_VERSION));
   #else
     Tcl_AppendElement(irp, SSLeay_version(SSLEAY_VERSION));

--- a/src/tls.c
+++ b/src/tls.c
@@ -593,7 +593,7 @@ static char *ssl_printname(X509_NAME *name)
  *
  * You need to nfree() the returned pointer.
  */
-static char *ssl_printtime(ASN1_UTCTIME *t)
+static char *ssl_printtime(const ASN1_UTCTIME *t)
 {
   long len;
   char *data, *buf;
@@ -691,8 +691,13 @@ static void ssl_showcert(X509 *cert, const int loglev)
 
 
   /* Validity time */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
+  from = ssl_printtime(X509_get0_notBefore(cert));
+  to = ssl_printtime(X509_get0_notAfter(cert));
+#else
   from = ssl_printtime(X509_get_notBefore(cert));
   to = ssl_printtime(X509_get_notAfter(cert));
+#endif
   putlog(loglev, "*", "TLS: certificate valid from %s to %s", from, to);
   nfree(from);
   nfree(to);
@@ -1113,11 +1118,19 @@ static int tcl_tlsstatus STDVAR
     Tcl_DStringAppendElement(&ds, "issuer");
     Tcl_DStringAppendElement(&ds, p);
     nfree(p);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
+    p = ssl_printtime(X509_get0_notBefore(cert));
+#else
     p = ssl_printtime(X509_get_notBefore(cert));
+#endif
     Tcl_DStringAppendElement(&ds, "notBefore");
     Tcl_DStringAppendElement(&ds, p);
     nfree(p);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
+    p = ssl_printtime(X509_get0_notAfter(cert));
+#else
     p = ssl_printtime(X509_get_notAfter(cert));
+#endif
     Tcl_DStringAppendElement(&ds, "notAfter");
     Tcl_DStringAppendElement(&ds, p);
     nfree(p);

--- a/src/tls.c
+++ b/src/tls.c
@@ -343,7 +343,11 @@ static X509 *ssl_getcert(int sock)
   i = findsock(sock);
   if (i == -1 || !td->socklist[i].ssl)
     return NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L /* 3.0.0 */
+  return SSL_get0_peer_certificate(td->socklist[i].ssl);
+#else
   return SSL_get_peer_certificate(td->socklist[i].ssl);
+#endif
 }
 
 /* Get the certificate fingerprint of the connection corresponding
@@ -363,16 +367,19 @@ char *ssl_getfp(int sock)
   if (!(cert = ssl_getcert(sock)))
     return NULL;
   if (!X509_digest(cert, EVP_sha1(), md, &i)) {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* 3.0.0 */
     X509_free(cert);
+#endif
     return NULL;
   }
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* 3.0.0 */
+  X509_free(cert);
+#endif
   if (!(p = OPENSSL_buf2hexstr(md, i))) {
-    X509_free(cert);
     return NULL;
   }
   strlcpy(fp, p, sizeof fp);
   OPENSSL_free(p);
-  X509_free(cert);
   return fp;
 }
 
@@ -391,15 +398,27 @@ const char *ssl_getuid(int sock)
   if (!(cert = ssl_getcert(sock)))
     return NULL;
   /* Get the subject name */
-  if (!(subj = X509_get_subject_name(cert)))
+  if (!(subj = X509_get_subject_name(cert))) {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* 3.0.0 */
+    X509_free(cert);
+#endif
     return NULL;
+  }
 
   /* Get the first UID */
   idx = X509_NAME_get_index_by_NID(subj, NID_userId, -1);
-  if (idx == -1)
+  if (idx == -1) {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* 3.0.0 */
+    X509_free(cert);
+#endif
     return NULL;
+  }
   name = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subj, idx));
   /* Extract the contents, assuming null-terminated ASCII string */
+  /* For openssl < 3.0.0 we leak cert here, but we cant free cert here
+   * because we return an internal pointer of certificate
+   * also this function is only triggered in dcc_telnet_id()
+   * and only for ssl-cert-auth set to 2 */
   return (const char *) egg_ASN1_string_data(name);
 }
 
@@ -788,9 +807,14 @@ static void ssl_info(const SSL *ssl, int where, int ret)
     putlog(data->loglevel, "*", "TLS: handshake successful. Secure connection "
            "established.");
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L /* 3.0.0 */
+    if ((cert = SSL_get0_peer_certificate(ssl))) {
+      ssl_showcert(cert, LOG_DEBUG);
+#else
     if ((cert = SSL_get_peer_certificate(ssl))) {
       ssl_showcert(cert, LOG_DEBUG);
       X509_free(cert);
+#endif
     }
     else
       putlog(data->loglevel, "*", "TLS: peer did not present a certificate");
@@ -1074,7 +1098,11 @@ static int tcl_tlsstatus STDVAR
   /* Try to get a cert, clients aren't required to send a
    * certificate, so this is optional
    */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L /* 3.0.0 */
+  cert = SSL_get0_peer_certificate(td->socklist[j].ssl);
+#else
   cert = SSL_get_peer_certificate(td->socklist[j].ssl);
+#endif
   /* The following information is certificate dependent */
   if (cert) {
     p = ssl_printname(X509_get_subject_name(cert));
@@ -1097,7 +1125,9 @@ static int tcl_tlsstatus STDVAR
     Tcl_DStringAppendElement(&ds, "serial");
     Tcl_DStringAppendElement(&ds, p);
     nfree(p);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* 3.0.0 */
     X509_free(cert);
+#endif
   }
   /* We should always have a cipher, but who knows? */
   cipher = SSL_get_current_cipher(td->socklist[j].ssl);

--- a/src/tls.c
+++ b/src/tls.c
@@ -129,7 +129,9 @@ int ssl_init()
 #endif
   if (ssl_seed()) {
     putlog(LOG_MISC, "*", "ERROR: TLS: unable to seed PRNG. Disabling SSL");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
     ERR_free_strings();
+#endif
     return -2;
   }
   /* A TLS/SSL connection established with this method will understand all
@@ -137,7 +139,9 @@ int ssl_init()
   if (!(ssl_ctx = SSL_CTX_new(SSLv23_method()))) {
     putlog(LOG_MISC, "*", "%s", ERR_error_string(ERR_get_error(), NULL));
     putlog(LOG_MISC, "*", "ERROR: TLS: unable to create context. Disabling SSL.");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
     ERR_free_strings();
+#endif
     return -1;
   }
   ssl_files_loaded = 0;
@@ -169,7 +173,9 @@ int ssl_init()
       tls_capath[0] ? tls_capath : NULL)) {
     putlog(LOG_MISC, "*", "ERROR: TLS: unable to set CA certificates location: %s",
            ERR_error_string(ERR_get_error(), NULL));
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
     ERR_free_strings();
+#endif
   }
   /* Let advanced users specify the list of allowed ssl protocols */
   #define EGG_SSLv2   (1 << 0)
@@ -276,7 +282,9 @@ int ssl_init()
   if (tls_ciphers[0] && !SSL_CTX_set_cipher_list(ssl_ctx, tls_ciphers)) {
     /* this replaces any preset ciphers so an invalid list is fatal */
     putlog(LOG_MISC, "*", "ERROR: TLS: no valid ciphers found. Disabling SSL.");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
     ERR_free_strings();
+#endif
     SSL_CTX_free(ssl_ctx);
     ssl_ctx = NULL;
     return -3;
@@ -293,7 +301,9 @@ void ssl_cleanup()
   }
   if (tls_randfile)
     RAND_write_file(tls_randfile);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L /* 1.1.0 */
   ERR_free_strings();
+#endif
 }
 
 char *ssl_fpconv(char *in, char *out)


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix leak for openssl > 3.0 and fix all openssl deprecations

Additional description (if needed):
Fix leak for openssl > 3.0

The leak is happening in `ssl_getuid()` which is called only in `dcc_telnet_id()` for telnet over ssl when `ssl-cert-auth` is set to 2. This PR fixes the leak for eggdrop using openssl >= 3.0.

Fix openssl 1.1 deprecation `SSLeay_version()` -> `OpenSSL_version()`
Fix openssl 1.1 deprecation `ERR_free_strings()`
Fix openssl 3.0 deprecation `SSL_get_peer_certificate()`
Fix openssl 1.1 deprecation `X509_get_notBefore()` and `X509_get_notAfter()` and make `ssl_printtime()` parameter `const`

Test cases demonstrating functionality (if applicable):
**Fixes the following errors when openssl 3.4.1 is compiled with `no-deprecated`:**
1.
```
chanprog.c: In function ‘tell_verbose_status’:
chanprog.c:300:11: error: implicit declaration of function ‘SSLeay_version’; did you mean ‘SSL_version’? [-Wimplicit-function-declaration]
  300 |           SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);
      |           ^~~~~~~~~~~~~~
      |           SSL_version
chanprog.c:300:26: error: ‘SSLEAY_VERSION’ undeclared (first use in this function); did you mean ‘SSL3_VERSION’?
  300 |           SSLeay_version(SSLEAY_VERSION), MISC_HEADERVERSION);
      |                          ^~~~~~~~~~~~~~
      |                          SSL3_VERSION
```
2.
```
tls.c: In function ‘ssl_init’:
tls.c:132:5: error: implicit declaration of function ‘ERR_free_strings’; did you mean ‘ERR_load_strings’? [-Wimplicit-function-declaration]
  132 |     ERR_free_strings();
      |     ^~~~~~~~~~~~~~~~
      |     ERR_load_strings
```
3.
```
tls.c: In function ‘ssl_getcert’:
tls.c:346:10: error: implicit declaration of function ‘SSL_get_peer_certificate’; did you mean ‘SSL_get1_peer_certificate’? [-Wimplicit-function-declaration]
  346 |   return SSL_get_peer_certificate(td->socklist[i].ssl);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
      |          SSL_get1_peer_certificate
tls.c:346:10: error: returning ‘int’ from a function with return type ‘X509 *’ {aka ‘struct x509_st *’} makes pointer from integer without a cast [-Wint-conversion]
  346 |   return SSL_get_peer_certificate(td->socklist[i].ssl);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
4.
```
tls.c: In function ‘ssl_showcert’:
tls.c:694:24: error: implicit declaration of function ‘X509_get_notBefore’; did you mean ‘X509_getm_notBefore’? [-Wimplicit-function-declaration]
  694 |   from = ssl_printtime(X509_get_notBefore(cert));
      |                        ^~~~~~~~~~~~~~~~~~
      |                        X509_getm_notBefore
tls.c:694:24: error: passing argument 1 of ‘ssl_printtime’ makes pointer from integer without a cast [-Wint-conversion]
  694 |   from = ssl_printtime(X509_get_notBefore(cert));
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
      |                        |
      |                        int
```