### PR TITLE
Fix possible file descriptor leak in share_ufsend()

### DIFF
--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1270,6 +1270,7 @@ static void share_ufsend(int idx, char *par)
       putlog(LOG_BOTS, "*", "Asynchronous connection failed!");
       dprintf(idx, "s e Can't connect to you!\n");
       zapfbot(idx);
+      fclose(f);
     } else {
       strcpy(dcc[i].nick, "*users");
       dcc[i].u.xfer->filename = nmalloc(strlen(s) + 1);


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix possible file descriptor leak in `share_ufsend()`

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
