### PR TITLE
Fix gotkick(): unset chan.status CHAN_ACTIVE

### DIFF
--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2328,18 +2328,21 @@ static int gotkick(char *from, char *origmsg)
   if (!chan)
     return 0;
   nick = newsplit(&msg);
-  if (match_my_nick(nick) && channel_pending(chan) &&
-      !channel_inactive(chan)) {
-    chan->status &= ~(CHAN_ACTIVE | CHAN_PEND);
+  if (match_my_nick(nick) && !channel_inactive(chan)) {
+    if (channel_pending(chan)) {
+      chan->status &= ~(CHAN_ACTIVE | CHAN_PEND);
 
-    key = chan->channel.key[0] ? chan->channel.key : chan->key_prot;
-    if (key[0])
-      dprintf(DP_SERVER, "JOIN %s %s\n",
-              chan->name[0] ? chan->name : chan->dname, key);
-    else
-      dprintf(DP_SERVER, "JOIN %s\n",
-              chan->name[0] ? chan->name : chan->dname);
-    clear_channel(chan, CHAN_RESETALL);
+      key = chan->channel.key[0] ? chan->channel.key : chan->key_prot;
+      if (key[0])
+        dprintf(DP_SERVER, "JOIN %s %s\n",
+                chan->name[0] ? chan->name : chan->dname, key);
+      else
+        dprintf(DP_SERVER, "JOIN %s\n",
+                chan->name[0] ? chan->name : chan->dname);
+      clear_channel(chan, CHAN_RESETALL);
+    } else
+      // make sure the bot knows it is no longer on that channel
+      chan->status &= ~CHAN_ACTIVE;
     return 0; /* rejoin if kicked before getting needed info <Wcc[08/08/02]> */
   }
   if (channel_active(chan)) {

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2363,6 +2363,8 @@ static int gotkick(char *from, char *origmsg)
     /* This _needs_ to use chan->dname <cybah> */
     get_user_flagrec(u, &fr, chan->dname);
     set_handle_laston(chan->dname, u, now);
+    if (kicked_me)
+      chan->status &= ~CHAN_ACTIVE;
     check_tcl_kick(whodid, uhost, u, chan->dname, nick, msg);
 
     chan = findchan(chname);
@@ -2397,8 +2399,6 @@ static int gotkick(char *from, char *origmsg)
       check_lonely_channel(chan);
     }
   }
-  if (kicked_me)
-    chan->status &= ~CHAN_ACTIVE;
   return 0;
 }
 

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2320,6 +2320,7 @@ static int gotkick(char *from, char *origmsg)
   struct chanset_t *chan;
   struct userrec *u;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+  int kicked_me = 0;
 
   strlcpy(buf2, origmsg, sizeof buf2);
   msg = buf2;
@@ -2340,10 +2341,9 @@ static int gotkick(char *from, char *origmsg)
         dprintf(DP_SERVER, "JOIN %s\n",
                 chan->name[0] ? chan->name : chan->dname);
       clear_channel(chan, CHAN_RESETALL);
+      return 0; /* rejoin if kicked before getting needed info <Wcc[08/08/02]> */
     } else
-      // make sure the bot knows it is no longer on that channel
-      chan->status &= ~CHAN_ACTIVE;
-    return 0; /* rejoin if kicked before getting needed info <Wcc[08/08/02]> */
+      kicked_me = 1; // unset CHAN_ACTIVE aftter check_tcl_kick()
   }
   if (channel_active(chan)) {
     fixcolon(msg);
@@ -2397,6 +2397,8 @@ static int gotkick(char *from, char *origmsg)
       check_lonely_channel(chan);
     }
   }
+  if (kicked_me)
+    chan->status &= ~CHAN_ACTIVE;
   return 0;
 }
 

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2343,7 +2343,7 @@ static int gotkick(char *from, char *origmsg)
       clear_channel(chan, CHAN_RESETALL);
       return 0; /* rejoin if kicked before getting needed info <Wcc[08/08/02]> */
     } else
