### PR TITLE
Fix uninitialised value

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1398,6 +1398,7 @@ static void dcc_telnet_hostresolved(int i)
     if (dcc[j].sock >= 0) {
       sockname_t name;
       name.addrlen = sizeof(name.addr);
+      name.family = dcc[j].sockname.family;
       if (getsockname(dcc[i].sock, &name.addr.sa, &name.addrlen) < 0)
         debug2("dcc: dcc_telnet_hostresolved(): getsockname() socket %ld error %s", dcc[i].sock, strerror(errno));
       setsnport(name, 0);

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1397,8 +1397,8 @@ static void dcc_telnet_hostresolved(int i)
     dcc[j].sock = getsock(dcc[j].sockname.family, 0);
     if (dcc[j].sock >= 0) {
       sockname_t name;
-      name.addrlen = sizeof(name.addr);
       name.family = dcc[j].sockname.family;
+      name.addrlen = sizeof(name.addr);
       if (getsockname(dcc[i].sock, &name.addr.sa, &name.addrlen) < 0)
         debug2("dcc: dcc_telnet_hostresolved(): getsockname() socket %ld error %s", dcc[i].sock, strerror(errno));
       setsnport(name, 0);


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
`> valgrind --track-origins=yes ./eggdrop -t BotA.conf`
Then telnet to the bot
```
[...]
[06:40:18] Telnet connection: localhost.home.arpa/43372
==545660== Conditional jump or move depends on uninitialised value(s)
==545660==    at 0x402B970: dcc_telnet_hostresolved (dcc.c:1403)
==545660==    by 0x40300A2: dns_dcchostbyip (dns.c:164)
==545660==    by 0x4030CDA: call_hostbyip (dns.c:439)
==545660==    by 0x403F8EF: sockread (net.c:1067)
==545660==    by 0x403FC56: sockgets (net.c:1178)
==545660==    by 0x4036FB4: mainloop (main.c:765)
==545660==    by 0x4038305: main (main.c:1223)
```
==545660==  Uninitialised value was created by a stack allocation
==545660==    at 0x402B403: dcc_telnet_hostresolved (dcc.c:1318)
==545660== 
[06:40:18] net: eof!(write) socket 11 (Broken pipe,32)
[06:40:18] EOF ident connection