### PR TITLE
Fix type mismatch

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,7 @@ extern sigjmp_buf alarmret;
 time_t now;
 static int argc;
 static char **argv;
-char *argv0;
+const char *argv0;
 
 /*
  * Please use the PATCH macro instead of directly altering the version
@@ -471,7 +471,7 @@ static void show_help() {
          "-t  Don't background; use terminal to simulate DCC chat.\n"
          "-m  Create userfile.\n"
          "-h  Show this help and exit.\n"
-         "-v  Show version info and exit.\n\n", argv[0]);
+         "-v  Show version info and exit.\n\n", argv0);
   bg_send_quit(BG_ABORT);
 }
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -95,7 +95,7 @@ extern time_t now, online_since;
 extern tand_t *tandbot;
 extern Tcl_Interp *interp;
 extern sock_list *socklist;
-extern char *argv0;
+extern const char *argv0;
 
 
 int xtra_kill();

--- a/src/modules.c
+++ b/src/modules.c
@@ -95,7 +95,7 @@ extern time_t now, online_since;
 extern tand_t *tandbot;
 extern Tcl_Interp *interp;
 extern sock_list *socklist;
-extern char argv0;
+extern char *argv0;
 
 
 int xtra_kill();


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes:

One-line summary:


Additional description (if needed):
Fixes the following compiler warning:
```
modules.c:98:13: warning: type of 'argv0' does not match original declaration [-Wlto-type-mismatch]
   98 | extern char argv0;
      |             ^
./main.c:86:7: note: 'argv0' was previously declared here
   86 | char *argv0;
      |       ^
```

Test cases demonstrating functionality (if applicable):
