### PR TITLE
Fix: Call check_expired_dcc() every second to honor -timeout settings

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -2287,7 +2287,7 @@ void dcc_ident(int idx, char *buf, int len)
   lostdcc(idx);
 }
 
-void eof_timeout_dcc_ident(int idx, const char *s)
+static void eof_timeout_dcc_ident(int idx, const char *s)
 {
   char buf[7 + UHOSTLEN];
   int i;

--- a/src/main.c
+++ b/src/main.c
@@ -557,10 +557,10 @@ static void core_secondly()
   uint64_t drift_mins;
 
   do_check_timers(&utimer);     /* Secondly timers */
+  check_expired_dcc();
   cnt++;
   if (cnt >= 10) {              /* Every 10 seconds */
     cnt = 0;
-    check_expired_dcc();
     if (con_chan && !backgrd) {
       dprintf(DP_STDOUT, "\033[2J\033[1;1H");
       if ((cliflags & CLI_N) && (cliflags & CLI_C)) {


### PR DESCRIPTION
Found by: https://github.com/michaelortmann
Patch by: https://github.com/michaelortmann
Fixes: 

One-line summary:
Call `check_expired_dcc()` every second to honor `-timeout` settings

Additional description (if needed):
This bug is ancient
While at it, i made `eof_timeout_dcc_ident()` static

Test cases demonstrating functionality (if applicable):
`set ident-timeout 3`
Configure your machine/network, so that ident requests of the bot will time out
Then telnet to the bot
`check_expired_dcc()` is executed every 10 seconds, so you will notice that the timeout will be longer than 3 seconds depending on the gap between the start of the timeout and the start of the `check_expired_dcc()` cycle