### PR TITLE
Tcl_Eval() -> Tcl_EvalObjv()

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -279,9 +279,10 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
   int objc = 0, objc2;
-  Tcl_Obj *objv[4 + 16], *list = NULL, **objv2;
+  Tcl_Obj **objv, *list = NULL, **objv2;
   int i;
 
+  objv = nmalloc(sizeof(Tcl_Obj *) * 4);
   objv[objc++] = Tcl_NewStringObj(tclinfo->proc, -1);
   objv[objc++] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
   objv[objc++] = Tcl_NewStringObj(hostn, -1);
@@ -290,9 +291,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
     list = Tcl_NewStringObj(tclinfo->paras, -1);
     Tcl_IncrRefCount(list);
     if (Tcl_ListObjGetElements(interp, list, &objc2, &objv2) == TCL_OK) {
-      if (objc2 > 16) {
-        objc2 = 16;
-      }
+      objv = nrealloc(objv, sizeof(Tcl_Obj *) * (4 + objc2));
       for (i = 0; i < objc2; i++) {
         objv[objc++] = objv2[i];
       }
@@ -313,6 +312,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
   }
   if (list)
     Tcl_DecrRefCount(list);
+  nfree(objv);
   nfree(tclinfo->proc);
   if (tclinfo->paras)
     nfree(tclinfo->paras);

--- a/src/dns.c
+++ b/src/dns.c
@@ -283,10 +283,14 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
   int i;
 
   objv = nmalloc(sizeof(Tcl_Obj *) * 4);
-  objv[objc++] = Tcl_NewStringObj(tclinfo->proc, -1);
-  objv[objc++] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
-  objv[objc++] = Tcl_NewStringObj(hostn, -1);
-  objv[objc++] = Tcl_NewStringObj(ok ? "1" : "0", -1);
+  objv[objc] = Tcl_NewStringObj(tclinfo->proc, -1);
+  Tcl_IncrRefCount(objv[objc++]);
+  objv[objc] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
+  Tcl_IncrRefCount(objv[objc++]);
+  objv[objc] = Tcl_NewStringObj(hostn, -1);
+  Tcl_IncrRefCount(objv[objc++]);
+  objv[objc] = Tcl_NewStringObj(ok ? "1" : "0", -1);
+  Tcl_IncrRefCount(objv[objc++]);
   if ((tclinfo->paras) && (*(tclinfo->paras))) {
     list = Tcl_NewStringObj(tclinfo->paras, -1);
     Tcl_IncrRefCount(list);
@@ -301,17 +305,15 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
       goto error;
     }
   }
-  for (i = 0; i < 4; i++) {
-    Tcl_IncrRefCount(objv[i]);
-  }
+
   if (Tcl_EvalObjv(interp, objc, objv, 0) == TCL_ERROR) {
     putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
     Tcl_BackgroundError(interp);
   }
+error:
   for (i = 0; i < 4; i++) {
     Tcl_DecrRefCount(objv[i]);
   }
-error:
   if (list)
     Tcl_DecrRefCount(list);
   nfree(objv);

--- a/src/dns.c
+++ b/src/dns.c
@@ -278,15 +278,28 @@ void dcc_dnshostbyip(sockname_t *ip)
 static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other)
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
-  int objc = 0;
-  Tcl_Obj *objv[5];
+  int objc = 0, objc2;
+  Tcl_Obj *objv[4 + 16], *list, **objv2;
+  int i;
 
   objv[objc++] = Tcl_NewStringObj(tclinfo->proc, -1);
   objv[objc++] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
   objv[objc++] = Tcl_NewStringObj(hostn, -1);
   objv[objc++] = Tcl_NewStringObj(ok ? "1" : "0", -1);
-  if ((tclinfo->paras) && (*(tclinfo->paras)))
-    objv[objc++] = Tcl_NewStringObj(tclinfo->paras, -1);
+  if ((tclinfo->paras) && (*(tclinfo->paras))) {
+    list = Tcl_NewStringObj(tclinfo->paras, -1);
+    if (Tcl_ListObjGetElements(interp, list, &objc2, &objv2) == TCL_OK) {
+      if (objc2 > 16) {
+        objc2 = 16;
+      }
+      for (i = 0; i < objc2; i++) {
+        objv[objc++] = objv2[i];
+      }
+    } else {
+      putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
+      Tcl_BackgroundError(interp);
+    }
+  }
   for (int i = 0; i < objc; i++) {
     Tcl_IncrRefCount(objv[i]);
   }

--- a/src/dns.c
+++ b/src/dns.c
@@ -298,6 +298,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
     } else {
       putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
       Tcl_BackgroundError(interp);
+      goto error;
     }
   }
   for (i = 0; i < 4; i++) {
@@ -310,6 +311,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
   for (i = 0; i < 4; i++) {
     Tcl_DecrRefCount(objv[i]);
   }
+error:
   if (list)
     Tcl_DecrRefCount(list);
   nfree(objv);

--- a/src/dns.c
+++ b/src/dns.c
@@ -278,7 +278,6 @@ void dcc_dnshostbyip(sockname_t *ip)
 static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other)
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
-
   int objc = 0;
   Tcl_Obj *objv[5];
 
