### PR TITLE
Enhance tdns node mutex lock

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1060,11 +1060,11 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
 #ifdef EGG_TDNS
   dtn_prev = dns_thread_head;
   for (dtn = dtn_prev->next; dtn; dtn = dtn->next) {
-    pthread_mutex_lock(&dtn->mutex);
-    if (*dtn->strerror)
-      debug2("%s: hostname %s", dtn->strerror, dtn->host);
     fd = dtn->fildes[0];
     if (FD_ISSET(fd, &fdr)) {
+      pthread_mutex_lock(&dtn->mutex);
+      if (*dtn->strerror)
+        debug2("%s: hostname %s", dtn->strerror, dtn->host);
       if (dtn->type == DTN_TYPE_HOSTBYIP)
         call_hostbyip(&dtn->addr, dtn->host, !*dtn->strerror);
       else
@@ -1076,8 +1076,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
       dtn_prev->next = dtn->next;
       nfree(dtn);
       dtn = dtn_prev;
-    } else
-      pthread_mutex_unlock(&dtn->mutex);
+    }
     dtn_prev = dtn;
   }
 #endif


### PR DESCRIPTION
Found by: github.com/michaelortmann/
Patch by: github.com/michaelortmann/
Fixes: 

One-line summary:

Additional description (if needed):
Quick summary of what is happening now:
- Each tdns thread has its own data node in a linked list.
- Each tdns thread finishes by writing its data to its node, using a mutex lock on that node, then calling close() on a pipe to signal eggdrops main thread select() that data is ready.
- In eggdrops mainloop net.c (the changed code of this PR) we loop over the linked list, check which node(s) fds were closed and handle those nodes.

By putting the debug print of the node->strerror inside the FD_ISSET code-block,  we only need to lock the relevant nodes.

Test cases demonstrating functionality (if applicable):
tested for regression with:
```
valgrind --tool=helgrind ./eggdrop -nt BotA.conf
[...]
.tcl dnslookup google.de foo
```