### PR TITLE
webui.mod followup PR

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1442,7 +1442,7 @@ static void dcc_telnet_hostresolved(int i)
 #ifdef TLS
   /* Delay ident lookup for webui http until websocket */
   if (!strcmp(dcc[idx].nick, "(webui)")) {
-    webui_dcc_telnet_hostresolved(i);
+    webui_dcc_telnet_hostresolved(i, idx);
     return;
   }
 #endif /* TLS */

--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1440,7 +1440,7 @@ static void dcc_telnet_hostresolved(int i)
   }
 
 #ifdef TLS
-  /* Skip ident lookup for webui http */
+  /* Delay ident lookup for webui http until websocket */
   if (!strcmp(dcc[idx].nick, "(webui)")) {
     webui_dcc_telnet_hostresolved(i);
     return;

--- a/src/dccutil.c
+++ b/src/dccutil.c
@@ -557,16 +557,15 @@ void changeover_dcc(int i, struct dcc_table *type, int xtra_size)
   /* Free old structure. */
   if (dcc[i].type && dcc[i].type->kill)
     dcc[i].type->kill(i, dcc[i].u.other);
-  else if (dcc[i].u.other) {
+  else if (dcc[i].u.other)
     nfree(dcc[i].u.other);
-    dcc[i].u.other = NULL;
-  }
 
   dcc[i].type = type;
   if (xtra_size) {
     dcc[i].u.other = nmalloc(xtra_size);
     egg_bzero(dcc[i].u.other, xtra_size);
-  }
+  } else
+    dcc[i].u.other = NULL;
 }
 
 int detect_dcc_flood(time_t *timer, struct chat_info *chat, int idx)

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -351,6 +351,7 @@ struct dcc_t {
     struct dns_info *dns;
     struct dupwait_info *dupwait;
     int ident_sock;
+    int webui_listen_idx;
     void *other;
   } u;                          /* Special use depending on type        */
 };

--- a/src/mod/webui.mod/Makefile
+++ b/src/mod/webui.mod/Makefile
@@ -28,12 +28,12 @@ clean:
 distclean: clean
 
 #safety hash
-../webui.o: .././webui.mod/webui.c ../../../src/mod/module.h \
- ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
- ../../../src/lang.h ../../../src/eggdrop.h ../../../src/compat/in6.h \
- ../../../src/flags.h ../../../src/cmdt.h ../../../src/tclegg.h \
- ../../../src/tclhash.h ../../../src/chan.h ../../../src/users.h \
- ../../../src/compat/compat.h ../../../src/compat/base64.h \
- ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
- ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
- ../../../src/mod/modvals.h ../../../src/tandem.h ../../../src/version.h
+../webui.o: webui.c ../../../src/mod/module.h ../../../src/main.h \
+ ../../../config.h ../../../eggint.h ../../../lush.h ../../../src/lang.h \
+ ../../../src/eggdrop.h ../../../src/compat/in6.h ../../../src/flags.h \
+ ../../../src/cmdt.h ../../../src/tclegg.h ../../../src/tclhash.h \
+ ../../../src/chan.h ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h ../../../src/version.h

--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -33,15 +33,16 @@ avoid off-topic discussions)
       style="width: 100%"
     />
     <script>
