### PR TITLE
Enhance tls error logging

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -883,6 +883,9 @@ static void ssl_info(const SSL *ssl, int where, int ret)
              (where & SSL_CB_READ) ? "read" : "write",
              SSL_alert_type_string_long(ret),
              SSL_alert_desc_string_long(ret));
+      if (!strcmp(SSL_alert_type_string(ret), "F") &&
+          !strcmp(SSL_alert_desc_string(ret), "RO"))
+        putlog(LOG_MISC, "*", "ERROR: No tls port?");
     } else {
       /* Ignore close notify warnings */
       debug1("TLS: Received close notify during %s",

--- a/src/tls.c
+++ b/src/tls.c
@@ -885,7 +885,7 @@ static void ssl_info(const SSL *ssl, int where, int ret)
              SSL_alert_desc_string_long(ret));
       if (!strcmp(SSL_alert_type_string(ret), "F") &&
           !strcmp(SSL_alert_desc_string(ret), "RO"))
-        putlog(LOG_MISC, "*", "ERROR: No tls port?");
+        putlog(LOG_MISC, "*", "TLS: Long TLSCiphertext field received, connection failed. Is this really a TLS port?");
     } else {
       /* Ignore close notify warnings */
       debug1("TLS: Received close notify during %s",


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: 

One-line summary:
Enhance tls error logging in case of connecting via +port to a non ssl port

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
The last line is new and logged to LOG_MISC instead of tls->loglevel, which could hide such message
```
[15:02:17] Trying server 127.0.0.1:+6667
[15:02:17] [!m] CAP LS 302
[15:02:17] TLS: alert during write: fatal (record overflow).
[15:02:17] ERROR: No tls port?
```