### PR TITLE
Fix gotmode() regression

### DIFF
--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -1013,7 +1013,8 @@ static int gotmode(char *from, char *origmsg)
       z = strlen(msg);
       if (msg[--z] == ' ')      /* I hate cosmetic bugs :P -poptix */
         msg[z] = 0;
-      fixcolon(msg);
+      if (msg[0] == ':')
+        msg++;
       putlog(LOG_MODES, chan->dname, "%s: mode change '%s %s' by %s", ch, chg,
              msg, from);
       nick = splitnick(&from);


### PR DESCRIPTION
Found by: https://github.com/crazycatdevs
Patch by: https://github.com/michaelortmann
Fixes: #1861

One-line summary:
Fix gotmode() regression

Additional description (if needed):
See #1861

Test cases demonstrating functionality (if applicable):
`/mode #testchan +vv testuser1 testuser2`
Before:
```
[21:40:19] [@] :michael!~michael@localhost MODE #testchan +vv testuser1 testuser2
[21:40:19] #testchan: mode change '+vv testuser1' by michael!~michael@localhost
[21:40:19] * Mode change on #testchan for nonexistent !
```
After:
```
[21:59:58] [@] :michael!~michael@localhost MODE #testchan +vv testuser1 testuser2
[21:59:58] #testchan: mode change '+vv testuser1 testuser2' by michael!~michael@localhost
```