### PR TITLE
Crash Fix .rehash

### DIFF
--- a/src/tcldcc.c
+++ b/src/tcldcc.c
@@ -1100,7 +1100,7 @@ static int setlisten(Tcl_Interp *irp, char *ip, char *portp, char *type, char *m
       if (((ipv4) && (dcc[idx].sockname.addr.sa.sa_family != AF_INET)) ||
          ((!ipv4) && (dcc[idx].sockname.addr.sa.sa_family != AF_INET6))) {
         found = 0;
-        break;
+        continue;
       }
 #endif
 


### PR DESCRIPTION
Found by: https://github.com/TehPeGaSuS
Patch by: https://github.com/michaelortmann
Fixes: #1834

One-line summary:
Crash Fix .rehash

Additional description (if needed):
Fix control flow `setlisten()`

Test cases demonstrating functionality (if applicable):
eggdrop.conf:
```
listen 127.0.0.1 3333 all
listen ::1 3333 all
```
Before:
```
.rehash
[...]
[01:43:08] Listening for telnet connections on 127.0.0.1 port 3333 (all).
[01:43:08] Tcl error in file 'BotA.conf':
[01:43:08] Couldn't listen on port 3333 on ::1: Address already in use. Please check that the port is not already in use
    while executing
"listen ::1 3333 all"
    (file "BotA.conf" line 1620)
[01:43:08] * CONFIG FILE NOT LOADED (NOT FOUND, OR ERROR)
```
After:
```
.rehash
[...]
[01:43:19] Listening for telnet connections on 127.0.0.1 port 3333 (all).
[01:43:19] Listening for telnet connections on ::1 port 3333 (all).
[...]
```