### PR TITLE
Arbitrary mode support, phase 1

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1324,18 +1324,6 @@ set bounce-invites 0
 # Set this to 1 if you want to bounce all server modes.
 set bounce-modes 0
 
-# The following settings should be left commented unless the default values
-# are being overridden. By default, exempts and invites are on for EFnet and
-# IRCnet, but off for all other large networks. This behavior can be modified
-# with the following 2 flags. If your network doesn't support +e/+I modes then
-# you will be unable to use these features.
-#
-# Do you want to enable exempts (+e modes)?
-#set use-exempts 0
-
-# Do you want to enable invites (+I modes)?
-#set use-invites 0
-
 # If you want people to be able to add themselves to the bot's userlist
 # with the default userflags (defined above in the config file) via the
 # 'hello' msg command, set this to 1.

--- a/src/eggdrop.h
+++ b/src/eggdrop.h
@@ -747,6 +747,12 @@ enum {
   #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
+#define MAX_IRC_TOKENS 64 // TODO: does this make sense?
+typedef struct parsed_irc {
+  size_t argc;
+  char *argv[MAX_IRC_TOKENS];
+} parsed_irc_t;
+
 #ifdef EGG_TDNS
 #include <pthread.h>
 #define DTN_TYPE_HOSTBYIP 0

--- a/src/misc.c
+++ b/src/misc.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include "chan.h"
+#include "src/eggdrop.h"
 #include "tandem.h"
 #include "modules.h"
 
@@ -267,6 +268,60 @@ char *newsplit(char **rest)
     *o++ = 0;
   *rest = o;
   return r;
+}
+
+// WARNING: modifies original text
+// Split IRC text into words (without the "from" component, which could also start with ':')
+// - replace all ' ' with \0, splitting into words
+// - if a word starts with ':' it is the last word, it can contain spaces
+// - return argc/argv structure (pointers into original text)
+struct parsed_irc parse_irc(char *text)
+{
+  struct parsed_irc result = {.argc = 0};
+
+  while (*text) {
+    while (*text == ' ') {
+      *text++ = '\0';
+    }
+    if (!*text) {
+      break;
+    }
+    if (result.argc == MAX_IRC_TOKENS - 1) {
+      putlog(LOG_MISC, "*", "parse_irc() error: too many tokens, PLEASE REPORT THIS BUG");
+      result.argv[result.argc++] = text;
+      break;
+    } else if (*text == ':') {
+      *text++ = '\0';
+      result.argv[result.argc++] = text;
+      break;
+    } else {
+      result.argv[result.argc++] = text;
+      while (*text && *text != ' ') {
+        text++;
+      }
+    }
+  }
+
+  return result;
+}
+
+char *join_str_array(char **argv, int argc, char *delim, char *outbuf, size_t outbufsiz)
+{
+  size_t written = 0;
+
+  if (!argc) {
+    outbuf[0] = '\0';
+    return outbuf;
+  }
+
+  for (int i = 0; i < argc; i++) {
+    written += snprintf(outbuf + written, outbufsiz - written, "%s%s", argv[i], i == argc - 1 ? "" : delim);
+    if (written >= outbufsiz) {
+      written = outbufsiz - 1;
+      break;
+    }
+  }
+  return outbuf;
 }
 
 /* maskhost(), modified to support custom mask types, as defined

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2860,6 +2860,11 @@ static void update_chanmodes(mode_info_t *modes, int is_prefix)
       }
     }
   }
+  if (!is_prefix) {
+    // assume that if +e/+I are list-type modes that they are exempts and invites
+    use_exempts = (MODE_TYPE('e') == MODETYPE_LIST);
+    use_invites = (MODE_TYPE('I') == MODETYPE_LIST);
+  }
 }
 
 // CHANMODES=eIbq,k,flj,CFLMPQScgimnprstuz

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -958,16 +958,21 @@ static void recheck_channel(struct chanset_t *chan, int dobans)
 }
 
 /* got 324: mode status
- * <server> 324 <to> <channel> <mode>
+ * <server> 324 <to> <channel> <mode> [<mode params>...]
  */
