### PR TITLE
Fix user_entry_find()

### DIFF
--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -779,7 +779,6 @@ static char *traced_globchanset(ClientData cdata, Tcl_Interp *irp,
 }
 
 static tcl_ints my_tcl_ints[] = {
-  {"share-greet",              NULL,                     0},
   {"use-info",                 &use_info,                0},
   {"quiet-save",               &quiet_save,              0},
   {"allow-ps",                 &allow_ps,                0},
@@ -1014,7 +1013,6 @@ char *channels_start(Function *global_funcs)
   add_tcl_strings(my_tcl_strings);
   add_help_reference("channels.help");
   add_help_reference("chaninfo.help");
-  my_tcl_ints[0].val = &share_greet;
   add_tcl_ints(my_tcl_ints);
   add_tcl_coups(mychan_tcl_coups);
   read_channels(0, 0);

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -502,6 +502,7 @@ static tcl_ints def_tcl_ints[] = {
   {"prefer-ipv6",           &pref_af,              0},
 #endif
   {"show-uname",            &show_uname,           0},
+  {"share-greet",           &share_greet,          0},
   {NULL,                    NULL,                  0}
 };
 

--- a/src/userent.c
+++ b/src/userent.c
@@ -1647,8 +1647,7 @@ struct user_entry *find_user_entry(struct user_entry_type *et,
   struct user_entry **e, *t;
 
   for (e = &(u->entries); *e; e = &((*e)->next)) {
-    if (((*e)->type == et) ||
-        ((*e)->name && !strcasecmp((*e)->name, et->name))) {
+    if (((*e)->type == et) || !strcasecmp((*e)->type->name, et->name)) {
       t = *e;
       *e = t->next;
       t->next = u->entries;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: Could help with fixing #133

One-line summary:
Fix `user_entry_find()`

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Here is a bug fixed by this PR. Before: .chinfo cannot find and remove an INFO. After: it can as expected.
Before:
```
.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)

.chinfo test123 foo
.rehash
.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)
  INFO: foo

.chinfo test123
Wiped default info for test123

.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)
  INFO: foo
```
After:
```
.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)

.chinfo test123 foo
.rehash
.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)
  INFO: foo

.chinfo test123
Wiped default info for test123

.whois test123
HANDLE                           PASS NOTES FLAGS           LAST
test123                          no       0 -               never (nowhere)
```
