### PR TITLE
Add eggdrop version check python script

### DIFF
--- a/src/mod/python.mod/scripts/check_version.py
+++ b/src/mod/python.mod/scripts/check_version.py
@@ -24,7 +24,8 @@ def check_version():
             putlog(
                 f"Version check: eggdrop update found: latest {latest_version} current {current_version}"
             )
-            threading.Timer(24 * 60 * 60, check_version).start()  # 24h
+    threading.Timer(24 * 60 * 60, check_version).start()  # 24h
 
 
 check_version()
+print("Loaded check_version.py")

--- a/src/mod/python.mod/scripts/check_version.py
+++ b/src/mod/python.mod/scripts/check_version.py
@@ -12,7 +12,9 @@ import urllib.request
 current_version = eggdrop.tcl.set("version")
 index1 = current_version.find(" ")
 index2 = current_version.find("+")
-current_version = "v" + current_version[: min(index1, index2)]
+current_version = (
+    f"v{current_version[: index1 if index2 < 0 or index2 > index1 else index2]}"
+)
 
 
 def check_version():

--- a/src/mod/python.mod/scripts/check_version.py
+++ b/src/mod/python.mod/scripts/check_version.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2025 Michael Ortmann MIT License
+# Copyright (C) 2025 Eggheads Development Team
+# We use ruff as a code formatter to keep the code style consistent (and to
+# avoid off-topic discussions)
+import eggdrop
+from eggdrop.tcl import putlog
+import json
+import threading
+import urllib.request
+
+current_version = eggdrop.tcl.set("version")
+index1 = current_version.find(" ")
+index2 = current_version.find("+")
+current_version = "v" + current_version[: min(index1, index2)]
+
+
+def check_version():
+    with urllib.request.urlopen(
+        "https://api.github.com/repos/eggheads/eggdrop/releases/latest"
+    ) as fp:
+        latest_version = json.load(fp)["tag_name"]
+        if current_version != latest_version:
+            putlog(
+                f"Version check: eggdrop update found: latest {latest_version} current {current_version}"
+            )
+            threading.Timer(24 * 60 * 60, check_version).start()  # 24h
+
+
+check_version()


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: 

One-line summary:
Add eggdrop version check python script

Additional description (if needed):
The script version checks every 24h
The other example scripts never used `eggdrop.tcl.set()` and `threading`, so this is a nice addition

Test cases demonstrating functionality (if applicable):
eggdrop.conf:
```
loadmodule python
pysource scripts/check_version.py
```
```
> ./eggdrop -t eggdrop.conf
[...]     
Module loaded: python          
Version check: eggdrop update found: latest v1.10.1 current v1.10.0
Loaded check_version.py
```