-static int got324(char *from, char *msg)
+static int got324(char *from, char *origmsg)
 {
-  int i = 1, ok = 0;
-  char *p, *q, *chname;
+  int i = 1, ok = 0, nextarg = 3;
+  char *chname, *chg, *arg, buf[511];
+  struct parsed_irc msg;
   struct chanset_t *chan;
 
-  newsplit(&msg);
-  chname = newsplit(&msg);
+  strlcpy(buf, origmsg, sizeof buf);
+  msg = parse_irc(buf);
+  if (msg.argc < 3)
+    return 0;
+  chname = msg.argv[1];
+  chg = msg.argv[2];
   chan = findchan(chname);
   if (!chan) {
     putlog(LOG_MISC, "*", "%s: %s", IRC_UNEXPECTEDMODE, chname);
@@ -978,58 +983,65 @@ static int got324(char *from, char *msg)
     ok = 1;
   chan->status &= ~CHAN_ASKEDMODES;
   chan->channel.mode = 0;
-  while (msg[i] != 0) {
-    if (msg[i] == 'i')
-      chan->channel.mode |= CHANINV;
-    if (msg[i] == 'p')
-      chan->channel.mode |= CHANPRIV;
-    if (msg[i] == 's')
-      chan->channel.mode |= CHANSEC;
-    if (msg[i] == 'm')
-      chan->channel.mode |= CHANMODER;
-    if (msg[i] == 'c')
-      chan->channel.mode |= CHANNOCLR;
-    if (msg[i] == 'C')
-      chan->channel.mode |= CHANNOCTCP;
-    if (msg[i] == 'R')
-      chan->channel.mode |= CHANREGON;
-    if (msg[i] == 'M')
-      chan->channel.mode |= CHANMODREG;
-    if (msg[i] == 'r')
-      chan->channel.mode |= CHANLONLY;
-    if (msg[i] == 'D')
-      chan->channel.mode |= CHANDELJN;
-    if (msg[i] == 'u')
-      chan->channel.mode |= CHANSTRIP;
-    if (msg[i] == 'N')
-      chan->channel.mode |= CHANNONOTC;
-    if (msg[i] == 'T')
-      chan->channel.mode |= CHANNOAMSG;
-    if (msg[i] == 'd')
-      chan->channel.mode |= CHANINVIS;
-    if (msg[i] == 't')
-      chan->channel.mode |= CHANTOPIC;
-    if (msg[i] == 'n')
-      chan->channel.mode |= CHANNOMSG;
-    if (msg[i] == 'a')
-      chan->channel.mode |= CHANANON;
-    if (msg[i] == 'q')
-      chan->channel.mode |= CHANQUIET;
-    if (msg[i] == 'k') {
-      chan->channel.mode |= CHANKEY;
-      p = strchr(msg, ' ');
-      if (p != NULL) {          /* Test for null key assignment */
-        p++;
-        q = strchr(p, ' ');
-        if (q != NULL) {
-          *q = 0;
-          set_key(chan, p);
-          memmove(p, q + 1, strlen(q + 1) + 1);
-        } else {
-          set_key(chan, p);
-          *p = 0;
-        }
+  while (chg[i] != 0) {
+    arg = NULL;
+    if (MODE_HAS_SET_ARG(chg[i])) {
+      if (nextarg < (int) msg.argc) {
+        arg = msg.argv[nextarg++];
+      } else {
+        putlog(LOG_MISC, "*", "Error parsing modes in '%s', not enough arguments for +%c", origmsg, chg[i]);
       }
+    }
+    /* hardcoded assumptions in the existing old select code, SANITY CHECK */
+    if (strchr("kl", chg[i]) && !arg) {
+      arg = "";
+      putlog(LOG_MISC, "*", "Error parsing modes in '%s', Eggdrop assumes mode change +%c has a parameter but isupport says no", origmsg, chg[i]);
+    }
+    if (strchr("ipsmcCRMrDuNTdtnaq", chg[i]) && arg) {
+      putlog(LOG_MISC, "*", "Error parsing modes in '%s', Eggdrop assumes mode change +%c has no parameter but isupport says yes, ignoring", origmsg, chg[i]);
+      i++;
+      continue;
+    }
+    if (chg[i] == 'i')
+      chan->channel.mode |= CHANINV;
+    if (chg[i] == 'p')
+      chan->channel.mode |= CHANPRIV;
+    if (chg[i] == 's')
+      chan->channel.mode |= CHANSEC;
+    if (chg[i] == 'm')
+      chan->channel.mode |= CHANMODER;
+    if (chg[i] == 'c')
+      chan->channel.mode |= CHANNOCLR;
+    if (chg[i] == 'C')
+      chan->channel.mode |= CHANNOCTCP;
+    if (chg[i] == 'R')
+      chan->channel.mode |= CHANREGON;
+    if (chg[i] == 'M')
+      chan->channel.mode |= CHANMODREG;
+    if (chg[i] == 'r')
+      chan->channel.mode |= CHANLONLY;
+    if (chg[i] == 'D')
+      chan->channel.mode |= CHANDELJN;
+    if (chg[i] == 'u')
+      chan->channel.mode |= CHANSTRIP;
+    if (chg[i] == 'N')
+      chan->channel.mode |= CHANNONOTC;
+    if (chg[i] == 'T')
+      chan->channel.mode |= CHANNOAMSG;
+    if (chg[i] == 'd')
+      chan->channel.mode |= CHANINVIS;
+    if (chg[i] == 't')
+      chan->channel.mode |= CHANTOPIC;
+    if (chg[i] == 'n')
+      chan->channel.mode |= CHANNOMSG;
+    if (chg[i] == 'a')
+      chan->channel.mode |= CHANANON;
+    if (chg[i] == 'q')
+      chan->channel.mode |= CHANQUIET;
+    if (chg[i] == 'k') {
+      chan->channel.mode |= CHANKEY;
+      if (*arg)
+        set_key(chan, arg);
       if ((chan->channel.mode & CHANKEY) && (!chan->channel.key[0] ||
           !strcmp("*", chan->channel.key)))
         /* Undernet use to show a blank channel key if one was set when
@@ -1039,20 +1051,9 @@ static int got324(char *from, char *msg)
          * (guppy 22Dec2001) */
         chan->status |= CHAN_ASKEDMODES;
     }
-    if (msg[i] == 'l') {
-      p = strchr(msg, ' ');
-      if (p != NULL) {          /* test for null limit assignment */
-        p++;
-        q = strchr(p, ' ');
-        if (q != NULL) {
-          *q = 0;
-          chan->channel.maxmembers = atoi(p);
-          memmove(p, q + 1, strlen(q + 1) + 1);
-        } else {
-          chan->channel.maxmembers = atoi(p);
-          *p = 0;
-        }
-      }
+    if (chg[i] == 'l') {
+      if (*arg)
+        chan->channel.maxmembers = atoi(arg);
     }
     i++;
   }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -2843,6 +2843,103 @@ static int parse_maxlist(const char *value)
   return 0;
 }
 
+// selectively update global information table,
+// either chanmodes only or prefix modes only,
+// then delete all non-existing modes of that type only
+static void update_chanmodes(mode_info_t *modes, int is_prefix)
+{
+  for (int i = 0; i < 256; i++) {
+    if (modes[i].type) {
+      // is in the new mode info, must overwrite even if type changed
+      modecharinfo[i] = modes[i]; // struct copy
+    } else if (modecharinfo[i].type) {
+      // was in the old mode info but not in the new mode info -> delete
+      // but respect if its type has already changed
+      if ((modecharinfo[i].type == MODETYPE_PREFIX && is_prefix) || (modecharinfo[i].type != MODETYPE_PREFIX && !is_prefix)) {
+        memset(&modecharinfo[i], 0, sizeof modecharinfo[i]);
+      }
+    }
+  }
+}
+
+// CHANMODES=eIbq,k,flj,CFLMPQScgimnprstuz
+// listmodes, keymodes, limitmodes, flagmodes
+static int process_chanmodes(char *value)
+{
+  mode_type_t modetype = MODETYPE_LIST;
+  mode_info_t modes[256];
+
+  memset(&modes, 0, sizeof modes);
+
+  while (*value) {
+    // parse all modes until ','
+    while (*value && isalnum((unsigned char)*value)) {
+      modes[(unsigned char)*value].type = modetype;
+      modes[(unsigned char)*value].prefix = '\0';
+      debug2("Learned mode type: +%c type %s", *value, MODE_TYPE_STR(modetype));
+      value++;
+    }
+    // sanity check
+    if ((modetype != MODETYPE_FLAG && *value != ',') || (modetype == MODETYPE_FLAG && *value)) {
+      return -1;
+    }
+    // next section in order
+    if (modetype == MODETYPE_LIST) {
+      modetype = MODETYPE_KEY;
+    } else if (modetype == MODETYPE_KEY) {
+      modetype = MODETYPE_LIMIT;
+    } else if (modetype == MODETYPE_LIMIT) {
+      modetype = MODETYPE_FLAG;
+    } else {
+      break;
+    }
+    value++;
+  }
+  if (modetype != MODETYPE_FLAG) {
+    return -1;
+  }
+  // update global info table, but only for chanmodes (not prefix modes)
+  update_chanmodes(modes, 0);
+  return 0;
+}
+
+// PREFIX=(ov)@+
+static int process_prefix(const char *value)
+{
+  const char *prefix = value;
+  mode_info_t modes[256];
+
+  memset(&modes, 0, sizeof modes);
+
+  if (*value++ != '(') {
+    return -1;
+  }
+  while (*prefix && *prefix != ')') {
+    prefix++;
+  }
+  if (*prefix++ != ')') {
+    return -1;
+  }
+  // PREFIX=(ov)@+
+  // *value--^  ^--*prefix
+  while (*value && *value != ')') {
+    if (!*prefix || !isalnum((unsigned char)*value)) {
+      return -1;
+    }
+    modes[(unsigned char)*value].type = MODETYPE_PREFIX;
+    modes[(unsigned char)*value].prefix = *prefix;
+    debug3("Learned mode type: +%c type %s, prefixchar %c", *value, MODE_TYPE_STR(MODETYPE_PREFIX), *prefix);
+    value++;
+    prefix++;
+  }
+  if (*value != ')' || *prefix) {
+    return -1;
+  }
+  // update global info table, but only for prefixes
+  update_chanmodes(modes, 1);
+  return 0;
+}
+
 static int irc_isupport(char *key, char *isset_str, char *value)
 {
   int isset = !strcmp(isset_str, "1");
@@ -2865,6 +2962,20 @@ static int irc_isupport(char *key, char *isset_str, char *value)
     }
   } else if (!strcmp(key, "BOT")) {
     botflag005 = value[0];
+  } else if (!strcmp(key, "CHANMODES")) {
+    if (!isset) {
+      value = "";
+    }
+    if (process_chanmodes(value)) {
+      putlog(LOG_MISC, "*", "Error: isupport unable to parse CHANMODES=%s, ignoring", isset ? value : "(unset)");
+    }
+  } else if (!strcmp(key, "PREFIX")) {
+    if (!isset) {
+      value = "";
+    }
+    if (process_prefix(value)) {
+      putlog(LOG_MISC, "*", "Error: isupport unable to parse PREFIX=%s, ignoring", isset ? value : "(unset)");
+    }
   }
   return 0;
 }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -1198,9 +1198,6 @@ static void do_nettype()
   case NETT_HYBRID_EFNET:
     kick_method = 1;
     modesperline = 4;
-    use_354 = 0;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 100;
     max_exempts = 100;
     max_invites = 100;
@@ -1211,9 +1208,6 @@ static void do_nettype()
   case NETT_LIBERA:
     kick_method = 1;
     modesperline = 4;
-    use_354 = 1;
-    use_exempts = 1;
-    use_invites = 1;
     max_exempts = 100;
     max_invites = 100;
     max_bans = 100;
@@ -1224,9 +1218,6 @@ static void do_nettype()
   case NETT_FREENODE:
     kick_method = 1;
     modesperline = 4;
-    use_354 = 1;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 100;
     max_exempts = 100;
     max_invites = 100;
@@ -1237,9 +1228,6 @@ static void do_nettype()
   case NETT_IRCNET:
     kick_method = 4;
     modesperline = 3;
-    use_354 = 0;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 64;
     max_exempts = 64;
     max_invites = 64;
@@ -1250,9 +1238,6 @@ static void do_nettype()
   case NETT_UNDERNET:
     kick_method = 1;
     modesperline = 6;
-    use_354 = 1;
-    use_exempts = 0;
-    use_invites = 0;
     max_bans = 100;
     max_exempts = 0;
     max_invites = 0;
@@ -1263,9 +1248,6 @@ static void do_nettype()
   case NETT_DALNET:
     kick_method = 4;
     modesperline = 6;
-    use_354 = 0;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 200;
     max_exempts = 100;
     max_invites = 100;
@@ -1276,9 +1258,6 @@ static void do_nettype()
   case NETT_QUAKENET:
     kick_method = 1;
     modesperline = 6;
-    use_354 = 1;
-    use_exempts = 0;
-    use_invites = 0;
     max_bans = 45;
     max_exempts = 0;
     max_invites = 0;
@@ -1289,9 +1268,6 @@ static void do_nettype()
   case NETT_RIZON:
     kick_method = 1;
     modesperline = 4;
-    use_354 = 0;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 250;
     max_exempts = 250;
     max_invites = 250;
@@ -1304,9 +1280,6 @@ static void do_nettype()
     twitch = 1;
     kick_method = 1;
     modesperline = 4;
-    use_354 = 0;
-    use_exempts = 1;
-    use_invites = 1;
     max_bans = 100;
     max_exempts = 100;
     max_invites = 100;

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -67,6 +67,8 @@ static char opchars[8];         /* the chars in a /who reply meaning op */
 
 static Tcl_Obj *tcl_account;
 
+static mode_info_t modecharinfo[256];
+
 #include "chan.c"
 #include "mode.c"
 #include "cmdsirc.c"
@@ -1118,6 +1120,29 @@ static void tell_account_tracking_status(int idx, int details)
   }
 }
 
+static void tell_modeparsing_type(int idx, mode_type_t type)
+{
+  dprintf(idx, "    %s modes: %s", MODE_TYPE_STR(type), type == MODETYPE_PREFIX ? "" : "+");
+  for (int i = 0; i < 256; i++) {
+    if (modecharinfo[i].type == type) {
+      dprintf(idx, "%c", i);
+      if (type == MODETYPE_PREFIX) {
+        dprintf(idx, "(%c) ", modecharinfo[i].prefix);
+      }
+    }
+  }
+  dprintf(idx, "\n");
+}
+
+static void tell_modeparsing(int idx)
+{
+  tell_modeparsing_type(idx, MODETYPE_FLAG);
+  tell_modeparsing_type(idx, MODETYPE_LIMIT);
+  tell_modeparsing_type(idx, MODETYPE_KEY);
+  tell_modeparsing_type(idx, MODETYPE_LIST);
+  tell_modeparsing_type(idx, MODETYPE_PREFIX);
+}
+
 static void irc_report(int idx, int details)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
@@ -1157,6 +1182,9 @@ static void irc_report(int idx, int details)
     dprintf(idx, "    %s\n", q);
   }
   tell_account_tracking_status(idx, details);
