### PR TITLE
Remove case sensitivity in bind replacement

### DIFF
--- a/src/tclhash.c
+++ b/src/tclhash.c
@@ -409,7 +409,7 @@ int bind_bind_entry(tcl_bind_list_t *tl, const char *flags,
   for (tc = tm->first; tc; tc = tc->next) {
     if (tc->attributes & TC_DELETED)
       continue;
-    if (!strcasecmp(tc->func_name, proc)) {
+    if (!strcmp(tc->func_name, proc)) {
       tc->flags.match = FR_GLOBAL | FR_CHAN;
       break_down_flags(flags, &(tc->flags), NULL);
       return 1;


### PR DESCRIPTION
Found by: Jinx
Patch by: Geo

One-line summary:


Additional description (if needed):
Previous functionality:
```
 .tcl bind dcc n test testcom
 .binds
       TYPE FLAGS    COMMAND              HITS BINDING (TCL)
        dcc n|-      test                    0 testcom
 .tcl bind dcc n test testCom
 .binds
       TYPE FLAGS    COMMAND              HITS BINDING (TCL)
        dcc n|-      test                    0 testcom
```
 testcom{} and testCom{} are different legal procs, that aren't replaced



Test cases demonstrating functionality (if applicable):
