### PR TITLE
Cleanup ctcp.mod - remove unused UTC and includes

### DIFF
--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -108,8 +108,6 @@ static int ctcp_CLIENTINFO(char *nick, char *uhosr, char *handle,
     p = CLIENTINFO_ACTION;
   else if (!strcasecmp(msg, "dcc"))
     p = CLIENTINFO_DCC;
-  else if (!strcasecmp(msg, "utc"))
-    p = CLIENTINFO_UTC;
   else if (!strcasecmp(msg, "ping"))
     p = CLIENTINFO_PING;
   else if (!strcasecmp(msg, "echo"))

--- a/src/mod/ctcp.mod/ctcp.c
+++ b/src/mod/ctcp.mod/ctcp.c
@@ -27,8 +27,6 @@
 #include "ctcp.h"
 #include "src/mod/module.h"
 #include "server.mod/server.h"
-#include <netinet/in.h>
-#include <arpa/inet.h>
 
 static Function *global = NULL, *server_funcs = NULL;
 

--- a/src/mod/ctcp.mod/ctcp.h
+++ b/src/mod/ctcp.mod/ctcp.h
@@ -24,7 +24,7 @@
 #ifndef _EGG_MOD_CTCP_CTCP_H
 #define _EGG_MOD_CTCP_CTCP_H
 
-#define CLIENTINFO "SED VERSION CLIENTINFO USERINFO ERRMSG FINGER TIME ACTION DCC UTC PING ECHO  :Use CLIENTINFO <COMMAND> to get more specific information"
+#define CLIENTINFO "SED VERSION CLIENTINFO USERINFO ERRMSG FINGER TIME ACTION DCC PING ECHO  :Use CLIENTINFO <COMMAND> to get more specific information"
 #define CLIENTINFO_SED "SED contains simple_encrypted_data"
 #define CLIENTINFO_VERSION "VERSION shows client type, version and environment"
 #define CLIENTINFO_CLIENTINFO "CLIENTINFO gives information about available CTCP commands"
@@ -34,7 +34,6 @@
 #define CLIENTINFO_TIME "TIME tells you the time on the user's host"
 #define CLIENTINFO_ACTION "ACTION contains action descriptions for atmosphere"
 #define CLIENTINFO_DCC "DCC requests a direct_client_connection"
-#define CLIENTINFO_UTC "UTC substitutes the local timezone"
 #define CLIENTINFO_PING "PING returns the arguments it receives"
 #define CLIENTINFO_ECHO "ECHO returns the arguments it receives"
 


### PR DESCRIPTION
Found by: https://github.com/michaelortmann/
Patch by: https://github.com/michaelortmann/
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):