### PR TITLE
Require owner perms for python

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -551,8 +551,8 @@ set whois-fields "url birthday"
 #unbind dcc n set *dcc:set
 
 # If you enable this setting, only permanent owners (owner setting) will be
-# able to use .tcl and .set. Moreover, if you want only let permanent owners
-# use .dump, then set this to 2.
+# able to use .tcl, .set and, if loaded, .python. Moreover, if you want only
+# let permanent owners use .dump, then set this to 2.
 # WARNING: setting this to 0 is a security risk, don't do it unless you trust
 # your owners enough to give them shell access to the account the bot is
 # running on. 

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -2845,7 +2845,7 @@ static void cmd_tcl(struct userrec *u, int idx, char *msg)
   char *result;
   Tcl_DString dstr;
 
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }
@@ -2880,7 +2880,7 @@ static void cmd_set(struct userrec *u, int idx, char *msg)
   char s[512], *result;
   Tcl_DString dstr;
 
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }
@@ -2920,7 +2920,7 @@ static void cmd_loadmod(struct userrec *u, int idx, char *par)
 {
   const char *p;
 
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }
@@ -2942,7 +2942,7 @@ static void cmd_unloadmod(struct userrec *u, int idx, char *par)
 {
   char *p;
 
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }

--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -65,7 +65,7 @@ static void cmd_python(struct userrec *u, int idx, char *par) {
   Py_ssize_t n;
   int i;
 
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }

--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -65,6 +65,11 @@ static void cmd_python(struct userrec *u, int idx, char *par) {
   Py_ssize_t n;
   int i;
 
+  if (!(isowner(dcc[idx].nick)) && (must_be_owner)) {
+    dprintf(idx, "%s", MISC_NOSUCHCMD);
+    return;
+  }
+
   PyErr_Clear();
 
   // Expression output redirection via sys.displayhook
@@ -439,7 +444,7 @@ static PyMethodDef EggTclMethods[] = {
 
 static cmd_t mydcc[] = {
   /* command  flags  function     tcl-name */
-  {"python",    "",     (IntFunc) cmd_python,   NULL},
+  {"python",    "n",    (IntFunc) cmd_python,   NULL},
   {NULL,        NULL,   NULL,                   NULL}  /* Mark end. */
 };
 

--- a/src/mod/server.mod/cmdsserv.c
+++ b/src/mod/server.mod/cmdsserv.c
@@ -84,7 +84,7 @@ static void cmd_servers(struct userrec *u, int idx, char *par)
 
 static void cmd_dump(struct userrec *u, int idx, char *par)
 {
-  if (!(isowner(dcc[idx].nick)) && (must_be_owner == 2)) {
+  if (!isowner(dcc[idx].nick) && must_be_owner == 2) {
     dprintf(idx, "%s", MISC_NOSUCHCMD);
     return;
   }


### PR DESCRIPTION
Found by: thommey
Patch by: Geo

One-line summary:
Require +n flag to use .python command

Additional description (if needed):
Also checks the `must-be-owner` config setting to see if all owners or only perm owners can use `.python`

Test cases demonstrating functionality (if applicable):
set must-be-owner 1
```
You have no messages.
*** Geo joined the party line.
.tcl
What?  You need '.help'
.python
What?  You need '.help'
```
set must-be-owner 0
```
.tcl
Tcl: 
.python
Python Error: invalid syntax (<string>, line 0)
```



