### PR TITLE
Remove amalgamations (irc.mod first)

### DIFF
--- a/src/mod/irc.mod/Makefile
+++ b/src/mod/irc.mod/Makefile
@@ -16,7 +16,7 @@ static: ../irc.o
 modules: ../../../irc.$(MOD_EXT)
 
 ../irc.o: $(OBJS) irc.h irc_proto.h
-	ld -r -o ../irc.o $(OBJS)
+	$(CC) -r -nostdlib -o ../irc.o $(OBJS)
 
 %.o: $(srcdir)/%.c irc.h irc_proto.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $<

--- a/src/mod/irc.mod/Makefile
+++ b/src/mod/irc.mod/Makefile
@@ -2,6 +2,8 @@
 
 srcdir = .
 
+SRCS = $(wildcard $(srcdir)/*.c)
+OBJS = $(notdir $(SRCS:.c=.o))
 
 doofus:
 	@echo "" && \
@@ -13,21 +15,21 @@ static: ../irc.o
 
 modules: ../../../irc.$(MOD_EXT)
 
-../irc.o: irc.o mode.o
-	ld -r -o ../irc.o irc.o mode.o
+../irc.o: $(OBJS) irc.h irc_proto.h
+	ld -r -o ../irc.o $(OBJS)
 
-irc.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c
-
-mode.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/mode.c
+%.o: $(srcdir)/%.c irc.h irc_proto.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $<
 
 ../../../irc.$(MOD_EXT): ../irc.o
 	$(LD) $(CFLAGS) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../irc.$(MOD_EXT)
 
 depend:
-	$(CC) $(CFLAGS) -MM $(srcdir)/irc.c -MT ../irc.o > .depend
-	$(CC) $(CFLAGS) -MM $(srcdir)/mode.c -MT mode.o >> .depend
+	echo "../irc.o: $(OBJS)" > .depend; \
+	for src in $(SRCS); do \
+	  obj=$$(basename $$src .c).o; \
+	  $(CC) $(CFLAGS) -MM $$src -MT $$obj >> .depend; \
+	done
 
 clean:
 	@rm -f .depend *.o *.$(MOD_EXT) *~
@@ -35,29 +37,70 @@ clean:
 distclean: clean
 
 #safety hash
-irc.o: .././irc.mod/irc.c ../../../src/mod/module.h \
- ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
- ../../../src/lang.h ../../../src/eggdrop.h ../../../src/compat/in6.h \
- ../../../src/flags.h ../../../src/cmdt.h ../../../src/tclegg.h \
- ../../../src/tclhash.h ../../../src/chan.h ../../../src/users.h \
- ../../../src/compat/compat.h ../../../src/compat/base64.h \
- ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
- ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
- ../../../src/mod/modvals.h ../../../src/tandem.h .././irc.mod/irc.h \
- .././irc.mod/irc_proto.h \
+../irc.o: chan.o cmdsirc.o irc.o mode.o msgcmds.o tclirc.o
+chan.o: .././irc.mod/chan.c ../../../src/mod/module.h ../../../src/main.h \
+ ../../../config.h ../../../eggint.h ../../../lush.h ../../../src/lang.h \
+ ../../../src/eggdrop.h ../../../src/flags.h ../../../src/cmdt.h \
+ ../../../src/tclegg.h ../../../src/tclhash.h ../../../src/chan.h \
+ ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
  ../../../src/mod/server.mod/server.h \
- ../../../src/mod/channels.mod/channels.h .././irc.mod/chan.c \
- .././irc.mod/cmdsirc.c .././irc.mod/msgcmds.c \
- .././irc.mod/tclirc.c
-mode.o: .././irc.mod/mode.c ../../../src/mod/module.h \
+ ../../../src/mod/channels.mod/channels.h
+cmdsirc.o: .././irc.mod/cmdsirc.c ../../../src/mod/module.h \
  ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
- ../../../src/lang.h ../../../src/eggdrop.h ../../../src/compat/in6.h \
- ../../../src/flags.h ../../../src/cmdt.h ../../../src/tclegg.h \
- ../../../src/tclhash.h ../../../src/chan.h ../../../src/users.h \
- ../../../src/compat/compat.h ../../../src/compat/base64.h \
- ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
- ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
- ../../../src/mod/modvals.h ../../../src/tandem.h .././irc.mod/irc.h \
- .././irc.mod/irc_proto.h \
+ ../../../src/lang.h ../../../src/eggdrop.h ../../../src/flags.h \
+ ../../../src/cmdt.h ../../../src/tclegg.h ../../../src/tclhash.h \
+ ../../../src/chan.h ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
+ ../../../src/mod/server.mod/server.h \
+ ../../../src/mod/channels.mod/channels.h
+irc.o: .././irc.mod/irc.c ../../../src/mod/module.h ../../../src/main.h \
+ ../../../config.h ../../../eggint.h ../../../lush.h ../../../src/lang.h \
+ ../../../src/eggdrop.h ../../../src/flags.h ../../../src/cmdt.h \
+ ../../../src/tclegg.h ../../../src/tclhash.h ../../../src/chan.h \
+ ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
+ ../../../src/mod/server.mod/server.h \
+ ../../../src/mod/channels.mod/channels.h
+mode.o: .././irc.mod/mode.c ../../../src/mod/module.h ../../../src/main.h \
+ ../../../config.h ../../../eggint.h ../../../lush.h ../../../src/lang.h \
+ ../../../src/eggdrop.h ../../../src/flags.h ../../../src/cmdt.h \
+ ../../../src/tclegg.h ../../../src/tclhash.h ../../../src/chan.h \
+ ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
+ ../../../src/mod/server.mod/server.h \
+ ../../../src/mod/channels.mod/channels.h
+msgcmds.o: .././irc.mod/msgcmds.c ../../../src/mod/module.h \
+ ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
+ ../../../src/lang.h ../../../src/eggdrop.h ../../../src/flags.h \
+ ../../../src/cmdt.h ../../../src/tclegg.h ../../../src/tclhash.h \
+ ../../../src/chan.h ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
+ ../../../src/mod/server.mod/server.h \
+ ../../../src/mod/channels.mod/channels.h
+tclirc.o: .././irc.mod/tclirc.c ../../../src/mod/module.h \
+ ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
+ ../../../src/lang.h ../../../src/eggdrop.h ../../../src/flags.h \
+ ../../../src/cmdt.h ../../../src/tclegg.h ../../../src/tclhash.h \
+ ../../../src/chan.h ../../../src/users.h ../../../src/compat/compat.h \
+ ../../../src/compat/base64.h ../../../src/compat/inet_aton.h \
+ ../../../src/compat/snprintf.h ../../../src/compat/explicit_bzero.h \
+ ../../../src/compat/strlcpy.h ../../../src/mod/modvals.h \
+ ../../../src/tandem.h .././irc.mod/irc.h .././irc.mod/irc_proto.h \
  ../../../src/mod/server.mod/server.h \
  ../../../src/mod/channels.mod/channels.h

--- a/src/mod/irc.mod/Makefile
+++ b/src/mod/irc.mod/Makefile
@@ -13,14 +13,21 @@ static: ../irc.o
 
 modules: ../../../irc.$(MOD_EXT)
 
-../irc.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c && mv -f irc.o ../
+../irc.o: irc.o mode.o
+	ld -r -o ../irc.o irc.o mode.o
+
+irc.o:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/irc.c
+
+mode.o:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DMAKING_MODS -c $(srcdir)/mode.c
 
 ../../../irc.$(MOD_EXT): ../irc.o
 	$(LD) $(CFLAGS) -o ../../../irc.$(MOD_EXT) ../irc.o $(XLIBS) $(MODULE_XLIBS) && $(STRIP) ../../../irc.$(MOD_EXT)
 
 depend:
 	$(CC) $(CFLAGS) -MM $(srcdir)/irc.c -MT ../irc.o > .depend
+	$(CC) $(CFLAGS) -MM $(srcdir)/mode.c -MT mode.o >> .depend
 
 clean:
 	@rm -f .depend *.o *.$(MOD_EXT) *~
@@ -28,7 +35,7 @@ clean:
 distclean: clean
 
 #safety hash
-../irc.o: .././irc.mod/irc.c ../../../src/mod/module.h \
+irc.o: .././irc.mod/irc.c ../../../src/mod/module.h \
  ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
  ../../../src/lang.h ../../../src/eggdrop.h ../../../src/compat/in6.h \
  ../../../src/flags.h ../../../src/cmdt.h ../../../src/tclegg.h \
@@ -37,7 +44,20 @@ distclean: clean
  ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
  ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
  ../../../src/mod/modvals.h ../../../src/tandem.h .././irc.mod/irc.h \
+ .././irc.mod/irc_proto.h \
  ../../../src/mod/server.mod/server.h \
  ../../../src/mod/channels.mod/channels.h .././irc.mod/chan.c \
- .././irc.mod/mode.c .././irc.mod/cmdsirc.c .././irc.mod/msgcmds.c \
+ .././irc.mod/cmdsirc.c .././irc.mod/msgcmds.c \
  .././irc.mod/tclirc.c
+mode.o: .././irc.mod/mode.c ../../../src/mod/module.h \
+ ../../../src/main.h ../../../config.h ../../../eggint.h ../../../lush.h \
+ ../../../src/lang.h ../../../src/eggdrop.h ../../../src/compat/in6.h \
+ ../../../src/flags.h ../../../src/cmdt.h ../../../src/tclegg.h \
+ ../../../src/tclhash.h ../../../src/chan.h ../../../src/users.h \
+ ../../../src/compat/compat.h ../../../src/compat/base64.h \
+ ../../../src/compat/inet_aton.h ../../../src/compat/snprintf.h \
+ ../../../src/compat/explicit_bzero.h ../../../src/compat/strlcpy.h \
+ ../../../src/mod/modvals.h ../../../src/tandem.h .././irc.mod/irc.h \
+ .././irc.mod/irc_proto.h \
+ ../../../src/mod/server.mod/server.h \
+ ../../../src/mod/channels.mod/channels.h

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -25,7 +25,14 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#define MODULE_NAME "irc"
+#define MAKING_IRC
+
+#include "src/mod/module.h"
 #include "irc.h"
+#include "irc_proto.h"
+#include "server.mod/server.h"
+#include "channels.mod/channels.h"
 
 
 static time_t last_ctcp = (time_t) 0L;
@@ -122,7 +129,7 @@ static void setaccount(char *nick, char *account)
 
 /* Returns the current channel mode.
  */
-static char *getchanmode(struct chanset_t *chan)
+char *getchanmode(struct chanset_t *chan)
 {
   static char s[121];
   int atr, i;
@@ -176,7 +183,7 @@ static char *getchanmode(struct chanset_t *chan)
   return s;
 }
 
-static void check_exemptlist(struct chanset_t *chan, char *from)
+void check_exemptlist(struct chanset_t *chan, char *from)
 {
   masklist *e;
   int ok = 0;
@@ -198,7 +205,7 @@ static void check_exemptlist(struct chanset_t *chan, char *from)
  * Moved all do_ban(), do_exempt() and do_invite() into this single function
  * as the code bloat is starting to get ridiculous <cybah>
  */
-static void do_mask(struct chanset_t *chan, masklist *m, char *mask, char mode)
+void do_mask(struct chanset_t *chan, masklist *m, char *mask, char mode)
 {
   for (; m && m->mask[0]; m = m->next)
     if (cmp_masks(mask, m->mask) && rfc_casecmp(mask, m->mask))
@@ -402,7 +409,7 @@ int detect_chan_flood(char *floodnick, char *floodhost, char *from,
 
 /* Given a [nick!]user@host, place a quick ban on them on a chan.
  */
-static char *quickban(struct chanset_t *chan, char *uhost)
+char *quickban(struct chanset_t *chan, char *uhost)
 {
   static char s1[512];
 
@@ -634,8 +641,8 @@ static void recheck_invites(struct chanset_t *chan)
 
 /* Resets the masks on the channel.
  */
-static void resetmasks(struct chanset_t *chan, masklist *m, maskrec *mrec,
-                       maskrec *global_masks, char mode)
+void resetmasks(struct chanset_t *chan, masklist *m, maskrec *mrec,
+                maskrec *global_masks, char mode)
 {
   if (!me_op(chan) && (!me_halfop(chan) ||
       (strchr(NOHALFOPS_MODES, 'b') != NULL) ||
@@ -665,7 +672,7 @@ static void resetmasks(struct chanset_t *chan, masklist *m, maskrec *mrec,
     break;
   }
 }
-static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
+void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
 {
   memberlist *m;
   char user[NICKMAX+UHOSTLEN+1];
@@ -685,7 +692,7 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
     add_mode(chan, '+', 'b', banmask);
 }
 
-static void recheck_channel_modes(struct chanset_t *chan)
+void recheck_channel_modes(struct chanset_t *chan)
 {
   int cur = chan->channel.mode, mns = chan->mode_mns_prot,
       pls = chan->mode_pls_prot;
@@ -879,7 +886,7 @@ static void check_this_member(struct chanset_t *chan, char *nick,
   }
 }
 
-static void check_this_user(char *hand, int delete, char *host)
+void check_this_user(char *hand, int delete, char *host)
 {
   char s[NICKMAX+UHOSTLEN+1];
   memberlist *m;
@@ -1882,7 +1889,7 @@ static int got332(char *from, char *msg)
 
 /* Set delay for +o, +h, or +v channel modes
  */
-static void set_delay(struct chanset_t *chan, char *nick)
+void set_delay(struct chanset_t *chan, char *nick)
 {
   time_t a_delay;
   int aop_min, aop_max, aop_diff, count = 0;
@@ -2876,7 +2883,7 @@ static int gotrawt(char *from, char *msg, Tcl_Obj *tags) {
   return 0;
 }
 
-static cmd_t irc_raw[] = {
+cmd_t irc_raw[] = {
   {"324",     "",   (IntFunc) got324,          "irc:324"},
   {"352",     "",   (IntFunc) got352,          "irc:352"},
   {"353",     "",   (IntFunc) got353,          "irc:353"},
@@ -2915,12 +2922,12 @@ static cmd_t irc_raw[] = {
   {NULL,     NULL,  NULL,                           NULL}
 };
 
-static cmd_t irc_rawt[] = {
+cmd_t irc_rawt[] = {
   {"*",       "",   (IntFunc) gotrawt,        "irc:rawt"},
   {NULL,    NULL,   NULL,                           NULL}
 };
 
-static cmd_t irc_isupport_binds[] = {
+cmd_t irc_isupport_binds[] = {
   {"*",       "",   (IntFunc) irc_isupport, "irc:isupport"},
   {NULL,    NULL,   NULL,                             NULL}
 };

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -212,8 +212,8 @@ static void do_mask(struct chanset_t *chan, masklist *m, char *mask, char mode)
  *
  * victim for flood-deop, account for flood-join
  */
-static int detect_chan_flood(char *floodnick, char *floodhost, char *from,
-                             struct chanset_t *chan, int which, char *victim_or_account)
+int detect_chan_flood(char *floodnick, char *floodhost, char *from,
+                     struct chanset_t *chan, int which, char *victim_or_account)
 {
   char h[NICKMAX+UHOSTLEN+1], ftype[12], *p;
   struct userrec *u;
@@ -414,8 +414,8 @@ static char *quickban(struct chanset_t *chan, char *uhost)
 /* Kick any user (except friends/masters) with certain mask from channel
  * with a specified comment.  Ernst 18/3/1998
  */
-static void kick_all(struct chanset_t *chan, char *hostmask, char *comment,
-                     int bantype)
+void kick_all(struct chanset_t *chan, char *hostmask, char *comment,
+              int bantype)
 {
   memberlist *m;
   char kicknick[512], s[NICKMAX+UHOSTLEN+1];
@@ -500,7 +500,7 @@ static void refresh_ban_kick(struct chanset_t *chan, char *user, char *nick)
 /* This is a bit cumbersome at the moment, but it works... Any improvements
  * then feel free to have a go.. Jason
  */
-static void refresh_exempt(struct chanset_t *chan, char *user)
+void refresh_exempt(struct chanset_t *chan, char *user)
 {
   maskrec *e;
   masklist *b;
@@ -901,7 +901,7 @@ static void check_this_user(char *hand, int delete, char *host)
 
 /* Things to do when i just became a chanop:
  */
-static void recheck_channel(struct chanset_t *chan, int dobans)
+void recheck_channel(struct chanset_t *chan, int dobans)
 {
   memberlist *m;
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };

--- a/src/mod/irc.mod/cmdsirc.c
+++ b/src/mod/irc.mod/cmdsirc.c
@@ -21,6 +21,18 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#define MODULE_NAME "irc"
+#define MAKING_IRC
+
+#include "src/mod/module.h"
+#include "irc.h"
+#include "irc_proto.h"
+#include "server.mod/server.h"
+#include "channels.mod/channels.h"
+
+static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+
 static struct chanset_t *get_channel(int idx, char *chname)
 {
   struct chanset_t *chan;
@@ -1128,7 +1140,7 @@ static void cmd_reset(struct userrec *u, int idx, char *par)
   }
 }
 
-static cmd_t irc_dcc[] = {
+cmd_t irc_dcc[] = {
   {"adduser",      "m|m",   (IntFunc) cmd_adduser,      NULL},
   {"deluser",      "m|m",   (IntFunc) cmd_deluser,      NULL},
   {"reset",        "m|m",   (IntFunc) cmd_reset,        NULL},

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -26,49 +26,75 @@
 
 #include "src/mod/module.h"
 #include "irc.h"
+#include "irc_proto.h"
 #include "server.mod/server.h"
 #include "channels.mod/channels.h"
 
 #include <sys/utsname.h>
 
+/* Forward declarations for functions local to the irc.c translation unit */
+static void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);
+static void check_tcl_invite(char *, char *, char *, char *);
+static void check_tcl_joinspltrejn(char *, char *, struct userrec *, char *,
+                                   p_tcl_bind_list);
+static void check_tcl_part(char *, char *, struct userrec *, char *, char *);
+static void check_tcl_signtopcnick(char *, char *, struct userrec *u, char *,
+                                   char *, p_tcl_bind_list);
+static int check_tcl_pubm(char *, char *, char *, char *);
+static int check_tcl_pub(char *, char *, char *, char *);
+static int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *,
+                                    char*);
+static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account);
+static int check_tcl_chghost(char *, char *, char *, struct userrec *, char *, char *, char *);
+static int me_voice(struct chanset_t *);
+static int any_ops(struct chanset_t *);
+static int hand_on_chan(struct chanset_t *, struct userrec *);
+static char *getchanmode(struct chanset_t *);
+static void set_delay(struct chanset_t *, char *);
+static char *quickban(struct chanset_t *, char *);
+static int killmember(struct chanset_t *chan, char *nick);
+static void check_lonely_channel(struct chanset_t *chan);
+
 static p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
 static p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt, H_ircaway;
 static p_tcl_bind_list H_account, H_chghost;
 
-static Function *global = NULL, *channels_funcs = NULL, *server_funcs = NULL;
+Function *global = NULL, *channels_funcs = NULL, *server_funcs = NULL;
 
 static int ctcp_mode;
 static int wait_split = 300;    /* Time to wait for user to return from net-split. */
-static int max_bans = 30;       /* Modified by net-type 1-4 */
-static int max_exempts = 20;    /* Modified by net-type 1-4 */
-static int max_invites = 20;    /* Modified by net-type 1-4 */
-static int max_modes = 30;      /* Modified by net-type 1-4 */
-static int bounce_bans = 0;
-static int bounce_exempts = 0;
-static int bounce_invites = 0;
-static int bounce_modes = 0;
+int max_bans = 30;              /* Modified by net-type 1-4 */
+int max_exempts = 20;           /* Modified by net-type 1-4 */
+int max_invites = 20;           /* Modified by net-type 1-4 */
+int max_modes = 30;             /* Modified by net-type 1-4 */
+int bounce_bans = 0;
+int bounce_exempts = 0;
+int bounce_invites = 0;
+int bounce_modes = 0;
 static int learn_users = 0;
 static int wait_info = 15;
 static int invite_key = 1;
 static int no_chanrec_info = 0;
-static int modesperline = 3;    /* Number of modes per line to send. */
-static int mode_buf_len = 200;  /* Maximum bytes to send in 1 mode. */
+int modesperline = 3;           /* Number of modes per line to send. */
+int mode_buf_len = 200;         /* Maximum bytes to send in 1 mode. */
 static int use_354 = 0;         /* Use ircu's short 354 /who responses. */
 static int kick_method = 1;     /* How many kicks does the IRC network support
                                  * at once? Use 0 for as many as possible.
                                  * (Ernst 18/3/1998) */
 static int keepnick = 1;        /* Keep nick */
 static int twitch = 0;          /* Is this a Twitch server? */
-static int prevent_mixing = 1;  /* Prevent mixing old/new modes */
+int prevent_mixing = 1;         /* Prevent mixing old/new modes */
 static int rfc_compliant = 1;   /* Value depends on net-type. */
-static int include_lk = 1;      /* For correct calculation in real_add_mode. */
+int include_lk = 1;             /* For correct calculation in real_add_mode. */
 
 static char opchars[8];         /* the chars in a /who reply meaning op */
 
 static Tcl_Obj *tcl_account;
 
+static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
+
 #include "chan.c"
-#include "mode.c"
 #include "cmdsirc.c"
 #include "msgcmds.c"
 #include "tclirc.c"
@@ -223,8 +249,8 @@ static void punish_badguy(struct chanset_t *chan, char *whobad,
 /* Punishes bad guys under certain circumstances using methods as defined
  * by the revenge_mode flag.
  */
-static void maybe_revenge(struct chanset_t *chan, char *whobad,
-                          char *whovictim, int type)
+void maybe_revenge(struct chanset_t *chan, char *whobad,
+                   char *whovictim, int type)
 {
   char *badnick, *victim, buf[NICKLEN + UHOSTLEN];
   int mevictim;
@@ -254,7 +280,7 @@ static void maybe_revenge(struct chanset_t *chan, char *whobad,
 
 /* Set the key.
  */
-static void set_key(struct chanset_t *chan, char *k)
+void set_key(struct chanset_t *chan, char *k)
 {
   nfree(chan->channel.key);
   if (k == NULL) {
@@ -277,7 +303,7 @@ static int hand_on_chan(struct chanset_t *chan, struct userrec *u)
   return 0;
 }
 
-static void refresh_who_chan(char *channame)
+void refresh_who_chan(char *channame)
 {
   if (!twitch) {    /* Twitch doesn't support WHOs */
     if (use_354)
@@ -291,7 +317,7 @@ static void refresh_who_chan(char *channame)
 /* Adds a ban, exempt or invite mask to the list
  * m should be chan->channel.(exempt|invite|ban)
  */
-static void newmask(masklist *m, char *s, char *who)
+void newmask(masklist *m, char *s, char *who)
 {
   for (; m && m->mask[0] && rfc_casecmp(m->mask, s); m = m->next);
   if (m->mask[0])
@@ -351,7 +377,7 @@ static int killmember(struct chanset_t *chan, char *nick)
 
 /* Check if I am a chanop. Returns boolean 1 or 0.
  */
-static int me_op(struct chanset_t *chan)
+int me_op(struct chanset_t *chan)
 {
   memberlist *mx = NULL;
 
@@ -366,7 +392,7 @@ static int me_op(struct chanset_t *chan)
 
 /* Check if I am a halfop. Returns boolean 1 or 0.
  */
-static int me_halfop(struct chanset_t *chan)
+int me_halfop(struct chanset_t *chan)
 {
   memberlist *mx = NULL;
 
@@ -855,8 +881,8 @@ static void check_tcl_signtopcnick(char *nick, char *uhost, struct userrec *u,
                  MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
 }
 
-static void check_tcl_mode(char *nick, char *uhost, struct userrec *u,
-                           char *chname, char *mode, char *target)
+void check_tcl_mode(char *nick, char *uhost, struct userrec *u,
+                    char *chname, char *mode, char *target)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char args[512];
@@ -973,7 +999,7 @@ static int check_tcl_pubm(char *nick, char *from, char *chname, char *msg)
   return 1;
 }
 
-static void check_tcl_need(char *chname, char *type)
+void check_tcl_need(char *chname, char *type)
 {
   char buf[1024];
 

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -33,36 +33,19 @@
 #include <sys/utsname.h>
 
 /* Forward declarations for functions local to the irc.c translation unit */
-static void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);
-static void check_tcl_invite(char *, char *, char *, char *);
-static void check_tcl_joinspltrejn(char *, char *, struct userrec *, char *,
-                                   p_tcl_bind_list);
-static void check_tcl_part(char *, char *, struct userrec *, char *, char *);
-static void check_tcl_signtopcnick(char *, char *, struct userrec *u, char *,
-                                   char *, p_tcl_bind_list);
-static int check_tcl_pubm(char *, char *, char *, char *);
-static int check_tcl_pub(char *, char *, char *, char *);
-static int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *,
-                                    char*);
-static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account);
-static int check_tcl_chghost(char *, char *, char *, struct userrec *, char *, char *, char *);
-static int me_voice(struct chanset_t *);
-static int any_ops(struct chanset_t *);
-static int hand_on_chan(struct chanset_t *, struct userrec *);
-static char *getchanmode(struct chanset_t *);
-static void set_delay(struct chanset_t *, char *);
-static char *quickban(struct chanset_t *, char *);
-static int killmember(struct chanset_t *chan, char *nick);
-static void check_lonely_channel(struct chanset_t *chan);
+static int want_to_revenge(struct chanset_t *, struct userrec *,
+                           struct userrec *, char *, char *, int);
+static void punish_badguy(struct chanset_t *, char *, struct userrec *,
+                          char *, char *, int, int);
 
-static p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
-static p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt, H_ircaway;
-static p_tcl_bind_list H_account, H_chghost;
+p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
+p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt, H_ircaway;
+p_tcl_bind_list H_account, H_chghost;
 
 Function *global = NULL, *channels_funcs = NULL, *server_funcs = NULL;
 
-static int ctcp_mode;
-static int wait_split = 300;    /* Time to wait for user to return from net-split. */
+int ctcp_mode;
+int wait_split = 300;           /* Time to wait for user to return from net-split. */
 int max_bans = 30;              /* Modified by net-type 1-4 */
 int max_exempts = 20;           /* Modified by net-type 1-4 */
 int max_invites = 20;           /* Modified by net-type 1-4 */
@@ -71,33 +54,27 @@ int bounce_bans = 0;
 int bounce_exempts = 0;
 int bounce_invites = 0;
 int bounce_modes = 0;
-static int learn_users = 0;
-static int wait_info = 15;
-static int invite_key = 1;
-static int no_chanrec_info = 0;
+int learn_users = 0;
+int wait_info = 15;
+int invite_key = 1;
+int no_chanrec_info = 0;
 int modesperline = 3;           /* Number of modes per line to send. */
 int mode_buf_len = 200;         /* Maximum bytes to send in 1 mode. */
-static int use_354 = 0;         /* Use ircu's short 354 /who responses. */
-static int kick_method = 1;     /* How many kicks does the IRC network support
+int use_354 = 0;                /* Use ircu's short 354 /who responses. */
+int kick_method = 1;            /* How many kicks does the IRC network support
                                  * at once? Use 0 for as many as possible.
                                  * (Ernst 18/3/1998) */
-static int keepnick = 1;        /* Keep nick */
-static int twitch = 0;          /* Is this a Twitch server? */
+int keepnick = 1;               /* Keep nick */
+int twitch = 0;                 /* Is this a Twitch server? */
 int prevent_mixing = 1;         /* Prevent mixing old/new modes */
-static int rfc_compliant = 1;   /* Value depends on net-type. */
+int rfc_compliant = 1;          /* Value depends on net-type. */
 int include_lk = 1;             /* For correct calculation in real_add_mode. */
 
-static char opchars[8];         /* the chars in a /who reply meaning op */
+char opchars[8];                /* the chars in a /who reply meaning op */
 
-static Tcl_Obj *tcl_account;
+Tcl_Obj *tcl_account;
 
-static struct flag_record user = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
-static struct flag_record victim = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
 
-#include "chan.c"
-#include "cmdsirc.c"
-#include "msgcmds.c"
-#include "tclirc.c"
 
 /* Contains the logic to decide whether we want to punish someone. Returns
  * true (1) if we want to, false (0) if not.
@@ -292,7 +269,7 @@ void set_key(struct chanset_t *chan, char *k)
   strcpy(chan->channel.key, k);
 }
 
-static int hand_on_chan(struct chanset_t *chan, struct userrec *u)
+int hand_on_chan(struct chanset_t *chan, struct userrec *u)
 {
   memberlist *m;
 
@@ -337,7 +314,7 @@ void newmask(masklist *m, char *s, char *who)
 
 /* Removes a nick from the channel member list (returns 1 if successful)
  */
-static int killmember(struct chanset_t *chan, char *nick)
+int killmember(struct chanset_t *chan, char *nick)
 {
   memberlist *x, *old;
 
@@ -407,7 +384,7 @@ int me_halfop(struct chanset_t *chan)
 
 /* Check whether I'm voice. Returns boolean 1 or 0.
  */
-static int me_voice(struct chanset_t *chan)
+int me_voice(struct chanset_t *chan)
 {
   memberlist *mx;
 
@@ -422,7 +399,7 @@ static int me_voice(struct chanset_t *chan)
 
 /* Check if there are any ops on the channel. Returns boolean 1 or 0.
  */
-static int any_ops(struct chanset_t *chan)
+int any_ops(struct chanset_t *chan)
 {
   memberlist *x;
 
@@ -490,7 +467,7 @@ void reset_chan_info(struct chanset_t *chan, int reset, int do_reset)
 /* Leave the specified channel and notify registered Tcl procs. This
  * should not be called by itself.
  */
-static void do_channel_part(struct chanset_t *chan)
+void do_channel_part(struct chanset_t *chan)
 {
   if (!channel_inactive(chan) && chan->name[0]) {
     /* Using chan->name is important here, especially for !chans <cybah> */
@@ -556,7 +533,7 @@ static void status_log()
  * might as well leave and rejoin. If i'm NOT the only person
  * on the channel, but i'm still not op'd, demand ops.
  */
-static void check_lonely_channel(struct chanset_t *chan)
+void check_lonely_channel(struct chanset_t *chan)
 {
   memberlist *m;
   int i = 0;
@@ -787,8 +764,8 @@ static int invite_4char STDVAR
   return TCL_OK;
 }
 
-static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec *u,
-                             char *chan, char *ident, char * host)
+int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec *u,
+                      char *chan, char *ident, char * host)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };
   char usermask[UHOSTMAX];
@@ -808,8 +785,8 @@ static int check_tcl_chghost(char *nick, char *from, char *mask, struct userrec 
   return (x == BIND_EXEC_LOG);
 }
 
-static int check_tcl_ircaway(char *nick, char *from, char *mask,
-            struct userrec *u, char *chan, char *msg)
+int check_tcl_ircaway(char *nick, char *from, char *mask,
+                      struct userrec *u, char *chan, char *msg)
 {
   int x;
   char *hand = u ? u->handle : "*";
@@ -825,8 +802,8 @@ static int check_tcl_ircaway(char *nick, char *from, char *mask,
   return (x == BIND_EXEC_LOG);
 }
 
-static void check_tcl_joinspltrejn(char *nick, char *uhost, struct userrec *u,
-                                   char *chname, p_tcl_bind_list table)
+void check_tcl_joinspltrejn(char *nick, char *uhost, struct userrec *u,
+                            char *chname, p_tcl_bind_list table)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char args[1024];
@@ -843,8 +820,8 @@ static void check_tcl_joinspltrejn(char *nick, char *uhost, struct userrec *u,
 
 /* we handle part messages now *sigh* (guppy 27Jan2000) */
 
-static void check_tcl_part(char *nick, char *uhost, struct userrec *u,
-                           char *chname, char *text)
+void check_tcl_part(char *nick, char *uhost, struct userrec *u,
+                    char *chname, char *text)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char args[1024];
@@ -860,9 +837,9 @@ static void check_tcl_part(char *nick, char *uhost, struct userrec *u,
                  MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
 }
 
-static void check_tcl_signtopcnick(char *nick, char *uhost, struct userrec *u,
-                                   char *chname, char *reason,
-                                   p_tcl_bind_list table)
+void check_tcl_signtopcnick(char *nick, char *uhost, struct userrec *u,
+                            char *chname, char *reason,
+                            p_tcl_bind_list table)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char args[1024];
@@ -900,8 +877,8 @@ void check_tcl_mode(char *nick, char *uhost, struct userrec *u,
                  MATCH_MODE | BIND_USE_ATTR | BIND_STACKABLE);
 }
 
-static void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
-                           char *chname, char *dest, char *reason)
+void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
+                    char *chname, char *dest, char *reason)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   char args[512];
@@ -919,7 +896,7 @@ static void check_tcl_kick(char *nick, char *uhost, struct userrec *u,
                  MATCH_MASK | BIND_USE_ATTR | BIND_STACKABLE);
 }
 
-static void check_tcl_invite(char *nick, char *from, char *chan, char *invitee)
+void check_tcl_invite(char *nick, char *from, char *chan, char *invitee)
 {
   char args[1024];
 
@@ -932,7 +909,7 @@ static void check_tcl_invite(char *nick, char *from, char *chan, char *invitee)
                     MATCH_MASK | BIND_STACKABLE);
 }
 
-static int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
+int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   int x;
@@ -963,7 +940,7 @@ static int check_tcl_pub(char *nick, char *from, char *chname, char *msg)
   return 1;
 }
 
-static int check_tcl_pubm(char *nick, char *from, char *chname, char *msg)
+int check_tcl_pubm(char *nick, char *from, char *chname, char *msg)
 {
   struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
   int x;
@@ -1010,7 +987,7 @@ void check_tcl_need(char *chname, char *type)
                  MATCH_MASK | BIND_STACKABLE);
 }
 
-static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account)
+void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account)
 {
   char mask[1024];
   struct flag_record fr = { FR_GLOBAL | FR_CHAN | FR_ANYWH, 0, 0, 0, 0, 0 };

--- a/src/mod/irc.mod/irc.h
+++ b/src/mod/irc.mod/irc.h
@@ -34,30 +34,6 @@
 #define REVENGE_DEOP 2          /* Took op              */
 
 #ifdef MAKING_IRC
-static void check_tcl_need(char *, char *);
-static void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);
-static void check_tcl_invite(char *, char *, char *, char *);
-static void check_tcl_mode(char *, char *, struct userrec *, char *, char *, char *);
-static void check_tcl_joinspltrejn(char *, char *, struct userrec *, char *,
-                                   p_tcl_bind_list);
-static void check_tcl_part(char *, char *, struct userrec *, char *, char *);
-static void check_tcl_signtopcnick(char *, char *, struct userrec *u, char *,
-                                   char *, p_tcl_bind_list);
-static int check_tcl_pubm(char *, char *, char *, char *);
-static int check_tcl_pub(char *, char *, char *, char *);
-static int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *,
-                                    char*);
-static void check_tcl_account(char *nick, char *uhost, struct userrec *u, char *chan, char *account);
-static int check_tcl_chghost(char *, char *, char *, struct userrec *, char *, char *, char *);
-static int me_op(struct chanset_t *);
-static int me_halfop(struct chanset_t *);
-static int me_voice(struct chanset_t *);
-static int any_ops(struct chanset_t *);
-static int hand_on_chan(struct chanset_t *, struct userrec *);
-static char *getchanmode(struct chanset_t *);
-static void flush_mode(struct chanset_t *, int);
-static void set_delay(struct chanset_t *, char *);
-static void refresh_who_chan(char *);
 
 /* reset(bans|exempts|invites) are now just macros that call resetmasks
  * in order to reduce the code duplication. <cybah>
@@ -70,22 +46,7 @@ static void refresh_who_chan(char *);
                                        (chan)->invites, global_invites, 'I')
 
 void reset_chan_info(struct chanset_t *, int, int);
-static void recheck_channel(struct chanset_t *, int);
 #undef set_key /* because it could collide with openssl */
-static void set_key(struct chanset_t *, char *);
-static void maybe_revenge(struct chanset_t *, char *, char *, int);
-static int detect_chan_flood(char *, char *, char *, struct chanset_t *, int,
-                             char *);
-static void newmask(masklist *, char *, char *);
-static char *quickban(struct chanset_t *, char *);
-static void got_op(struct chanset_t *chan, char *nick, char *from, char *who,
-                   struct userrec *opu, struct flag_record *opper);
-static void got_halfop(struct chanset_t *chan, char *nick, char *from,
-                       char *who, struct userrec *opu,
-                       struct flag_record *opper);
-static int killmember(struct chanset_t *chan, char *nick);
-static void check_lonely_channel(struct chanset_t *chan);
-static int gotmode(char *, char *);
 
 #define newban(chan, mask, who)         newmask((chan)->channel.ban, mask, who)
 #define newexempt(chan, mask, who)      newmask((chan)->channel.exempt, mask, \

--- a/src/mod/irc.mod/irc_proto.h
+++ b/src/mod/irc.mod/irc_proto.h
@@ -24,26 +24,82 @@ extern int bounce_invites;
 extern int bounce_modes;
 extern int prevent_mixing;
 extern int include_lk;
+extern int kick_method;
+extern int use_354;
+extern int learn_users;
+extern int wait_info;
+extern int invite_key;
+extern int no_chanrec_info;
+extern int wait_split;
+extern int keepnick;
+extern int twitch;
+extern int ctcp_mode;
+extern int rfc_compliant;
+extern char opchars[8];
+extern Tcl_Obj *tcl_account;
+extern p_tcl_bind_list H_topc, H_splt, H_sign, H_rejn, H_part, H_pub, H_pubm;
+extern p_tcl_bind_list H_nick, H_mode, H_kick, H_join, H_need, H_invt, H_ircaway;
+extern p_tcl_bind_list H_account, H_chghost;
 
 /* Functions from irc.c */
 void check_tcl_mode(char *, char *, struct userrec *, char *, char *, char *);
 void check_tcl_need(char *, char *);
+void check_tcl_kick(char *, char *, struct userrec *, char *, char *, char *);
+void check_tcl_invite(char *, char *, char *, char *);
+int check_tcl_pub(char *, char *, char *, char *);
+int check_tcl_pubm(char *, char *, char *, char *);
+void check_tcl_joinspltrejn(char *, char *, struct userrec *, char *,
+                            p_tcl_bind_list);
+void check_tcl_part(char *, char *, struct userrec *, char *, char *);
+void check_tcl_signtopcnick(char *, char *, struct userrec *, char *,
+                            char *, p_tcl_bind_list);
+int check_tcl_ircaway(char *, char *, char *, struct userrec *, char *, char *);
+void check_tcl_account(char *, char *, struct userrec *, char *, char *);
+int check_tcl_chghost(char *, char *, char *, struct userrec *, char *, char *,
+                      char *);
 void maybe_revenge(struct chanset_t *, char *, char *, int);
 void set_key(struct chanset_t *, char *);
 int me_op(struct chanset_t *);
 int me_halfop(struct chanset_t *);
+int me_voice(struct chanset_t *);
+int any_ops(struct chanset_t *);
+int hand_on_chan(struct chanset_t *, struct userrec *);
 void refresh_who_chan(char *);
 void newmask(masklist *, char *, char *);
+void check_lonely_channel(struct chanset_t *);
+int killmember(struct chanset_t *, char *);
+void do_channel_part(struct chanset_t *);
 
-/* Functions from chan.c (compiled as part of irc.c) */
+/* Functions from chan.c */
+char *getchanmode(struct chanset_t *);
+void check_exemptlist(struct chanset_t *, char *);
+void do_mask(struct chanset_t *, masklist *, char *, char);
 int detect_chan_flood(char *, char *, char *, struct chanset_t *, int, char *);
+char *quickban(struct chanset_t *, char *);
 void kick_all(struct chanset_t *, char *, char *, int);
 void refresh_exempt(struct chanset_t *, char *);
 void recheck_channel(struct chanset_t *, int);
+void recheck_channel_modes(struct chanset_t *);
+void check_this_ban(struct chanset_t *, char *, int);
+void check_this_user(char *, int, char *);
+void set_delay(struct chanset_t *, char *);
+void resetmasks(struct chanset_t *, masklist *, maskrec *, maskrec *, char);
+extern cmd_t irc_raw[];
+extern cmd_t irc_rawt[];
+extern cmd_t irc_isupport_binds[];
 
 /* Functions from mode.c */
 void flush_mode(struct chanset_t *, int);
 void real_add_mode(struct chanset_t *, char, char, char *);
 int gotmode(char *, char *);
+
+/* Functions/tables from cmdsirc.c */
+extern cmd_t irc_dcc[];
+
+/* Functions/tables from msgcmds.c */
+extern cmd_t C_msg[];
+
+/* Functions/tables from tclirc.c */
+extern tcl_cmds tclchan_cmds[];
 
 #endif /* _EGG_MOD_IRC_IRC_PROTO_H */

--- a/src/mod/irc.mod/irc_proto.h
+++ b/src/mod/irc.mod/irc_proto.h
@@ -1,0 +1,49 @@
+/*
+ * irc_proto.h -- part of irc.mod
+ *   shared declarations between translation units of irc.mod
+ */
+
+#ifndef _EGG_MOD_IRC_IRC_PROTO_H
+#define _EGG_MOD_IRC_IRC_PROTO_H
+
+/* Module function tables from irc.c */
+extern Function *global;
+extern Function *channels_funcs;
+extern Function *server_funcs;
+
+/* Variables from irc.c */
+extern int modesperline;
+extern int mode_buf_len;
+extern int max_bans;
+extern int max_exempts;
+extern int max_invites;
+extern int max_modes;
+extern int bounce_bans;
+extern int bounce_exempts;
+extern int bounce_invites;
+extern int bounce_modes;
+extern int prevent_mixing;
+extern int include_lk;
+
+/* Functions from irc.c */
+void check_tcl_mode(char *, char *, struct userrec *, char *, char *, char *);
+void check_tcl_need(char *, char *);
+void maybe_revenge(struct chanset_t *, char *, char *, int);
+void set_key(struct chanset_t *, char *);
+int me_op(struct chanset_t *);
+int me_halfop(struct chanset_t *);
+void refresh_who_chan(char *);
+void newmask(masklist *, char *, char *);
+
+/* Functions from chan.c (compiled as part of irc.c) */
+int detect_chan_flood(char *, char *, char *, struct chanset_t *, int, char *);
+void kick_all(struct chanset_t *, char *, char *, int);
+void refresh_exempt(struct chanset_t *, char *);
+void recheck_channel(struct chanset_t *, int);
+
+/* Functions from mode.c */
+void flush_mode(struct chanset_t *, int);
+void real_add_mode(struct chanset_t *, char, char, char *);
+int gotmode(char *, char *);
+
+#endif /* _EGG_MOD_IRC_IRC_PROTO_H */

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -23,6 +23,15 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#define MODULE_NAME "irc"
+#define MAKING_IRC
+
+#include "src/mod/module.h"
+#include "irc.h"
+#include "irc_proto.h"
+#include "server.mod/server.h"
+#include "channels.mod/channels.h"
+
 /* Reversing this mode? */
 static int reversing = 0;
 
@@ -62,7 +71,7 @@ static struct chanset_t *modebind_refresh(char *chname,
   return chan;
 }
 
-static void flush_mode(struct chanset_t *chan, int pri)
+void flush_mode(struct chanset_t *chan, int pri)
 {
   char *p, out[512], post[512];
   size_t postsize = sizeof(post);
@@ -196,8 +205,8 @@ static void flush_mode(struct chanset_t *chan, int pri)
 
 /* Queue a channel mode change
  */
-static void real_add_mode(struct chanset_t *chan,
-                          char plus, char mode, char *op)
+void real_add_mode(struct chanset_t *chan,
+                   char plus, char mode, char *op)
 {
   int i, type, modes, l;
   masklist *m;
@@ -988,7 +997,7 @@ static void got_uninvite(struct chanset_t *chan, char *nick, char *from,
     add_mode(chan, '+', 'I', who);
 }
 
-static int gotmode(char *from, char *origmsg)
+int gotmode(char *from, char *origmsg)
 {
   char *nick, *ch, *op, *chg, *msg;
   char s[UHOSTLEN], buf[511];

--- a/src/mod/irc.mod/msgcmds.c
+++ b/src/mod/irc.mod/msgcmds.c
@@ -21,6 +21,15 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#define MODULE_NAME "irc"
+#define MAKING_IRC
+
+#include "src/mod/module.h"
+#include "irc.h"
+#include "irc_proto.h"
+#include "server.mod/server.h"
+#include "channels.mod/channels.h"
+
 static int msg_hello(char *nick, char *h, struct userrec *u, char *p)
 {
   char host[UHOSTLEN], s[UHOSTLEN], s1[UHOSTLEN], handle[HANDLEN + 1];
@@ -1116,7 +1125,7 @@ static int msg_jump(char *nick, char *host, struct userrec *u, char *par)
  * The function is responsible for any logging. Return 1 if successful,
  * 0 if not.
  */
-static cmd_t C_msg[] = {
+cmd_t C_msg[] = {
   {"addhost", "",    (IntFunc) msg_addhost, NULL},
   {"die",     "n",   (IntFunc) msg_die,     NULL},
   {"go",      "",    (IntFunc) msg_go,      NULL},

--- a/src/mod/irc.mod/tclirc.c
+++ b/src/mod/irc.mod/tclirc.c
@@ -20,6 +20,15 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#define MODULE_NAME "irc"
+#define MAKING_IRC
+
+#include "src/mod/module.h"
+#include "irc.h"
+#include "irc_proto.h"
+#include "server.mod/server.h"
+#include "channels.mod/channels.h"
+
 /* Streamlined by answer.
  */
 static int tcl_chanlist STDVAR
@@ -1189,7 +1198,7 @@ static int tcl_putkick STDVAR
   return TCL_OK;
 }
 
-static tcl_cmds tclchan_cmds[] = {
+tcl_cmds tclchan_cmds[] = {
   {"chanlist",       tcl_chanlist},
   {"botisop",        tcl_botisop},
   {"botishalfop",    tcl_botishalfop},


### PR DESCRIPTION
Found by: thommey
Patch by: thommey

One-line summary:
Remove C file amalgamations (huge .c file by #include of other .c files) in modules

Additional description (if needed):
This drastically improves IDE support. irc_proto.h is the internal header file for irc.mod interdependencies. The key strategy to minimal build system changes is incremental linking of multiple .o files into a single .o file:
```
../irc.o: irc.o mode.o ...
	$(CC) -r -nostdlib -o ../irc.o irc.o mode.o ...
```

Disclaimer: 90% AI generated (Claude Opus 4.6)