-      WS_ECHO_ON = "\x01";
-      WS_ECHO_OFF = "\x02";
-      ws = new WebSocket(
+      "use strict";
+      const WS_ECHO_ON = "\x01";
+      const WS_ECHO_OFF = "\x02";
+      const ws = new WebSocket(
         (location.protocol === "https:" ? "wss:" : "ws:") +
           location.host +
           "/w",
       );
       out = document.getElementById("out");
-      echo = 1;
+      let echo = 1;
       ws.addEventListener("close", (event) => {
         d.remove();
         out.innerHTML = out.innerHTML + "Connection closed by foreign host.";

--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -15,65 +15,62 @@ avoid off-topic discussions)
   <!--gruvbox colors-->
   <body
     style="
-      display: grid;
-      grid-template-rows: 1fr auto;
-      margin: 0px;
-      height: 100%;
       background-color: #282828;
       color: #ebdbb2;
+      display: grid;
+      grid-template-rows: 1fr auto;
+      height: 100%;
+      margin: 0px;
     "
   >
     <pre id="out" style="overflow: auto"></pre>
-    <input
-      id="d"
-      type="text"
-      class="b"
-      onkeydown="b(this)"
-      autofocus
-      style="width: 100%"
-    />
+    <input id="input" type="text" autofocus style="width: 100%" />
     <script>
       "use strict";
       const WS_ECHO_ON = "\x01";
       const WS_ECHO_OFF = "\x02";
+      const input = document.getElementById("input");
       const ws = new WebSocket(
         (location.protocol === "https:" ? "wss:" : "ws:") +
           location.host +
           "/w",
       );
-      out = document.getElementById("out");
       let echo = true;
+      const out = document.getElementById("out");
       let sendCount = 0;
-      ws.addEventListener("close", (event) => {
-        d.remove();
-        out.innerHTML = out.innerHTML + "Connection closed by foreign host.";
-        out.scrollTop = out.scrollHeight;
-      });
-      ws.addEventListener("message", (event) => {
-        out.innerHTML = out.innerHTML + event.data.replace(/[\x01-\x02]/g, "");
-        out.scrollTop = out.scrollHeight;
-        if (event.data.includes(WS_ECHO_ON)) {
-          d.type = "text";
-          echo = true;
-        } else if (event.data.includes(WS_ECHO_OFF)) {
-          d.type = "password";
-          echo = false;
-        }
-      });
-      function b(c) {
+      input.addEventListener("keydown", (event) => {
         if (event.key === "Enter") {
-          ws.send(c.value);
+          ws.send(input.value);
           if (echo) {
-            out.innerHTML = out.innerHTML + c.value + "\n";
+            out.append(input.value + "\n");
             out.scrollTop = out.scrollHeight;
           }
-          c.value = "";
+          input.value = "";
           if (sendCount++ == 0) {
-            d.type = "password";
+            input.type = "password";
             echo = false;
           }
         }
-      }
+      });
+      ws.addEventListener("close", (event) => {
+        input.remove();
+        out.append("Connection closed by foreign host.");
+        out.scrollTop = out.scrollHeight;
+      });
+      ws.addEventListener("message", (event) => {
+        out.insertAdjacentHTML(
+          "beforeend",
+          event.data.replace(/[\x01-\x02]/g, ""),
+        );
+        out.scrollTop = out.scrollHeight;
+        if (event.data.includes(WS_ECHO_ON)) {
+          input.type = "text";
+          echo = true;
+        } else if (event.data.includes(WS_ECHO_OFF)) {
+          input.type = "password";
+          echo = false;
+        }
+      });
     </script>
   </body>
 </html>

--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -12,6 +12,7 @@ avoid off-topic discussions)
     <meta name="viewport" content="initial-scale=1" />
     <title>Eggdrop</title>
   </head>
+  <!--gruvbox colors-->
   <body
     style="
       display: grid;
@@ -22,7 +23,6 @@ avoid off-topic discussions)
       color: #ebdbb2;
     "
   >
-    <!--gruvbox colors-->
     <pre id="out" style="overflow: auto"></pre>
     <input
       id="d"

--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -42,7 +42,8 @@ avoid off-topic discussions)
           "/w",
       );
       out = document.getElementById("out");
-      let echo = 1;
+      let echo = true;
+      let sendCount = 0;
       ws.addEventListener("close", (event) => {
         d.remove();
         out.innerHTML = out.innerHTML + "Connection closed by foreign host.";
@@ -53,12 +54,10 @@ avoid off-topic discussions)
         out.scrollTop = out.scrollHeight;
         if (event.data.includes(WS_ECHO_ON)) {
           d.type = "text";
-          echo = 1;
-          console.log("echo on");
+          echo = true;
         } else if (event.data.includes(WS_ECHO_OFF)) {
           d.type = "password";
-          echo = 0;
-          console.log("echo off");
+          echo = false;
         }
       });
       function b(c) {
@@ -69,6 +68,10 @@ avoid off-topic discussions)
             out.scrollTop = out.scrollHeight;
           }
           c.value = "";
+          if (sendCount++ == 0) {
+            d.type = "password";
+            echo = false;
+          }
         }
       }
     </script>

