### PR TITLE
Crashfix: use after free in tcl_call_stringproc_cd() - be reentrant, do not nrealloc

### DIFF
--- a/src/tcl.c
+++ b/src/tcl.c
@@ -316,20 +316,31 @@ static void tcl_cleanup_stringinfo(ClientData cd)
   nfree(cd);
 }
 
-/* Compatibility wrapper that calls Tcl functions with String API */
+/* Compatibility wrapper that calls Tcl functions with String API
+ *
+ * Is reentrant, can call itself recursively, so argv is dynamically allocated
+ * Tcl_IncrRefCount() is needed to preserve the strings we get Tcl_GetString()
+ * from being cleaned up if Tcl is invoked from this
+ */
 static int tcl_call_stringproc_cd(ClientData cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
   const char **argv;
-  int i;
+  int i, ret;
   struct tcl_call_stringinfo *info = cd;
+
   /* The string API guarantees argv[argc] == NULL, unlike the obj API */
-  argv = nmalloc((objc + 1) * sizeof *argv); /* be reentrant, do not nrealloc */
-  for (i = 0; i < objc; i++)
+  argv = nmalloc((objc + 1) * sizeof *argv);
+  for (i = 0; i < objc; i++) {
+    Tcl_IncrRefCount(objv[i]);
     argv[i] = Tcl_GetString(objv[i]);
+  }
   argv[objc] = NULL;
-  i = (info->proc)(info->cd, interp, objc, argv);
+  ret = (info->proc)(info->cd, interp, objc, argv);
+  for (i = 0; i < objc; i++) {
+    Tcl_DecrRefCount(objv[i]);
+  }
   nfree(argv);
-  return i;
+  return ret;
 }
 
 /* The standard case of no actual cd */

--- a/src/tcl.c
+++ b/src/tcl.c
@@ -319,17 +319,17 @@ static void tcl_cleanup_stringinfo(ClientData cd)
 /* Compatibility wrapper that calls Tcl functions with String API */
 static int tcl_call_stringproc_cd(ClientData cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
-  static int max;
-  static const char **argv;
+  const char **argv;
   int i;
   struct tcl_call_stringinfo *info = cd;
   /* The string API guarantees argv[argc] == NULL, unlike the obj API */
-  if (objc + 1 > max)
-    argv = nrealloc(argv, (objc + 1) * sizeof *argv);
+  argv = nmalloc((objc + 1) * sizeof *argv); /* be reentrant, do not nrealloc */
   for (i = 0; i < objc; i++)
     argv[i] = Tcl_GetString(objv[i]);
   argv[objc] = NULL;
-  return (info->proc)(info->cd, interp, objc, argv);
+  i = (info->proc)(info->cd, interp, objc, argv);
+  nfree(argv);
+  return i;
 }
 
 /* The standard case of no actual cd */


### PR DESCRIPTION
Found by: https://github.com/kkwpsi
Patch by: https://github.com/michaelortmann
Fixes: https://github.com/michaelortmann/logs2html.mod/issues/1

One-line summary:
Fix use after free in tcl_call_stringproc_cd() - be reentrant, do not nrealloc

