### PR TITLE
Fix a function parameter constness for openssl < 1.0.0

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -622,7 +622,11 @@ static char *ssl_printname(X509_NAME *name)
  *
  * You need to nfree() the returned pointer.
  */
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L /* 1.0.0 */
 static char *ssl_printtime(const ASN1_UTCTIME *t)
+#else
+static char *ssl_printtime(ASN1_UTCTIME *t)
+#endif
 {
   long len;
   char *data, *buf;


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix a function parameter constness for openssl < 1.0.0

Additional description (if needed):
Fixes debris of #1791 
```
openssl-0.9.8zh:int ASN1_UTCTIME_print(BIO *fp, ASN1_UTCTIME *a);
openssl-1.0.0:int ASN1_UTCTIME_print(BIO *fp, const ASN1_UTCTIME *a);
```

Test cases demonstrating functionality (if applicable):
Fixes the following compile warning with openssl < 1.0.0 :
```
LD_LIBRARY_PATH=/home/michael/opt/openssl-0.9.8zh/lib ./configure --with-sslinc=/home/michael/opt/openssl-0.9.8zh/include --with-ssllib=/home/michael/opt/openssl-0.9.8zh/lib
LD_LIBRARY_PATH=/home/michael/opt/openssl-0.9.8zh/lib make config
LD_LIBRARY_PATH=/home/michael/opt/openssl-0.9.8zh/lib make
[...]
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I.. -I/home/michael/opt/openssl-0.9.8zh/include -DHAVE_CONFIG_H -I/usr/include  -c tls.c
tls.c: In function ‘ssl_printtime’:
tls.c:637:27: warning: passing argument 2 of ‘ASN1_UTCTIME_print’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  637 |   ASN1_UTCTIME_print(bio, t);
      |                           ^
In file included from /home/michael/opt/openssl-0.9.8zh/include/openssl/objects.h:965,
                 from /home/michael/opt/openssl-0.9.8zh/include/openssl/evp.h:98,
                 from /home/michael/opt/openssl-0.9.8zh/include/openssl/x509.h:73,
                 from /home/michael/opt/openssl-0.9.8zh/include/openssl/ssl.h:183,
                 from eggdrop.h:222,
                 from main.h:79,
                 from tls.c:27:
/home/michael/opt/openssl-0.9.8zh/include/openssl/asn1.h:1009:47: note: expected ‘ASN1_UTCTIME *’ {aka ‘struct asn1_string_st *’} but argument is of type ‘const ASN1_UTCTIME *’ {aka ‘const struct asn1_string_st *’}
 1009 | int ASN1_UTCTIME_print(BIO *fp, ASN1_UTCTIME *a);
      |                                 ~~~~~~~~~~~~~~^
```