### PR TITLE
Fix for -Wstrict-overflow=3

### DIFF
--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -707,7 +707,7 @@ static void filesys_dcc_send(char *nick, char *from, struct userrec *u,
 static char *mktempfile(char *filename)
 {
   char rands[8], *tempname, *fn = filename;
-  int l;
+  size_t l;
 
   make_rand_str(rands, sizeof rands - 1);
   l = strlen(filename);


### PR DESCRIPTION
Found by: https://github.com/michaelortmann
Patch by: https://github.com/michaelortmann
Fixes: 

One-line summary:
Fix for `-Wstrict-overflow=3`

Additional description (if needed):
```
gcc -fPIC -std=gnu99 -Wstrict-overflow=3 -pipe -Wall -I. -I../../.. -I../../.. -I../../../src/mod  -DHAVE_CONFIG_H -I/usr/include  -DMAKING_MODS -c .././filesys.mod/filesys.c && mv -f filesys.o ../
.././filesys.mod/filesys.c: In function ‘mktempfile’:
.././filesys.mod/filesys.c:714:3: warning: assuming signed overflow does not occur when changing X +- C1 cmp C2 to X cmp C2 -+ C1 [-Wstrict-overflow]
  714 |   if ((l + MKTEMPFILE_TOT) > NAME_MAX) {
      |   ^~
```

Test cases demonstrating functionality (if applicable):