Additional description (if needed):
Broken since eggdrop 1.9.0rc1 ([https://github.com/eggheads/eggdrop/pull/438](https://github.com/eggheads/eggdrop/pull/438)).

Test cases demonstrating functionality (if applicable):
```
==251937==ERROR: AddressSanitizer: heap-use-after-free on address 0x7566a6dec508 at pc 0x7906a73b0f18 bp 0x7ffcb6e4c810 sp 0x7ffcb6e4c800
READ of size 8 at 0x7566a6dec508 thread T0
    #0 0x7906a73b0f17 in tcl_addlogs2htmlchan .././logs2html.mod/tcllogs2html.c:79
    #1 0x61609a7f1cb4 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:332
    #2 0x61609a7f1df0 in tcl_call_stringproc /home/michael/projects/eggdrop/src/tcl.c:341
    #3 0x7906a907b7e8 in TclNRRunCallbacks /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:4541
    #4 0x7906a907d973 in TclEvalEx /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:5409
    #5 0x7906a9141552 in Tcl_FSEvalFileEx /usr/src/debug/tcl/tcl8.6.16/generic/tclIOUtil.c:1827
    #6 0x7906a9141821 in Tcl_EvalFile /usr/src/debug/tcl/tcl8.6.16/generic/tclIOUtil.c:424
    #7 0x61609a7f865d in readtclprog /home/michael/projects/eggdrop/src/tcl.c:1099
    #8 0x61609a7559b1 in chanprog /home/michael/projects/eggdrop/src/chanprog.c:400
    #9 0x61609a7cb9c3 in main main.c:1075
    #10 0x7906a80376b4  (/usr/lib/libc.so.6+0x276b4) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    #11 0x7906a8037768 in __libc_start_main (/usr/lib/libc.so.6+0x27768) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    #12 0x61609a71d4f4 in _start (/home/michael/eggdrop/eggdrop-1.10.0+0x2104f4) (BuildId: 89f731235cfd54a515c827b3610c8d401da21504)

0x7566a6dec508 is located 8 bytes inside of 64-byte region [0x7566a6dec500,0x7566a6dec540)
freed by thread T0 here:
    #0 0x7906a931fba5 in realloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:81
    #1 0x61609a7ccbdb in n_realloc /home/michael/projects/eggdrop/src/mem.c:389

previously allocated by thread T0 here:
    #0 0x7906a931fba5 in realloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:81
    #1 0x61609a7ccbdb in n_realloc /home/michael/projects/eggdrop/src/mem.c:389

SUMMARY: AddressSanitizer: heap-use-after-free .././logs2html.mod/tcllogs2html.c:79 in tcl_addlogs2htmlchan
```

```
$ valgrind --leak-check=full --track-origins=yes ./eggdrop -t BotA.conf
[...]
==257227== Invalid read of size 8
==257227==    at 0x5C86A09: tcl_addlogs2htmlchan (tcllogs2html.c:80)
==257227==    by 0x4062169: tcl_call_stringproc_cd (tcl.c:332)
==257227==    by 0x40621BC: tcl_call_stringproc (tcl.c:341)
==257227==    by 0x496B7E8: TclNRRunCallbacks (tclBasic.c:4541)
==257227==    by 0x496D973: TclEvalEx (tclBasic.c:5409)
==257227==    by 0x4A31552: Tcl_FSEvalFileEx (tclIOUtil.c:1827)
==257227==    by 0x4A31821: Tcl_EvalFile (tclIOUtil.c:424)
==257227==    by 0x4063DDF: readtclprog (tcl.c:1099)
==257227==    by 0x402BBB3: chanprog (chanprog.c:400)
==257227==    by 0x4053D20: main (main.c:1075)
==257227==  Address 0x578f4d8 is 8 bytes inside a block of size 64 free'd
==257227==    at 0x48F6E4F: realloc (vg_replace_malloc.c:1801)
==257227==    by 0x40546F9: n_realloc (mem.c:389)
==257227==    by 0x40620D8: tcl_call_stringproc_cd (tcl.c:328)
==257227==    by 0x40621BC: tcl_call_stringproc (tcl.c:341)
==257227==    by 0x496B7E8: TclNRRunCallbacks (tclBasic.c:4541)
==257227==    by 0x496D973: TclEvalEx (tclBasic.c:5409)
==257227==    by 0x496E31A: Tcl_EvalEx (tclBasic.c:5075)
==257227==    by 0x496E33A: Tcl_Eval (tclBasic.c:6001)
==257227==    by 0x496E98F: Tcl_VarEvalVA (tclBasic.c:7001)
==257227==    by 0x496EA71: Tcl_VarEval (tclBasic.c:7033)
==257227==    by 0x5C86610: get_log_path (tcllogs2html.c:27)
==257227==    by 0x5C869B6: tcl_addlogs2htmlchan (tcllogs2html.c:77)
==257227==  Block was alloc'd at
==257227==    at 0x48F6E4F: realloc (vg_replace_malloc.c:1801)
==257227==    by 0x40546F9: n_realloc (mem.c:389)
==257227==    by 0x40620D8: tcl_call_stringproc_cd (tcl.c:328)
==257227==    by 0x40621BC: tcl_call_stringproc (tcl.c:341)
==257227==    by 0x496B7E8: TclNRRunCallbacks (tclBasic.c:4541)
==257227==    by 0x496D973: TclEvalEx (tclBasic.c:5409)
==257227==    by 0x4A31552: Tcl_FSEvalFileEx (tclIOUtil.c:1827)
==257227==    by 0x4A31821: Tcl_EvalFile (tclIOUtil.c:424)
==257227==    by 0x4063DDF: readtclprog (tcl.c:1099)
==257227==    by 0x402BBB3: chanprog (chanprog.c:400)
==257227==    by 0x4053D20: main (main.c:1075)
==257227== 
[...]
```