### PR TITLE
Python support missing in eggdrop-basic.conf

### DIFF
--- a/eggdrop-basic.conf
+++ b/eggdrop-basic.conf
@@ -38,6 +38,7 @@ loadmodule uptime    ; # Centralized uptime stat collection (https://www.egghead
 #loadmodule ident    ; # Ident support
 #loadmodule twitch   ; # Twitch gaming service support
 #loadmodule webui    ; # WebUI support
+#loadmodule python   ; # Python support
 
 
 ##### BASIC SETTINGS #####


### PR DESCRIPTION
Found by: ZarTek-Creole
Patch by: ZarTek-Creole
Fixes: Python support missing in eggdrop-basic.conf

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
