### PR TITLE
Fix user@host

### DIFF
--- a/src/dcc.c
+++ b/src/dcc.c
@@ -1378,7 +1378,7 @@ void dcc_telnet_hostresolved2(int i, int idx) {
 static void dcc_telnet_hostresolved(int i)
 {
   int idx;
-  char s[sizeof lasttelnethost], *userhost;
+  char s[sizeof lasttelnethost];
 
   debug0("dcc_telnet_hostresolved()");
   strlcpy(dcc[i].host, dcc[i].u.dns->host, UHOSTLEN);
@@ -1405,7 +1405,6 @@ static void dcc_telnet_hostresolved(int i)
     }
   }
   snprintf(s, sizeof s, "-telnet!telnet@%s", dcc[i].host);
-  userhost = s + strlen("-telnet!");
   if (match_ignore(s) || detect_telnet_flood(s)) {
     killsock(dcc[i].sock);
     lostdcc(i);
@@ -1434,7 +1433,6 @@ static void dcc_telnet_hostresolved(int i)
     changeover_dcc(i, &DCC_SOCKET, 0);
     dcc[i].u.other = NULL;
     strcpy(dcc[i].nick, "*");
-    strlcpy(dcc[i].host, userhost, UHOSTLEN);
     check_tcl_listen(dcc[idx].host, dcc[i].sock);
     return;
   }
@@ -1447,7 +1445,6 @@ static void dcc_telnet_hostresolved(int i)
   }
 #endif /* TLS */
 
-  strlcpy(dcc[i].host, userhost, UHOSTLEN);
   dcc_telnet_hostresolved2(i, idx);
 }
 

--- a/src/userrec.c
+++ b/src/userrec.c
@@ -384,7 +384,6 @@ struct userrec *get_user_by_host(char *host)
   struct userrec *u, *ret = NULL;
   struct list_type *q;
   int cnt, i;
-  char host2[UHOSTLEN];
 
   if (host == NULL)
     return NULL;
@@ -393,7 +392,6 @@ struct userrec *get_user_by_host(char *host)
     return NULL;
   cnt = 0;
   cache_miss++;
-  strlcpy(host2, host, sizeof host2);
   for (u = userlist; u; u = u->next) {
     q = get_user(&USERENTRY_HOSTS, u);
     for (; q; q = q->next) {


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix user@host

Additional description (if needed):
`telnet@telnet@<host>` is bogus doppelmoppel @@
This is an ancient bug, since at least year 1999

Test cases demonstrating functionality (if applicable):
Before:
`[09:36:57] Logged in: testuser (telnet@telnet@localhost.home.arpa/33366)`
After (without identd running):
`[10:46:31] Logged in: testuser (telnet@localhost.home.arpa/44216)`
After (with identd running):
`[10:45:50] Logged in: testuser (michael@localhost.home.arpa/44520)`