@@ -286,7 +285,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
   objv[objc++] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
   objv[objc++] = Tcl_NewStringObj(hostn, -1);
   objv[objc++] = Tcl_NewStringObj(ok ? "1" : "0", -1);
-  if (*(tclinfo->paras))
+  if ((tclinfo->paras) && (*(tclinfo->paras)))
     objv[objc++] = Tcl_NewStringObj(tclinfo->paras, -1);
   for (int i = 0; i < objc; i++) {
     Tcl_IncrRefCount(objv[i]);
@@ -299,7 +298,8 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
     Tcl_DecrRefCount(objv[i]);
   }
   nfree(tclinfo->proc);
-  nfree(tclinfo->paras);
+  if (tclinfo->paras)
+    nfree(tclinfo->paras);
   nfree(tclinfo);
 }
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -279,7 +279,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
   int objc = 0, objc2;
-  Tcl_Obj *objv[4 + 16], *list, **objv2;
+  Tcl_Obj *objv[4 + 16], *list = NULL, **objv2;
   int i;
 
   objv[objc++] = Tcl_NewStringObj(tclinfo->proc, -1);
@@ -288,6 +288,7 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
   objv[objc++] = Tcl_NewStringObj(ok ? "1" : "0", -1);
   if ((tclinfo->paras) && (*(tclinfo->paras))) {
     list = Tcl_NewStringObj(tclinfo->paras, -1);
+    Tcl_IncrRefCount(list);
     if (Tcl_ListObjGetElements(interp, list, &objc2, &objv2) == TCL_OK) {
       if (objc2 > 16) {
         objc2 = 16;
@@ -300,16 +301,18 @@ static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other
       Tcl_BackgroundError(interp);
     }
   }
-  for (int i = 0; i < objc; i++) {
+  for (i = 0; i < 4; i++) {
     Tcl_IncrRefCount(objv[i]);
   }
   if (Tcl_EvalObjv(interp, objc, objv, 0) == TCL_ERROR) {
     putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
     Tcl_BackgroundError(interp);
   }
-  for (int i = 0; i < objc; i++) {
+  for (i = 0; i < 4; i++) {
     Tcl_DecrRefCount(objv[i]);
   }
+  if (list)
+    Tcl_DecrRefCount(list);
   nfree(tclinfo->proc);
   if (tclinfo->paras)
     nfree(tclinfo->paras);

--- a/src/dns.c
+++ b/src/dns.c
@@ -278,37 +278,28 @@ void dcc_dnshostbyip(sockname_t *ip)
 static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other)
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
-  Tcl_DString list;
 
-  Tcl_DStringInit(&list);
-  Tcl_DStringAppendElement(&list, tclinfo->proc);
-  Tcl_DStringAppendElement(&list, iptostr(&ip->addr.sa));
-  Tcl_DStringAppendElement(&list, hostn);
-  Tcl_DStringAppendElement(&list, ok ? "1" : "0");
+  int objc = 0;
+  Tcl_Obj *objv[5];
 
-  if (tclinfo->paras) {
-    EGG_CONST char *argv[2];
-    char *output;
-
-    argv[0] = Tcl_DStringValue(&list);
-    argv[1] = tclinfo->paras;
-    output = Tcl_Concat(2, argv);
-
-    if (Tcl_Eval(interp, output) == TCL_ERROR) {
-      putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
-      Tcl_BackgroundError(interp);
-    }
-    Tcl_Free(output);
-  } else if (Tcl_Eval(interp, Tcl_DStringValue(&list)) == TCL_ERROR) {
+  objv[objc++] = Tcl_NewStringObj(tclinfo->proc, -1);
+  objv[objc++] = Tcl_NewStringObj(iptostr(&ip->addr.sa), -1);
+  objv[objc++] = Tcl_NewStringObj(hostn, -1);
+  objv[objc++] = Tcl_NewStringObj(ok ? "1" : "0", -1);
+  if (*(tclinfo->paras))
+    objv[objc++] = Tcl_NewStringObj(tclinfo->paras, -1);
+  for (int i = 0; i < objc; i++) {
+    Tcl_IncrRefCount(objv[i]);
+  }
+  if (Tcl_EvalObjv(interp, objc, objv, 0) == TCL_ERROR) {
     putlog(LOG_MISC, "*", DCC_TCLERROR, tclinfo->proc, tcl_resultstring());
     Tcl_BackgroundError(interp);
   }
-
-  Tcl_DStringFree(&list);
-
+  for (int i = 0; i < objc; i++) {
+    Tcl_DecrRefCount(objv[i]);
+  }
   nfree(tclinfo->proc);
-  if (tclinfo->paras)
-    nfree(tclinfo->paras);
+  nfree(tclinfo->paras);
   nfree(tclinfo);
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Tcl_Eval() -> Tcl_EvalObjv()

Additional description (if needed):
Modernize use of tcl

Test cases demonstrating functionality (if applicable):
No functional change