### PR TITLE
Enhance yet another tls error logging

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -988,9 +988,14 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
               debug0("net: sockread(): SSL_read() SSL_ERROR_SYSCALL");
               putlog(LOG_MISC, "*", "NET: SSL read failed. Non-SSL connection?");
             }
-            else
-              debug2("net: sockread(): SSL_read() error = %s (%i)",
-                     ERR_error_string(ERR_get_error(), 0), err);
+            else {
+              long err2 = ERR_get_error();
+              debug3("net: sockread(): SSL_read() error = %s (%i) (%li)",
+                     ERR_error_string(err2, 0), err, err2);
+              if ((err == SSL_ERROR_SSL) &&
+                  (ERR_GET_REASON(err2) == SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE))
+                putlog(LOG_MISC, "*", "NET: SSL read(): Peer did not return a certificate, which is mandatory due to ssl-verify settings");
+            }
             x = -1;
           }
         } else

--- a/src/net.c
+++ b/src/net.c
@@ -994,7 +994,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
                      ERR_error_string(err2, 0), err, err2);
               if ((err == SSL_ERROR_SSL) &&
                   (ERR_GET_REASON(err2) == SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE))
-                putlog(LOG_MISC, "*", "NET: SSL read(): Peer did not return a certificate, which is mandatory due to ssl-verify settings");
+                putlog(LOG_MISC, "*", "NET: SSL read failed. Peer did not return a certificate, which is mandatory due to ssl-verify settings.");
             }
             x = -1;
           }


### PR DESCRIPTION
Found by: https://github.com/michaelortmann
Patch by: https://github.com/michaelortmann
Fixes: 

One-line summary:
Enhance yet another tls error logging

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
eggdrop.conf:
```
listen +3343 all
set ssl-verify-clients 15
```
`> openssl s_client -connect 127.0.0.1:3343`
Before:
```
[10:52:07] Telnet connection: localhost.home.arpa/50096
[10:52:07] EOF ident connection
[10:52:07] TLS: alert during write: fatal (unknown).
[10:52:07] Lost telnet connection to telnet@localhost.home.arpa/50096
```
After:
```
[11:05:06] Telnet connection: localhost.home.arpa/53642
[11:05:06] EOF ident connection
[11:05:06] TLS: alert during write: fatal (unknown).
[11:05:06] NET: SSL read failed. Peer did not return a certificate, which is mandatory due to ssl-verify settings.
[11:05:06] Lost telnet connection to telnet@localhost.home.arpa/53642
```