### PR TITLE
Fix client_msg_plain_len initialization

### DIFF
--- a/src/mod/server.mod/sasl.c
+++ b/src/mod/server.mod/sasl.c
@@ -534,7 +534,7 @@ static void sasl_scram_step_2(char *restrict client_msg_plain,
 static int gotauthenticate(char *from, char *msg)
 {
   char client_msg_plain[1024];
-  int client_msg_plain_len;
+  int client_msg_plain_len = 0;
 #ifdef TLS
   char server_msg_plain[1024];
   char error_msg[1050]; /* snprintf() truncation should be tolerable */


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix client_msg_plain_len initialization

Additional description (if needed):
Better safe than sorry

Test cases demonstrating functionality (if applicable):
Fixes following compiler warning under Alpine Linux v3.20.5:
```
gcc -fPIC -std=gnu99 -g -O2 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include  -DMAKING_MODS -c .././server.mod/server.c && mv -f server.o ../
In file included from .././server.mod/server.c:27:
.././server.mod/sasl.c: In function 'gotauthenticate':
../../../src/mod/module.h:502:20: warning: 'client_msg_plain_len' may be used uninitialized [-Wmaybe-uninitialized]
  502 | # define b64_ntop ((int (*) (uint8_t const *, size_t, char *, size_t))global[305])
.././server.mod/sasl.c:608:7: note: in expansion of macro 'b64_ntop'
  608 |   if (b64_ntop((unsigned char *) client_msg_plain, client_msg_plain_len, client_msg_b64, sizeof client_msg_b64) == -1) {
      |       ^~~~~~~~
In file included from .././server.mod/server.c:140:
.././server.mod/sasl.c:537:7: note: 'client_msg_plain_len' was declared here
  537 |   int client_msg_plain_len;
      |       ^~~~~~~~~~~~~~~~~~~~
```