### PR TITLE
Corrected utimers explanation

### DIFF
--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -2375,7 +2375,7 @@ utimers
 
   Description: lists all active secondly timers.
 
-  Returns: a list of active secondly timers, with each timer sub-list containing the number of minutes left until activation, the command that will be executed, the timerName, and the remaining number of repeats.
+  Returns: a list of active secondly timers, with each timer sub-list containing the number of seconds left until activation, the command that will be executed, the timerName, and the remaining number of repeats.
 
   Module: core
 


### PR DESCRIPTION
Shows seconds left, not minutes

Found by: CrazyCat
Patch by: CrazyCat
Fixes: error

One-line summary: utimers shows seconds left, not minutes


Test cases demonstrating functionality (if applicable): read the doc
