### PR TITLE
Crash fix heap-use-after-free

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1283,7 +1283,6 @@ static void dcc_telnet(int idx, char *buf, int i)
     return;
   }
 
-  dcc[i].u.dns->ip = &dcc[i].sockname;
   dcc[i].sock = sock;
   dcc[i].port = port;
 #ifdef TLS

--- a/src/dns.c
+++ b/src/dns.c
@@ -146,11 +146,11 @@ static void dns_dcchostbyip(sockname_t *ip, char *hostn, int ok, void *other)
         (dcc[idx].u.dns->dns_type == RES_HOSTBYIP) && (
 #ifdef IPV6
         (ip->family == AF_INET6 &&
-          IN6_ARE_ADDR_EQUAL(&dcc[idx].u.dns->ip->addr.s6.sin6_addr,
+          IN6_ARE_ADDR_EQUAL(&dcc[idx].sockname.addr.s6.sin6_addr,
                              &ip->addr.s6.sin6_addr)) ||
         (ip->family == AF_INET &&
 #endif
-          (dcc[idx].u.dns->ip->addr.s4.sin_addr.s_addr ==
+          (dcc[idx].sockname.addr.s4.sin_addr.s_addr ==
                               ip->addr.s4.sin_addr.s_addr)))
 #ifdef IPV6
        )
@@ -180,10 +180,7 @@ static void dns_dccipbyhost(sockname_t *ip, char *hostn, int ok, void *other)
         (dcc[idx].u.dns->dns_type == RES_IPBYHOST) &&
         !strcasecmp(dcc[idx].u.dns->host, hostn)) {
       if (ok) {
-        if (dcc[idx].u.dns->ip)
-          memcpy(dcc[idx].u.dns->ip, ip, sizeof(sockname_t));
-        else
-          memcpy(&dcc[idx].sockname, ip, sizeof(sockname_t));
+        memcpy(&dcc[idx].sockname, ip, sizeof(sockname_t));
         dcc[idx].u.dns->dns_success(idx);
       } else
         dcc[idx].u.dns->dns_failure(idx);

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -445,7 +445,9 @@ struct dns_info {
   char *cbuf;                   /* temporary buffer. Memory will be free'd
                                  * as soon as dns_info is free'd           */
   char *cptr;                   /* temporary pointer                       */
-  sockname_t *ip;               /* pointer to sockname with ipv4/6 address */
+  /* sockname with ipv4/6 address is dcc[i].sockname. we must not link that
+   * pointer here, because dcc array can be realloced
+   */
   int ibuf;                     /* temporary buffer for one integer        */
   char dns_type;                /* lookup type, e.g. RES_HOSTBYIP          */
   struct dcc_table *type;       /* type of the dcc table we are making the

--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -674,7 +674,6 @@ static void filesys_dcc_send(char *nick, char *from, struct userrec *u,
       }
       dcc[i].port = atoi(prt);
       (void) setsockname(&dcc[i].sockname, ip, dcc[i].port, 0);
-      dcc[i].u.dns->ip = &dcc[i].sockname;
       dcc[i].sock = -1;
 #ifdef TLS
       dcc[i].ssl = ssl;

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1923,7 +1923,6 @@ static int ctcp_DCC_CHAT(char *nick, char *from, char *handle,
 #endif
     dcc[i].port = atoi(prt);
     (void) setsockname(&dcc[i].sockname, ip, dcc[i].port, 0);
-    dcc[i].u.dns->ip = &dcc[i].sockname;
     dcc[i].sock = -1;
     strcpy(dcc[i].nick, u->handle);
     strcpy(dcc[i].host, from);


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: 

One-line summary:
Fix a pointer in dcc table linking into dcc table. We must not do that because dcc table can be realloced

Additional description (if needed):
Between dns resolve start and finish, realloc can happen here:
https://github.com/eggheads/eggdrop/blob/d317ac228eb6682fdd6386007e09d627efd618ca/src/dccutil.c#L89
like when someone connects to the eggdrrop at the right moment
Its a heap-use-after-free
When investigating the code i realized the dns_info.ip pointer is redundant, and the fix equals a cleanup.

Test cases demonstrating functionality (if applicable):
```
==444524==ERROR: AddressSanitizer: heap-use-after-free on address 0x7d0d8c608f58 at pc 0x559353b0b799 bp 0x7ffc6235d370 sp 0x7ffc6235d360
READ of size 4 at 0x7d0d8c608f58 thread T0
    #0 0x559353b0b798 in dns_dcchostbyip /home/michael/projects/eggdrop/src/dns.c:153
[...]
0x7d0d8c608f58 is located 3672 bytes inside of 4560-byte region [0x7d0d8c608100,0x7d0d8c6092d0)
freed by thread T0 here:
    #0 0x7efd8ef1fa45 in realloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:81
    #1 0x559353b3a356 in n_realloc /home/michael/projects/eggdrop/src/mem.c:388
    #2 0x559353afdde4 in increase_socks_max /home/michael/projects/eggdrop/src/dccutil.c:89
[...]
==444524==ABORTING
```