### PR TITLE
Fix tdns leak and init attr only once

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -630,20 +630,19 @@ void core_dns_ipbyhost(char *host)
     nfree(dtn);
     return;
   }
-  dtn->next = dns_thread_head->next;
-  dns_thread_head->next = dtn;
   strlcpy(dtn->host, host, sizeof dtn->host);
   if (pthread_create(&(dtn->thread_id), &attr, thread_dns_ipbyhost, (void *) dtn)) {
     putlog(LOG_MISC, "*", "core_dns_ipbyhost(): pthread_create(): error = %s", strerror(errno));
     call_ipbyhost(host, &addr, 0);
     close(dtn->fildes[0]);
     close(dtn->fildes[1]);
-    dns_thread_head->next = dtn->next;
     pthread_mutex_destroy(&dtn->mutex);
     nfree(dtn);
     return;
   }
   dtn->type = DTN_TYPE_IPBYHOST;
+  dtn->next = dns_thread_head->next;
+  dns_thread_head->next = dtn;
 }
 #else /* EGG_TDNS */
 /*

--- a/src/dns.c
+++ b/src/dns.c
@@ -591,6 +591,7 @@ void core_dns_hostbyip(sockname_t *addr)
   if (pipe(dtn->fildes) < 0) {
     putlog(LOG_MISC, "*", "core_dns_hostbyip(): pipe(): error: %s", strerror(errno));
     call_hostbyip(addr, iptostr(&addr->addr.sa), 0);
+    pthread_mutex_destroy(&dtn->mutex);
     nfree(dtn);
     return;
   }
@@ -600,6 +601,7 @@ void core_dns_hostbyip(sockname_t *addr)
     call_hostbyip(addr, iptostr(&addr->addr.sa), 0);
     close(dtn->fildes[0]);
     close(dtn->fildes[1]);
+    pthread_mutex_destroy(&dtn->mutex);
     nfree(dtn);
     return;
   }

--- a/src/dns.c
+++ b/src/dns.c
@@ -49,12 +49,14 @@ extern Tcl_Interp *interp;
 
 devent_t *dns_events = NULL;
 
+#ifdef EGG_TDNS
 void init_tdns() {
   if (pthread_attr_init(&attr))
     fatal("ERROR: init_tnds(): pthread_attr_init()", 0);
   dns_thread_head = nmalloc(sizeof(struct dns_thread_node));
   dns_thread_head->next = NULL;
 }
+#endif
 
 static int ipaddr_equal(const sockname_t *ip, const sockname_t *ip2)
 {

--- a/src/dns.c
+++ b/src/dns.c
@@ -39,6 +39,7 @@ extern int dcc_total;
 extern time_t now;
 extern Tcl_Interp *interp;
 #ifdef EGG_TDNS
+  pthread_attr_t attr;
   struct dns_thread_node *dns_thread_head;
   extern int pref_af;
 #else
@@ -47,6 +48,13 @@ extern Tcl_Interp *interp;
 #endif
 
 devent_t *dns_events = NULL;
+
+void init_tdns() {
+  if (pthread_attr_init(&attr))
+    fatal("ERROR: init_tnds(): pthread_attr_init()", 0);
+  dns_thread_head = nmalloc(sizeof(struct dns_thread_node));
+  dns_thread_head->next = NULL;
+}
 
 static int ipaddr_equal(const sockname_t *ip, const sockname_t *ip2)
 {
@@ -575,14 +583,7 @@ void *thread_dns_ipbyhost(void *arg)
 void core_dns_hostbyip(sockname_t *addr)
 {
   struct dns_thread_node *dtn = nmalloc(sizeof(struct dns_thread_node));
-  pthread_attr_t attr;
 
-  if (pthread_attr_init(&attr)) {
-    putlog(LOG_MISC, "*", "core_dns_hostbyip(): pthread_attr_init(): error = %s", strerror(errno));
-    call_hostbyip(addr, iptostr(&addr->addr.sa), 0);
-    nfree(dtn);
-    return;
-  }
   if (pthread_mutex_init(&dtn->mutex, NULL))
     fatal("ERROR: core_dns_hostbyip(): pthread_mutex_init() failed", 0);
   if (pipe(dtn->fildes) < 0) {
@@ -609,7 +610,6 @@ void core_dns_ipbyhost(char *host)
 {
   sockname_t addr;
   struct dns_thread_node *dtn;
-  pthread_attr_t attr;
 
   /* if addr is ip instead of host */
   if (setsockname(&addr, host, 0, 0) != AF_UNSPEC) {
@@ -617,17 +617,12 @@ void core_dns_ipbyhost(char *host)
     return;
   }
   dtn = nmalloc(sizeof(struct dns_thread_node));