--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -51,11 +51,11 @@ avoid off-topic discussions)
       ws.addEventListener("message", (event) => {
         out.innerHTML = out.innerHTML + event.data.replace(/[\x01-\x02]/g, "");
         out.scrollTop = out.scrollHeight;
-        if (event.data.indexOf(WS_ECHO_ON) > -1) {
+        if (event.data.includes(WS_ECHO_ON)) {
           d.type = "text";
           echo = 1;
           console.log("echo on");
-        } else if (event.data.indexOf(WS_ECHO_OFF) > -1) {
+        } else if (event.data.includes(WS_ECHO_OFF)) {
           d.type = "password";
           echo = 0;
           console.log("echo off");

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -70,7 +70,7 @@ static void put_404(int idx) {
     "Server: %s\r\n"
     "\r\n"
     "404 Not Found",
-    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
   response = nmalloc(i + 1);
   sprintf(response,
     "HTTP/1.1 404 \r\n" /* textual phrase is OPTIONAL */
@@ -79,7 +79,7 @@ static void put_404(int idx) {
     "Server: %s\r\n"
     "\r\n"
     "404 Not Found",
-    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
   tputs(dcc[idx].sock, response, i);
   nfree(response);
   killsock(dcc[idx].sock);
@@ -138,7 +138,7 @@ static void put_file(int idx, int file_cache_index) {
     "Server: %s\r\n"
     "\r\n",
     (intmax_t) sb.st_size, f->content_type,
-    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
   response = nmalloc(i + sb.st_size);
   sprintf(response,
     "HTTP/1.1 200 \r\n" /* textual phrase is OPTIONAL */
@@ -147,7 +147,7 @@ static void put_file(int idx, int file_cache_index) {
     "Server: %s\r\n"
     "\r\n",
     (intmax_t) sb.st_size, f->content_type,
-    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
   memcpy(response + i, f->data, sb.st_size);
   tputs(dcc[idx].sock, response, i + sb.st_size);
   nfree(response);

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -428,6 +428,7 @@ static void webui_unframe(int sock, char *buf, int *len)
 {
   int i;
   uint8_t *key, *payload;
+  uint16_t status_code;
 
   if (*len < 6) { /* TODO: better len check */
 
@@ -455,8 +456,9 @@ static void webui_unframe(int sock, char *buf, int *len)
     payload[i] = payload[i] ^ key[i % 4];
 
   if (buf[0] & 0x08) {
-    putlog(LOG_MISC, "*", "WEBUI: connection closed by peer with status code %i sock %i",
-           ntohs(*((uint16_t *) payload)), sock);
+    status_code = ntohs(*((uint16_t *) payload));
+    putlog(LOG_MISC, "*", "WEBUI: connection closed by peer with status code %i%s sock %i",
+           status_code, status_code == 1001 ? " (Going Away)" : "", sock);
     killsock(sock);
     lostdcc(findanyidx(sock));
     return;

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -53,6 +53,7 @@ static const uint8_t alert[] = {0x15, 0x03, 0x01, 0x00, 0x02, 0x02, 0x0a};
 static void webui_http_eof(int idx)
 {
   debug2("webui: webui_http_eof() idx %i sock %li", idx, dcc[idx].sock);
+  dcc[idx].u.webui_listen_idx = 0;
   killsock(dcc[idx].sock);
   lostdcc(idx);
 }

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -305,102 +305,145 @@ static void webui_dcc_telnet_hostresolved(int idx, int listen_idx)
     // dcc[i].u.other = NULL; /* important, else nfree() error in lostdcc on eof */
 }
 
-/* TODO: add bounds checking or use existing function under MIT/GPL license
- *       instead of our own code
- */
-static size_t escape_html(char *dst, char *src, size_t size) {
+static size_t escape_html(char *dst, size_t dst_size, char *src, size_t src_size) {
   int i;
   char *d = dst;
 
-  for (i = 0; i < size; i++) {
+  for (i = 0; i < src_size; i++) {
     switch ((unsigned char) src[i]) {
       case '"':
+        if (dst_size < 6) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = '&';
         *d++ = 'q';
         *d++ = 'u';
         *d++ = 'o';
         *d++ = 't';
         *d++ = ';';
+        dst_size -= 6;
         break;
       case '&':
+        if (dst_size < 5) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = '&';
         *d++ = 'a';
         *d++ = 'm';
         *d++ = 'p';
         *d++ = ';';
+        dst_size -= 5;
         break;
       case '\'':
+        if (dst_size < 6) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = '&';
         *d++ = 'a';
         *d++ = 'p';
         *d++ = 'o';
         *d++ = 's';
         *d++ = ';';
+        dst_size -= 6;
         break;
       case '<':
+        if (dst_size < 4) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = '&';
         *d++ = 'l';
         *d++ = 't';
         *d++ = ';';
+        dst_size -= 4;
         break;
       case '>':
+        if (dst_size < 4) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = '&';
         *d++ = 'g';
         *d++ = 't';
         *d++ = ';';
+        dst_size -= 4;
         break;
       case ESC:
-        if ((i + 4) < size) {
+        if ((i + 3) < src_size) {
           if (     ((unsigned char) src[i + 1] == '[') &&
                    ((unsigned char) src[i + 2] == '0') &&
                    ((unsigned char) src[i + 3] == 'm')) {
+            if (dst_size < 4) {
+              debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+              return d - dst;
+            }
             *d++ = '<';
             *d++ = '/';
             *d++ = 'b';
             *d++ = '>';
+            dst_size -= 4;
           } else if (((unsigned char) src[i + 1] == '[') &&
                    ((unsigned char) src[i + 2] == '1') &&
                    ((unsigned char) src[i + 3] == 'm')) {
+            if (dst_size < 3) {
+              debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+              return d - dst;
+            }
             *d++ = '<';
             *d++ = 'b';
             *d++ = '>';
+            dst_size -= 3;
           } else
-            debug3("webui: escape_html(): unknown escape sequence found, skipping, %x %x %x, PLEASE REPORT THIS BUG",
+            debug3("webui: escape_html(): unknown escape sequence found, skipping, %02x %02x %02x, PLEASE REPORT THIS BUG",
                    (unsigned char) src[i + 1], (unsigned char) src[i + 2], (unsigned char) src[i + 3]);
           i += 3;
         } else
           debug0("webui: escape_html(): unknown SHORT escape sequence found, skipping, PLEASE REPORT THIS BUG");
         break;
       case TLN_IAC:
-        if ((i + 2) < size) {
-          if (     ((unsigned char) src[i + 1] == TLN_WILL) &&
-                   ((unsigned char) src[i + 2] == TLN_ECHO))
+        if ((i + 2) < src_size) {
+          if (dst_size < 1) {
+            debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+            return d - dst;
+          }
+          if (       ((unsigned char) src[i + 1] == TLN_WILL) &&
+                     ((unsigned char) src[i + 2] == TLN_ECHO)) {
             *d++ = WS_ECHO_OFF;
-          else if (((unsigned char) src[i + 1] == TLN_WONT) &&
-                   ((unsigned char) src[i + 2] == TLN_ECHO))
+            dst_size--;
+          } else if (((unsigned char) src[i + 1] == TLN_WONT) &&
+                     ((unsigned char) src[i + 2] == TLN_ECHO)) {
             *d++ = WS_ECHO_ON;
-          else
-            debug2("webui: escape_html(): unknown telnet command found, skipping, %x %x, PLEASE REPORT THIS BUG",
+            dst_size--;
+          } else
+            debug2("webui: escape_html(): unknown telnet command found, skipping, %02x %02x, PLEASE REPORT THIS BUG",
                    (unsigned char) src[i + 1], (unsigned char) src[i + 2]);
           i += 2;
         } else
           debug0("webui: escape_html(): unknown SHORT telnet command found, skipping, PLEASE REPORT THIS BUG");
         break;
       default:
+        if (dst_size < 1) {
+          debug0("webui: escape_html(): destination string too long, PLEASE REPORT THIS BUG");
+          return d - dst;
+        }
         *d++ = src[i];
+        dst_size--;
     }
   }
   return d - dst;
 }
 
 static size_t webui_frame(char **dst, char *src, size_t len) {
-  static char buf[4096];
+  static char buf[LOGLINELEN];
   uint16_t len2;
 
   /* escape/replace html code chars
    * write to buf + offset 4 to leave room for webui frame header
    */
-  len = escape_html(buf + 4, src, len);
+  len = escape_html(buf + 4, (sizeof buf) - 4, src, len);
   /* we must not use putlog() or debug() here or we get recursion */
   /* A server MUST NOT mask any frames that it sends to the client */
   /* we use text, not binary, so escape_html() must output valid html */
@@ -419,7 +462,7 @@ static size_t webui_frame(char **dst, char *src, size_t len) {
   }
   /* we dont need to implement len > 0xffff,
    * because eggdrop wont send that much data at once,
-   * we also limit by sizeof buf = 4096 */
+   * we also limit by sizeof buf */
   return len;
 }
 

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -432,18 +432,8 @@ static void webui_unframe(int sock, char *buf, int *len)
 
     /* TODO: return error code ? */
     putlog(LOG_MISC, "*", "WEBUI error: bogus WebSocket frame from sock %i", sock);
-    /*
-    putlog(LOG_MISC, "*",
-           "WEBUI error: %s sent something other than WebSocket protocol",
-           iptostr(&dcc[idx].sockname.addr.sa));
-    killsock(dcc[idx].sock);
-    lostdcc(idx);
-    */
-    return;
-  }
-  if (buf[0] & 0x08) {
-    // TODO:
-    putlog(LOG_MISC, "*", "WEBUI: fixme: sent connection close not handled yet sock %i", sock);
+    killsock(sock);
+    lostdcc(findanyidx(sock));
     return;
   }
   /* xor decrypt
@@ -462,6 +452,14 @@ static void webui_unframe(int sock, char *buf, int *len)
   payload = key + 4;
   for (i = 0; i < *len; i++)
     payload[i] = payload[i] ^ key[i % 4];
+
+  if (buf[0] & 0x08) {
+    putlog(LOG_MISC, "*", "WEBUI: connection closed by peer with status code %i sock %i",
+           ntohs(*((uint16_t *) payload)), sock);
+    killsock(sock);
+    lostdcc(findanyidx(sock));
+    return;
+  }
 
   memmove(buf, payload, *len);
   /* we switched back from binary sock to text sock for sockgets() needs this for dcc_telnet_id() */

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -155,7 +155,7 @@ static void put_file(int idx, int file_cache_index) {
 static void webui_http_activity(int idx, char *buf, int len)
 {
   struct rusage ru1, ru2;
-  int r, i;
+  int r, i, listen_idx;
   char *response;
 
   if (len < 6) { /* TODO: better len check */
@@ -248,16 +248,10 @@ static void webui_http_activity(int idx, char *buf, int len)
     debug4("webui: set flag SOCK_WS socklist %i idx %i sock %li status %lu", findsock(dcc[idx].sock), idx, dcc[idx].sock, dcc[idx].status);
 
     dcc[idx].status |= STAT_USRONLY; /* magick */
-    for (i = 0; i < dcc_total; i++) /* we need to link from idx, dont we? is there a better way to do it? */
-      if (!strcmp(dcc[i].nick, "(webui)")) {
-        debug2("webui: found (webui) idx %i dcc %i", idx, i);
-        break;
-      }
 
-    // dcc[idx].u.other = NULL; /* fix ATTEMPTING TO FREE NON-MALLOC'D PTR: dccutil.c (561) */
-    dcc_telnet_hostresolved2(idx, i);
-
-    debug2("webui: CHANGEOVER -> idx %i sock %li", idx, dcc[idx].sock);
+    listen_idx = dcc[idx].u.webui_listen_idx;
+    dcc[idx].u.webui_listen_idx = 0;
+    dcc_telnet_hostresolved2(idx, listen_idx);
   } else if (buf[5] == 'a') {
     put_file(idx, 0);
   } else
@@ -300,12 +294,13 @@ static struct dcc_table DCC_WEBUI_HTTP = {
   NULL
 };
 
-static void webui_dcc_telnet_hostresolved(int i)
+static void webui_dcc_telnet_hostresolved(int idx, int listen_idx)
 {
-    debug1("webui_dcc_telnet_hostresolved() idx %i", i);
-    changeover_dcc(i, &DCC_WEBUI_HTTP, 0);
-    sockoptions(dcc[i].sock, EGG_OPTION_SET, SOCK_BINARY);
-    sockoptions(dcc[i].sock, EGG_OPTION_UNSET, SOCK_BUFFER);
+    debug2("webui_dcc_telnet_hostresolved() idx %i listen_idx %i", idx, listen_idx);
+    changeover_dcc(idx, &DCC_WEBUI_HTTP, 0);
+    dcc[idx].u.webui_listen_idx = listen_idx;
+    sockoptions(dcc[idx].sock, EGG_OPTION_SET, SOCK_BINARY);
+    sockoptions(dcc[idx].sock, EGG_OPTION_UNSET, SOCK_BUFFER);
     // dcc[i].u.other = NULL; /* important, else nfree() error in lostdcc on eof */
 }
 

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -179,14 +179,12 @@ static void webui_http_activity(int idx, char *buf, int len)
   debug2("webui: webui_http_activity(): idx %i len %i", idx, len);
   buf[len] = '\0'; /* TODO: is there no better way? we already know len */
   if (buf[5] == ' ') {
-    debug0("webui: GET /");
+    debug1("webui: GET / idx %i", idx);
     put_file(idx, 2);
   } else if (buf[5] == 'f') {
-    debug0("webui: GET /favicon.ico");
     put_file(idx, 1);
   } else if (buf[5] == 'w') {
-    debug0("webui: GET /w");
-    debug2("webui: webui_http_activity(): idx %i buf\n%s", idx, buf);
+    debug1("webui: GET /w idx %i", idx);
     buf = strstr(buf, WS_KEY);
     if (!buf) {
       putlog(LOG_MISC, "*", "WEBUI error: Sec-WebSocket-Key not found ip %s", iptostr(&dcc[idx].sockname.addr.sa));
@@ -195,10 +193,9 @@ static void webui_http_activity(int idx, char *buf, int len)
     buf += sizeof WS_KEY;
     for(i = 0; i < WS_KEYLEN; i++)
       if (!buf[i]) {
-        putlog(LOG_MISC, "*", "WEBUI error: Sec-WebSocket-Key too short");
+        putlog(LOG_MISC, "*", "WEBUI error: Sec-WebSocket-Key too short ip %s", iptostr(&dcc[idx].sockname.addr.sa));
         return;
       }
-    debug0("webui: server requests websocket upgrade");
     unsigned char hash[SHA_DIGEST_LENGTH];
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
@@ -245,7 +242,7 @@ static void webui_http_activity(int idx, char *buf, int len)
 
 
     socklist_i->flags &= ~ SOCK_BINARY; /* we need it for net.c sockgets(), is there better place to do this? */
-    debug1("webui: unset flag SOCK_BINARY sock %li", dcc[idx].sock);
+    debug2("webui: unset flag SOCK_BINARY idx %i sock %li", idx, dcc[idx].sock);
     strcpy(dcc[idx].host, "*"); /* important for later dcc_telnet_id wild_match, is there better place to do this? */
     /* .host becomes .nick in change_to_dcc_telnet_id() */
     debug4("webui: set flag SOCK_WS socklist %i idx %i sock %li status %lu", findsock(dcc[idx].sock), idx, dcc[idx].sock, dcc[idx].status);
@@ -253,7 +250,7 @@ static void webui_http_activity(int idx, char *buf, int len)
     dcc[idx].status |= STAT_USRONLY; /* magick */
     for (i = 0; i < dcc_total; i++) /* we need to link from idx, dont we? is there a better way to do it? */
       if (!strcmp(dcc[i].nick, "(webui)")) {
-        debug1("webui: found (webui) dcc %i", i);
+        debug2("webui: found (webui) idx %i dcc %i", idx, i);
         break;
       }
 
@@ -262,7 +259,6 @@ static void webui_http_activity(int idx, char *buf, int len)
 
     debug2("webui: CHANGEOVER -> idx %i sock %li", idx, dcc[idx].sock);
   } else if (buf[5] == 'a') {
-    debug0("webui: GET /apple-touch-icon.png");
     put_file(idx, 0);
   } else
     put_404(idx);
@@ -270,9 +266,9 @@ static void webui_http_activity(int idx, char *buf, int len)
     /* read probable remaining bytes */
     SSL *ssl = socklist[findsock(dcc[idx].sock)].ssl;
     if (ssl)
-      debug1("webui: SSL_read(): len %i", SSL_read(ssl, buf, 511));
+      debug2("webui: SSL_read(): idx %i len %i", idx, SSL_read(ssl, buf, 511));
     else
-      debug1("webui: read(): len %li", read(dcc[idx].sock, buf, 511));
+      debug2("webui: read(): idx %i len %li", idx, read(dcc[idx].sock, buf, 511));
   }
   if (!r && !getrusage(RUSAGE_SELF, &ru2))
     debug2("webui: webui_http_activity(): user %.3fms sys %.3fms",
@@ -306,7 +302,7 @@ static struct dcc_table DCC_WEBUI_HTTP = {
 
 static void webui_dcc_telnet_hostresolved(int i)
 {
-    debug1("webui_dcc_telnet_hostresolved(%i)", i);
+    debug1("webui_dcc_telnet_hostresolved() idx %i", i);
     changeover_dcc(i, &DCC_WEBUI_HTTP, 0);
     sockoptions(dcc[i].sock, EGG_OPTION_SET, SOCK_BINARY);
     sockoptions(dcc[i].sock, EGG_OPTION_UNSET, SOCK_BUFFER);
@@ -432,16 +428,15 @@ static size_t webui_frame(char **dst, char *src, size_t len) {
 }
 
 /* TODO: return error code ? */
-static void webui_unframe(char *buf, int *len)
+static void webui_unframe(int sock, char *buf, int *len)
 {
   int i;
   uint8_t *key, *payload;
 
-  debug1("webui: webui_unframe(): len %i", *len);
   if (*len < 6) { /* TODO: better len check */
 
     /* TODO: return error code ? */
-    putlog(LOG_MISC, "*", "WEBUI error: someone sent something other than WebSocket protocol");
+    putlog(LOG_MISC, "*", "WEBUI error: bogus WebSocket frame from sock %i", sock);
     /*
     putlog(LOG_MISC, "*",
            "WEBUI error: %s sent something other than WebSocket protocol",
@@ -452,7 +447,8 @@ static void webui_unframe(char *buf, int *len)
     return;
   }
   if (buf[0] & 0x08) {
-    putlog(LOG_MISC, "*", "WEBUI: fixme: sent connection close not handled yet");
+    // TODO:
+    putlog(LOG_MISC, "*", "WEBUI: fixme: sent connection close not handled yet sock %i", sock);
     return;
   }
   /* xor decrypt
@@ -490,7 +486,7 @@ static char *webui_close(void)
     if (!strcmp(dcc[idx].nick, "(webui)") ||
         !strcmp(dcc[idx].type->name, "WEBUI_HTTP") ||
         (socklist[findsock(dcc[idx].sock)].flags & SOCK_WS)) {
-      debug1("webui: webui_close(): closing sock %li", dcc[idx].sock);
+      debug2("webui: webui_close(): closing sock idx %i, %li", idx, dcc[idx].sock);
       killsock(dcc[idx].sock);
       lostdcc(idx);
     }

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -257,7 +257,7 @@ static void webui_http_activity(int idx, char *buf, int len)
         break;
       }
 
-    dcc[idx].u.other = NULL; /* fix ATTEMPTING TO FREE NON-MALLOC'D PTR: dccutil.c (561) */
+    // dcc[idx].u.other = NULL; /* fix ATTEMPTING TO FREE NON-MALLOC'D PTR: dccutil.c (561) */
     dcc_telnet_hostresolved2(idx, i);
 
     debug2("webui: CHANGEOVER -> idx %i sock %li", idx, dcc[idx].sock);
@@ -310,7 +310,7 @@ static void webui_dcc_telnet_hostresolved(int i)
     changeover_dcc(i, &DCC_WEBUI_HTTP, 0);
     sockoptions(dcc[i].sock, EGG_OPTION_SET, SOCK_BINARY);
     sockoptions(dcc[i].sock, EGG_OPTION_UNSET, SOCK_BUFFER);
-    dcc[i].u.other = NULL; /* important, else nfree() error in lostdcc on eof */
+    // dcc[i].u.other = NULL; /* important, else nfree() error in lostdcc on eof */
 }
 
 /* TODO: add bounds checking or use existing function under MIT/GPL license

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -177,7 +177,7 @@ static void webui_http_activity(int idx, char *buf, int len)
   }
   r = getrusage(RUSAGE_SELF, &ru1);
   debug2("webui: webui_http_activity(): idx %i len %i", idx, len);
-  buf[len] = '\0'; /* TODO: is there no better way? we already know len */
+  buf[len] = '\0';
   if (buf[5] == ' ') {
     debug1("webui: GET / idx %i", idx);
     put_file(idx, 2);

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -186,9 +186,10 @@ static void webui_http_activity(int idx, char *buf, int len)
     put_file(idx, 1);
   } else if (buf[5] == 'w') {
     debug0("webui: GET /w");
+    debug2("webui: webui_http_activity(): idx %i buf\n%s", idx, buf);
     buf = strstr(buf, WS_KEY);
     if (!buf) {
-      putlog(LOG_MISC, "*", "WEBUI error: Sec-WebSocket-Key not found");
+      putlog(LOG_MISC, "*", "WEBUI error: Sec-WebSocket-Key not found ip %s", iptostr(&dcc[idx].sockname.addr.sa));
       return;
     }
     buf += sizeof WS_KEY;

--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -243,7 +243,7 @@ static void webui_http_activity(int idx, char *buf, int len)
 
     socklist_i->flags &= ~ SOCK_BINARY; /* we need it for net.c sockgets(), is there better place to do this? */
     debug2("webui: unset flag SOCK_BINARY idx %i sock %li", idx, dcc[idx].sock);
-    strcpy(dcc[idx].host, "*"); /* important for later dcc_telnet_id wild_match, is there better place to do this? */
+    //strcpy(dcc[idx].host, "*"); /* important for later dcc_telnet_id wild_match, is there better place to do this? */
     /* .host becomes .nick in change_to_dcc_telnet_id() */
     debug4("webui: set flag SOCK_WS socklist %i idx %i sock %li status %lu", findsock(dcc[idx].sock), idx, dcc[idx].sock, dcc[idx].status);
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -171,7 +171,7 @@ int (*rfc_toupper) (int) = _rfc_toupper;
 int (*rfc_tolower) (int) = _rfc_tolower;
 void (*dns_hostbyip) (sockname_t *) = core_dns_hostbyip;
 void (*dns_ipbyhost) (char *) = core_dns_ipbyhost;
-void (*webui_dcc_telnet_hostresolved) (int) = 0;
+void (*webui_dcc_telnet_hostresolved) (int, int) = 0;
 size_t (*webui_frame) (char **, char *, size_t) = 0;
 void (*webui_unframe) (int, char *, int *) = 0;
 
@@ -1115,7 +1115,7 @@ void add_hook(int hook_num, Function func)
         dns_ipbyhost = (void (*)(char *)) func;
       break;
     case HOOK_DCC_TELNET_HOSTRESOLVED:
-      webui_dcc_telnet_hostresolved = (void (*)(int)) func;
+      webui_dcc_telnet_hostresolved = (void (*)(int, int)) func;
       break;
     case HOOK_WEBUI_FRAME:
       webui_frame = (size_t (*)(char **, char *, size_t)) func;
@@ -1194,8 +1194,8 @@ void del_hook(int hook_num, Function func)
         dns_ipbyhost = core_dns_ipbyhost;
       break;
     case HOOK_DCC_TELNET_HOSTRESOLVED:
-      if (webui_dcc_telnet_hostresolved == (void (*)(int)) func)
-        webui_dcc_telnet_hostresolved = (void (*)(int)) null_func;
+      if (webui_dcc_telnet_hostresolved == (void (*)(int, int)) func)
+        webui_dcc_telnet_hostresolved = (void (*)(int, int)) null_func;
       break;
     case HOOK_WEBUI_FRAME:
       if (webui_frame == (size_t (*)(char **, char *, size_t)) func)

--- a/src/modules.c
+++ b/src/modules.c
@@ -173,7 +173,7 @@ void (*dns_hostbyip) (sockname_t *) = core_dns_hostbyip;
 void (*dns_ipbyhost) (char *) = core_dns_ipbyhost;
 void (*webui_dcc_telnet_hostresolved) (int) = 0;
 size_t (*webui_frame) (char **, char *, size_t) = 0;
-void (*webui_unframe) (char *, int *) = 0;
+void (*webui_unframe) (int, char *, int *) = 0;
 
 module_entry *module_list;
 dependancy *dependancy_list = NULL;
@@ -1121,7 +1121,7 @@ void add_hook(int hook_num, Function func)
       webui_frame = (size_t (*)(char **, char *, size_t)) func;
       break;
     case HOOK_WEBUI_UNFRAME:
-      webui_unframe = (void (*)(char *, int *)) func;
+      webui_unframe = (void (*)(int, char *, int *)) func;
       break;
     }
 }
@@ -1202,8 +1202,8 @@ void del_hook(int hook_num, Function func)
         webui_frame = (size_t (*)(char**, char *, size_t)) null_func;
       break;
     case HOOK_WEBUI_UNFRAME:
-      if (webui_unframe == (void (*)(char *, int *)) func)
-        webui_unframe = (void (*)(char *, int *)) null_func;
+      if (webui_unframe == (void (*)(int, char *, int *)) func)
+        webui_unframe = (void (*)(int, char *, int *)) null_func;
       break;
     }
 }

--- a/src/net.c
+++ b/src/net.c
@@ -1021,7 +1021,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
       }
 #ifdef TLS
       if (socklist[i].flags & SOCK_WS)
-        webui_unframe(i, s, &x);
+        webui_unframe(slist[i].sock, s, &x);
 #endif /* TLS */
       s[x] = 0;
       *len = x;

--- a/src/net.c
+++ b/src/net.c
@@ -1021,7 +1021,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
       }
 #ifdef TLS
       if (socklist[i].flags & SOCK_WS)
-        webui_unframe(s, &x);
+        webui_unframe(i, s, &x);
 #endif /* TLS */
       s[x] = 0;
       *len = x;

--- a/src/proto.h
+++ b/src/proto.h
@@ -54,7 +54,7 @@ extern int (*rfc_ncasecmp) (const char *, const char *, int);
 extern int (*rfc_toupper) (int);
 extern int (*rfc_tolower) (int);
 extern int (*match_noterej) (struct userrec *, char *);
-extern void (*webui_dcc_telnet_hostresolved) (int);
+extern void (*webui_dcc_telnet_hostresolved) (int, int);
 extern size_t (*webui_frame) (char **, char *, size_t);
 extern void (*webui_unframe) (int, char *, int *);
 #endif

--- a/src/proto.h
+++ b/src/proto.h
@@ -56,7 +56,7 @@ extern int (*rfc_tolower) (int);
 extern int (*match_noterej) (struct userrec *, char *);
 extern void (*webui_dcc_telnet_hostresolved) (int);
 extern size_t (*webui_frame) (char **, char *, size_t);
-extern void (*webui_unframe) (char *, int *);
+extern void (*webui_unframe) (int, char *, int *);
 #endif
 
 /* botcmd.c */


### PR DESCRIPTION
Found by:
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):
1. workaround code for a problem with `dcc[i].u.other` replaced with proper fix in `changeover_dcc()`
2. Fixed code comment and enhanced logging
3. Fix ident for webui.mod (for case when more than 1 listening port was set in `eggdrop.conf`, like one for http and one for https)
4. `webui_unframe()` will now detect "connection closed by peer with status code" (for status code meaning see rfc rfc6455 7.4.1, for example status code 1001 would probably mean user moved away, closed browser window or tab)
5. Fix dcc.host for webui user. When a webui user does `.quit`:
Before:
`[07:32:23] DCC connection closed (testuser!telnet@*)`
After:
`[07:34:54] DCC connection closed (testuser!telnet@localhost.home.arpa)`
6. Enhanced index.html (html and js code)
7. `escape_html()` now does proper bounds checking on destination buffer.

Test cases demonstrating functionality (if applicable):