+  if (details) {
+    tell_modeparsing(idx);
+  }
 }
 
 /* Many networks either support max_bans/invite/exempts/ *or*

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -33,6 +33,31 @@
 #define REVENGE_KICK 1          /* Kicked victim        */
 #define REVENGE_DEOP 2          /* Took op              */
 
+/* Order and values are relied upon, do not change */
+/* 1-4 are from CHANMODE=b,k,l,mprst and 5 is from PREFIX=(ov)@+ */
+typedef enum mode_type {
+  MODETYPE_INVALID = 0, // invalid, must be 0 for init
+  MODETYPE_FLAG = 1,    // no params
+  MODETYPE_LIMIT = 2,   // param on set only
+  MODETYPE_KEY = 3,     // param always
+  MODETYPE_LIST = 4,    // param always
+  MODETYPE_PREFIX = 5   // param always
+} mode_type_t;
+
+#define MODE_TYPE_NAMES ((const char *[]){[MODETYPE_FLAG] = "Flag", [MODETYPE_LIST] = "List", [MODETYPE_KEY] = "Key", [MODETYPE_LIMIT] = "Limit", [MODETYPE_PREFIX] = "Prefix"})
+
+#define MODE_TYPE(c) (modecharinfo[(unsigned char)(c)].type)
+#define MODE_TYPE_STR(t) ((MODE_TYPE_NAMES)[(t)])
+
+#define MODE_HAS_SET_ARG(c) (MODE_TYPE((c)) >= MODETYPE_LIMIT)
+#define MODE_HAS_UNSET_ARG(c) (MODE_TYPE((c)) >= MODETYPE_KEY)
+#define MODE_PREFIX(c) (modecharinfo[(unsigned char)(c)].prefix)
+
+typedef struct mode_info {
+  mode_type_t type;
+  char prefix;
+} mode_info_t;
+
 #ifdef MAKING_IRC
 static void check_tcl_need(char *, char *);
 static void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -990,33 +990,30 @@ static void got_uninvite(struct chanset_t *chan, char *nick, char *from,
 
 static int gotmode(char *from, char *origmsg)
 {
-  char *nick, *ch, *op, *chg, *msg;
-  char s[UHOSTLEN], buf[511];
-  char ms2[3];
-  int z;
+  char *nick, *ch, *chg;
+  char s[UHOSTLEN], buf[511], joinbuf[512];
+  char ms2[3], *arg;
+  int nextarg;
+  struct parsed_irc msg;
   struct userrec *u;
   memberlist *m;
   struct chanset_t *chan;
 
   strlcpy(buf, origmsg, sizeof buf);
-  msg = buf;
+  msg = parse_irc(buf);
   /* Usermode changes? */
-  if (msg[0] && (strchr(CHANMETA, msg[0]) != NULL)) {
-    ch = newsplit(&msg);
-    chg = newsplit(&msg);
+  if (msg.argc > 1 && (strchr(CHANMETA, msg.argv[0][0]) != NULL)) {
+    ch = msg.argv[0];
+    chg = msg.argv[1];
+    nextarg = 2;
     reversing = 0;
     chan = findchan(ch);
     if (!chan) {
       putlog(LOG_MISC, "*", CHAN_FORCEJOIN, ch);
       dprintf(DP_SERVER, "PART %s\n", ch);
     } else if (channel_active(chan) || channel_pending(chan)) {
-      z = strlen(msg);
-      if (msg[--z] == ' ')      /* I hate cosmetic bugs :P -poptix */
-        msg[z] = 0;
-      if (msg[0] == ':')
-        msg++;
       putlog(LOG_MODES, chan->dname, "%s: mode change '%s %s' by %s", ch, chg,
-             msg, from);
+             join_str_array(msg.argv + 2, msg.argc - 2, " ", joinbuf, sizeof joinbuf), from);
       nick = splitnick(&from);
       m = ismember(chan, nick);
       if (m) {
@@ -1046,8 +1043,24 @@ static int gotmode(char *from, char *origmsg)
       ms2[0] = '+';
       ms2[2] = 0;
       while ((ms2[1] = *chg)) {
+        arg = NULL;
         int todo = 0;
 
+        if (*chg != '+' && *chg != '-') {
+          if ((ms2[0] == '+' && MODE_HAS_SET_ARG(*chg)) || (ms2[0] == '-' && MODE_HAS_UNSET_ARG(*chg))) {
+            if (nextarg < msg.argc) {
+              arg = msg.argv[nextarg++];
+            } else {
+              putlog(LOG_MISC, "*", "Error parsing modes in '%s', not enough arguments for %c%c", origmsg, ms2[0], *chg);
+            }
+          }
+          /* hardcoded assumptions in the existing old select code, SANITY CHECK */
+          if (((ms2[0] == '+' && strchr("behIklov", *chg)) || (ms2[0] == '-' && strchr("behIkov", *chg))) && !arg) {
+              arg = "";
+              putlog(LOG_MISC, "*", "Error parsing modes in '%s', Eggdrop assumes mode change %c%c has a parameter but isupport says no", origmsg, ms2[0], *chg);
+          }
+          debug5("%s: split mode change '%s%s%s' by %s", ch, ms2, arg ? " " : "", arg ? arg : "", from);
+        }
         switch (*chg) {
         case '+':
           ms2[0] = '+';
@@ -1163,11 +1176,7 @@ static int gotmode(char *from, char *origmsg)
             }
             chan->channel.maxmembers = 0;
           } else {
-            op = newsplit(&msg);
-            fixcolon(op);
-            if (*op == '\0')
-              break;
-            chan->channel.maxmembers = atoi(op);
+            chan->channel.maxmembers = atoi(arg);
             check_tcl_mode(nick, from, u, chan->dname, ms2,
                            int_to_base10(chan->channel.maxmembers));
             /* The Tcl proc might have modified/removed the chan or user */
@@ -1192,19 +1201,14 @@ static int gotmode(char *from, char *origmsg)
             chan->channel.mode |= CHANKEY;
           else
             chan->channel.mode &= ~CHANKEY;
-          op = newsplit(&msg);
-          fixcolon(op);
-          if (*op == '\0') {
-            break;
-          }
-          check_tcl_mode(nick, from, u, chan->dname, ms2, op);
+          check_tcl_mode(nick, from, u, chan->dname, ms2, arg);
           /* The Tcl proc might have modified/removed the chan or user */
           if (!(chan = modebind_refresh(ch, from, &user, NULL, NULL)))
             return 0;
           if (ms2[0] == '+') {
-            set_key(chan, op);
+            set_key(chan, arg);
             if (channel_active(chan))
-              got_key(chan, nick, from, op);
+              got_key(chan, nick, from, arg);
           } else {
             if (channel_active(chan)) {
               if (reversing && chan->channel.key[0])
@@ -1217,29 +1221,23 @@ static int gotmode(char *from, char *origmsg)
           }
           break;
         case 'o':
-          op = newsplit(&msg);
-          fixcolon(op);
           if (ms2[0] == '+')
-            got_op(chan, nick, from, op, u, &user);
+            got_op(chan, nick, from, arg, u, &user);
           else
-            got_deop(chan, nick, from, op, u);
+            got_deop(chan, nick, from, arg, u);
           break;
         case 'h':
-          op = newsplit(&msg);
-          fixcolon(op);
           if (ms2[0] == '+')
-            got_halfop(chan, nick, from, op, u, &user);
+            got_halfop(chan, nick, from, arg, u, &user);
           else
-            got_dehalfop(chan, nick, from, op, u);
+            got_dehalfop(chan, nick, from, arg, u);
           break;
         case 'v':
-          op = newsplit(&msg);
-          fixcolon(op);
-          m = ismember(chan, op);
+          m = ismember(chan, arg);
           if (!m) {
             if (channel_pending(chan))
               break;
-            putlog(LOG_MISC, chan->dname, CHAN_BADCHANMODE, chan->dname, op);
+            putlog(LOG_MISC, chan->dname, CHAN_BADCHANMODE, chan->dname, arg);
             chan->status |= CHAN_PEND;
             refresh_who_chan(chan->name);
           } else {
@@ -1248,21 +1246,21 @@ static int gotmode(char *from, char *origmsg)
             if (ms2[0] == '+') {
               m->flags &= ~SENTVOICE;
               m->flags |= CHANVOICE;
-              check_tcl_mode(nick, from, u, chan->dname, ms2, op);
+              check_tcl_mode(nick, from, u, chan->dname, ms2, arg);
               if (!(chan = modebind_refresh(ch, from, &user, s, &victim)))
                 return 0;
               if (channel_active(chan) && !glob_master(user) &&
                   !chan_master(user) && !match_my_nick(nick)) {
                 if (chan_quiet(victim) ||
                     (glob_quiet(victim) && !chan_voice(victim)))
-                  add_mode(chan, '-', 'v', op);
+                  add_mode(chan, '-', 'v', arg);
                 else if (reversing)
-                  add_mode(chan, '-', 'v', op);
+                  add_mode(chan, '-', 'v', arg);
               }
             } else {
               m->flags &= ~SENTDEVOICE;
               m->flags &= ~CHANVOICE;
-              check_tcl_mode(nick, from, u, chan->dname, ms2, op);
+              check_tcl_mode(nick, from, u, chan->dname, ms2, arg);
               if (!(chan = modebind_refresh(ch, from, &user, s, &victim)))
                 return 0;
               if (channel_active(chan) && !glob_master(user) &&
@@ -1271,36 +1269,30 @@ static int gotmode(char *from, char *origmsg)
                     (chan_voice(victim) || glob_voice(victim))) ||
                     (!chan_quiet(victim) && (glob_gvoice(victim) ||
                     chan_gvoice(victim))))
-                  add_mode(chan, '+', 'v', op);
+                  add_mode(chan, '+', 'v', arg);
                 else if (reversing)
-                  add_mode(chan, '+', 'v', op);
+                  add_mode(chan, '+', 'v', arg);
               }
             }
           }
           break;
         case 'b':
-          op = newsplit(&msg);
-          fixcolon(op);
           if (ms2[0] == '+')
-            got_ban(chan, nick, from, op, ch, u);
+            got_ban(chan, nick, from, arg, ch, u);
           else
-            got_unban(chan, nick, from, op, ch, u);
+            got_unban(chan, nick, from, arg, ch, u);
           break;
         case 'e':
-          op = newsplit(&msg);
-          fixcolon(op);
           if (ms2[0] == '+')
-            got_exempt(chan, nick, from, op, ch, u);
+            got_exempt(chan, nick, from, arg, ch, u);
           else
-            got_unexempt(chan, nick, from, op, ch, u);
+            got_unexempt(chan, nick, from, arg, ch, u);
           break;
         case 'I':
-          op = newsplit(&msg);
-          fixcolon(op);
           if (ms2[0] == '+')
-            got_invite(chan, nick, from, op, ch, u);
+            got_invite(chan, nick, from, arg, ch, u);
           else
-            got_uninvite(chan, nick, from, op, ch, u);
+            got_uninvite(chan, nick, from, arg, ch, u);
           break;
         }
         if (todo) {

--- a/src/mod/module.h
+++ b/src/mod/module.h
@@ -532,7 +532,8 @@ typedef void (*chanout_butfunc)(int, int, const char *, ...) ATTRIBUTE_FORMAT(pr
 #define findsock ((int(*)(int))global[327])
 /* 328 - 331 */
 #define stealth_telnets (*(int *)(global[328]))
-
+#define parse_irc ((parsed_irc_t (*)(char *))global[329])
+#define join_str_array ((char *(*)(char **, int, char *, char *, size_t))global[330])
 
 /* hostmasking */
 #define maskhost(a,b) maskaddr((a),(b),3)

--- a/src/mod/server.mod/isupport.c
+++ b/src/mod/server.mod/isupport.c
@@ -31,7 +31,7 @@ typedef struct isupport {
 
 static isupport_t *isupport_list;
 static p_tcl_bind_list H_isupport;
-static const char isupport_default[4096] = "CASEMAPPING=rfc1459 CHANNELLEN=80 NICKLEN=9 CHANTYPES=#& PREFIX=(ov)@+ CHANMODES=b,k,l,imnpst MODES=3 MAXCHANNELS=10 TOPICLEN=250 KICKLEN=250 STATUSMSG=@+";
+static const char isupport_default[4096] = "CASEMAPPING=rfc1459 CHANNELLEN=80 NICKLEN=9 CHANTYPES=#& PREFIX=(ohv)@%+ CHANMODES=beI,k,l,imnpstcCMRrDuNdTaq MODES=3 MAXCHANNELS=10 TOPICLEN=250 KICKLEN=250 STATUSMSG=@+";
 
 static int hexdigit2dec[128] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, /*   0 -   9 */

--- a/src/mod/server.mod/isupport.c
+++ b/src/mod/server.mod/isupport.c
@@ -418,7 +418,7 @@ void isupport_clear_values(int cleardefaultvalues) {
 void isupport_preconnect(void) {
   const char *def = Tcl_GetVar(interp, "isupport-default", TCL_GLOBAL_ONLY);
 
-  if (!def)
+  if (!def || !*def)
     def = isupport_default;
   isupport_parse(def, isupport_setdefault);
 }

--- a/src/modules.c
+++ b/src/modules.c
@@ -632,7 +632,9 @@ Function global_table[] = {
   (Function) dcc_telnet_hostresolved2,
   (Function) findsock,
 /* 328 - 331 */
-  (Function) & stealth_telnets    /* int                                 */
+  (Function) & stealth_telnets,   /* int                                 */
+  (Function) parse_irc,
+  (Function) join_str_array,
 };
 
 void init_modules(void)

--- a/src/proto.h
+++ b/src/proto.h
@@ -236,6 +236,8 @@ void check_logsize(void);
 void splitc(char *, char *, char);
 void splitcn(char *, char *, char, size_t);
 void remove_crlf(char **);
+parsed_irc_t parse_irc(char *);
+char *join_str_array(char **, int, char *, char *, size_t);
 char *newsplit(char **);
 char *splitnick(char **);
 void stridx(char *, char *, int);


### PR DESCRIPTION
Found by: various
Patch by: thommey

One-line summary: Understand mode info from raw 005 isupport and parse modes correctly

Additional description (if needed):
Phase 1 is parsing mode info from ISUPPORT raw 005 and using it to properly split modes (primarily for bind mode / pushmode) in gotmode() and got324().
It is not intended to overhaul eggdrop's mode enforcement or understanding of/reaction to modes.
The goal is to introduce proper parsing without breaking anything first.

**FULL FF-MERGE, NO SQUASHING**

Commit history is clean, review individual commits instead of full diff.