-  if (pthread_attr_init(&attr)) {
-    putlog(LOG_MISC, "*", "core_dns_ipbyhost(): pthread_attr_init(): error = %s", strerror(errno));
-    call_ipbyhost(host, &addr, 0);
-    nfree(dtn);
-    return;
-  }
   if (pthread_mutex_init(&dtn->mutex, NULL))
     fatal("ERROR: core_dns_ipbyhost(): pthread_mutex_init() failed", 0);
   if (pipe(dtn->fildes) < 0) {
     putlog(LOG_MISC, "*", "core_dns_ipbyhost(): pipe(): error: %s", strerror(errno));
     call_ipbyhost(host, &addr, 0);
+    pthread_mutex_destroy(&dtn->mutex);
     nfree(dtn);
     return;
   }
@@ -640,6 +635,7 @@ void core_dns_ipbyhost(char *host)
     close(dtn->fildes[0]);
     close(dtn->fildes[1]);
     dns_thread_head->next = dtn->next;
+    pthread_mutex_destroy(&dtn->mutex);
     nfree(dtn);
     return;
   }

--- a/src/main.c
+++ b/src/main.c
@@ -1068,9 +1068,8 @@ int main(int arg_c, char **arg_v)
   link_statics();
 #endif
 #ifdef EGG_TDNS
-  /* initialize dns_thread_head before chanprog() */
-  dns_thread_head = nmalloc(sizeof(struct dns_thread_node));
-  dns_thread_head->next = NULL;
+  /* initialize attr and dns_thread_head before chanprog() */
+  init_tdns();
 #endif
   ctime_r(&now, s);
   s[24] = 0;

--- a/src/net.c
+++ b/src/net.c
@@ -1072,6 +1072,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
       if (pthread_join(dtn->thread_id, &res))
         putlog(LOG_MISC, "*", "sockread(): pthread_join(): error = %s", strerror(errno));
       dtn_prev->next = dtn->next;
+      pthread_mutex_destroy(&dtn->mutex);
       nfree(dtn);
       dtn = dtn_prev;
     } else

--- a/src/proto.h
+++ b/src/proto.h
@@ -169,6 +169,7 @@ void del_dcc(int);
 void changeover_dcc(int, struct dcc_table *, int);
 
 /* dns.c */
+void init_tdns();
 extern void (*dns_hostbyip) (sockname_t *);
 void core_dns_hostbyip(sockname_t *);
 void call_hostbyip(sockname_t *, char *, int);


### PR DESCRIPTION
Found by: https://github.com/michaelortmann
Patch by: https://github.com/michaelortmann
Fixes: 

One-line summary:
Fix tdns leak and init attr only once

Additional description (if needed):
Also cleaned up code structure, moved tdns init code from `main.c` to `dns.c:init_tdns()`

Test cases demonstrating functionality (if applicable):
before:
```
$ valgrind --leak-check=full ./eggdrop -t BotA.conf 2>&1|grep dns.c
.tcl dnslookup google.com foo
.die
==11075==    by 0x24E202: core_dns_ipbyhost (dns.c:620)
==11075==    by 0x24E973: tcl_dnsipbyhost (dns.c:369)
==11075==    by 0x24E640: tcl_dnslookup (dns.c:739)
```
https://github.com/eggheads/eggdrop/blob/d317ac228eb6682fdd6386007e09d627efd618ca/src/dns.c#L620
after:
```
$ valgrind --leak-check=full ./eggdrop -t BotA.conf 2>&1|grep dns.c
.tcl dnslookup google.com foo
.die
```