### PR TITLE
Fix gotnotice() / ctcp

### DIFF
--- a/src/mod/server.mod/servmsg.c
+++ b/src/mod/server.mod/servmsg.c
@@ -715,7 +715,7 @@ static int gotnotice(char *from, char *msg)
       p++;
     if (*p == 1) {
       *p = 0;
-      if ((p - p1) < sizeof ctcpbuf) {
+      if ((p - p1) >= sizeof ctcpbuf) {
         putlog(LOG_SERV, "*", "Warning: Got NOTICE CTCP reply longer than "
                STRINGIFY(CTCP_MAX) " bytes: Bogus server?");
         return 0;


### PR DESCRIPTION
Found by: skydrome
Patch by: https://github.com/michaelortmann
Fixes: 

One-line summary:
Fix `gotnotice()` / ctcp

Additional description (if needed):
Fixes the following error: http://paste.tclhelp.net/?id=72jh
Broken since #1691

Test cases demonstrating functionality (if applicable):
```
bind pub - !lagcheck pub:lagcheck
bind ctcr - PING ctcr:pingreply

proc pub:lagcheck {nick host hand chan arg} {
	set ::lag [clock clicks]
	set ::lagchan $chan
	putquick "PRIVMSG $nick :\001PING $::lag\001"
}

proc ctcr:pingreply {nick host hand target method args} {
	global server botnick
	set ping [lindex $args 0]
	set diff [format {%.2f} [expr {([clock clicks] - $::lag) / 1000.00}]]
	set pingserver [lindex [split $server :] 0]

	if {[string is double -strict $ping]} {
		putserv "PRIVMSG $::lagchan :Reply from $botnick on $pingserver to $nick took ${diff}ms"
	}
}
```
Before:
```
!lagcheck michael

[01:40:53] [@] :michael!~michael@localhost PRIVMSG #foo :!lagcheck michael
[01:40:53] triggering bind pub:lagcheck
[01:40:53] [!m] PRIVMSG michael :PING 1747266053973720
[01:40:53] [m->] PRIVMSG michael :PING 1747266053973720
[01:40:53] triggered bind pub:lagcheck, user 0.053ms sys 0.055ms
[01:40:53] [@] :michael!~michael@localhost NOTICE BotA :PING 1747266053973720
[01:40:53] Warning: Got NOTICE CTCP reply longer than 512 bytes: Bogus server?
```
After:
```
!lagcheck michael

[01:46:23] [@] :michael!~michael@localhost PRIVMSG #foo :!lagcheck michael
[01:46:23] triggering bind pub:lagcheck
[01:46:23] [!m] PRIVMSG michael :PING 1747266383579729
[01:46:23] [m->] PRIVMSG michael :PING 1747266383579729
[01:46:23] triggered bind pub:lagcheck, user 0.061ms sys 0.045ms
[01:46:23] [@] :michael!~michael@localhost NOTICE BotA :PING 1747266383579729
[01:46:23] triggering bind ctcr:pingreply
[01:46:23] [!s] PRIVMSG #foo :Reply from BotA on zen.home.arpa to michael took 0.37ms
[01:46:23] triggered bind ctcr:pingreply, user 0.115ms sys 0.000ms
[01:46:23] CTCP reply PING: 1747266383579729 from michael (~michael@localhost) to BotA
[01:46:24] [s->] PRIVMSG #foo :Reply from BotA on zen.home.arpa to michael took 0.37ms

<BotA> Reply from BotA on zen.home.arpa to michael took 0.37ms
```