-      kicked_me = 1; // unset CHAN_ACTIVE aftter check_tcl_kick()
+      kicked_me = 1; /* unset CHAN_ACTIVE before check_tcl_kick() */
   }
   if (channel_active(chan)) {
     fixcolon(msg);


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: Found by analyzing #1723, not sure if it fixes the original bug, but this PR fixes a bug anyway

One-line summary:
Fix gotkick(): unset chan.status CHAN_ACTIVE

Additional description (if needed):
`check_lonely_channel()` could try to cycle the channel on join, even tho the bot should remember it is not on that channel anymore
`tcl_channel_modify()` could try to send `PART` on chan setting change to `+inactive`, even tho the bot should remember it is not on that channel anymore
This PR also fixes the delay (til next full minute) between changing chan setting -inactive and actually (re)joining the chan

Test cases demonstrating functionality (if applicable):
Load the following tcl script:
```
bind kick - * disable_chan_on_kick
proc disable_chan_on_kick {nick uhost hand chan target reason} {
	if {[isbotnick $target]} {
        putlog "Being kicked from $chan - setting it inactive"
	channel set $chan +inactive
        return 0
	}
}
```
Then let the bot join a channel
And then kick the bot from that channel
At last 
Before:
```
.console +*
[16:52:32] #-HQ# console +*
Set your console to #test23: mpjkcoblrxsdwvtuhg12345678 (msgs, public, joins, kicks/modes, cmds, misc, bots, linked bot msgs, raw, files, server input, debug, wallops, server output, botnet incoming, botnet outgoing, incoming share traffic, outgoing share traffic, level 1, level 2, level 3, level 4, level 5, level 6, level 7, level 8).
[16:52:34] [@] :michael!~michael@localhost KICK #test23 TestBot :testkick
[16:52:34] triggering bind disable_chan_on_kick
[16:52:34] Being kicked from #test23 - setting it inactive
[16:52:34] [!s] PART #test23
[16:52:34] triggered bind disable_chan_on_kick, user 0.084ms sys 0.064ms
[16:52:34] TestBot kicked from #test23 by michael: testkick
[16:52:35] [s->] PART #test23
[16:52:35] [@] :zen.home.arpa 442 TestBot #test23 :You're not on that channel
.chanset #test23 -inactive
[16:52:47] tcl: builtin dcc call: *dcc:chanset -HQ 1 #test23 -inactive
Successfully set modes { -inactive } on #test23.
[16:52:47] #-HQ# chanset #test23 -inactive
[16:53:00] Trying to cycle #test23 to regain ops.
[16:53:00] [!m] PART #test23
[16:53:00] [m->] PART #test23
[16:53:00] [!m] JOIN #test23
[16:53:00] [m->] JOIN #test23
[16:53:00] [@] :zen.home.arpa 442 TestBot #test23 :You're not on that channel
[16:53:00] Server says I'm not on channel: #test23
[16:53:00] [!s] JOIN #test23
[16:53:00] [@] :TestBot!~TestBot@localhost JOIN #test23 * :The Eggdrop Test Bot
[16:53:00] TestBot joined #test23.
[16:53:00] [!m] MODE #test23 +b
[16:53:00] [m->] MODE #test23 +b
[16:53:00] [!m] MODE #test23
[16:53:00] [m->] MODE #test23
[16:53:00] [!m] WHO #test23 c%chnufat,222
[16:53:00] [@] :zen.home.arpa 353 TestBot = #test23 :TestBot @michael
[16:53:00] [@] :zen.home.arpa 366 TestBot #test23 :End of /NAMES list.
[16:53:00] [@] :zen.home.arpa 368 TestBot #test23 :End of Channel Ban List
[16:53:00] [@] :zen.home.arpa 324 TestBot #test23 +nt
[16:53:00] [@] :zen.home.arpa 329 TestBot #test23 1760447240
[16:53:02] [m->] WHO #test23 c%chnufat,222
[16:53:02] [@] :zen.home.arpa 354 TestBot 222 #test23 ~TestBot localhost TestBot H 0
[16:53:02] [@] :zen.home.arpa 354 TestBot 222 #test23 ~michael localhost michael H@ 0
[16:53:02] [@] :zen.home.arpa 315 TestBot #test23 :End of /WHO list.
[16:53:08] [s->] JOIN #test23
```
After:
```
.console +*
[20:14:09] #-HQ# console +*
Set your console to #test23: mpjkcoblrxsdwvtuhg12345678 (msgs, public, joins, kicks/modes, cmds, misc, bots, linked bot msgs, raw, files, server input, debug, wallops, server output, botnet incoming, botnet outgoing, incoming share traffic, outgoing share traffic, level 1, level 2, level 3, level 4, level 5, level 6, level 7, level 8).
[20:14:11] [@] :michael!~michael@localhost KICK #test23 TestBot :testkick
[20:14:11] triggering bind disable_chan_on_kick
[20:14:11] Being kicked from #test23 - setting it inactive
[20:14:11] triggered bind disable_chan_on_kick, user 0.057ms sys 0.048ms
[20:14:11] TestBot kicked from #test23 by michael: testkick
.chanset #test23 -inactive
[20:14:35] tcl: builtin dcc call: *dcc:chanset -HQ 1 #test23 -inactive
[20:14:35] [!s] JOIN #test23
Successfully set modes { -inactive } on #test23.
[20:14:35] #-HQ# chanset #test23 -inactive
[20:14:36] [s->] JOIN #test23
[20:14:36] [@] :TestBot!~TestBot@localhost JOIN #test23 * :The Eggdrop Test Bot
[20:14:36] TestBot joined #test23.
[20:14:36] [!m] MODE #test23 +b
[20:14:36] [m->] MODE #test23 +b
[20:14:36] [!m] MODE #test23
[20:14:36] [m->] MODE #test23
[20:14:36] [!m] WHO #test23 c%chnufat,222
[20:14:36] [m->] WHO #test23 c%chnufat,222
[20:14:36] [@] :zen.home.arpa 353 TestBot = #test23 :TestBot @michael
[20:14:36] [@] :zen.home.arpa 366 TestBot #test23 :End of /NAMES list.
[20:14:36] [@] :zen.home.arpa 368 TestBot #test23 :End of Channel Ban List
[20:14:36] [@] :zen.home.arpa 324 TestBot #test23 +nt
[20:14:36] [@] :zen.home.arpa 329 TestBot #test23 1760447240
[20:14:36] [@] :zen.home.arpa 354 TestBot 222 #test23 ~TestBot localhost TestBot H 0
[20:14:36] [@] :zen.home.arpa 354 TestBot 222 #test23 ~michael localhost michael H@ 0
[20:14:36] [@] :zen.home.arpa 315 TestBot #test23 :End of /WHO list.
```