### PR TITLE
Crash fix nullpointer

### DIFF
--- a/src/userent.c
+++ b/src/userent.c
@@ -1647,7 +1647,7 @@ struct user_entry *find_user_entry(struct user_entry_type *et,
   struct user_entry **e, *t;
 
   for (e = &(u->entries); *e; e = &((*e)->next)) {
-    if (((*e)->type == et) || !strcasecmp((*e)->type->name, et->name)) {
+    if (((*e)->type == et) || ((*e)->type && !strcasecmp((*e)->type->name, et->name))) {
       t = *e;
       *e = t->next;
       t->next = u->entries;


### PR DESCRIPTION
Found by: Harekiet
Patch by: https://github.com/michaelortmann
Fixes: #1883

One-line summary:


Additional description (if needed):
Bug since #1797, so it effects only current git branch, eggdrop 1.10.1 is fine.

Test cases demonstrating functionality (if applicable):
If a userfile contains bogus lines, like for example:
`"--BOTFL"`
instead of
`"--BOTFL s"`
the bot would crash.

Crash info showing **type = 0x0**:
```
#0  0x000055df7718d264 in find_user_entry (et=et@entry=0x55df771ad0e0 <USERENTRY_BOTFL>, u=u@entry=0x55df956a7210) at userent.c:1650
1650	    if (((*e)->type == et) || !strcasecmp((*e)->type->name, et->name)) {
(gdb) print **e
$1 = {next = 0x0, type = 0x0, u = {string = 0x55df9563f4d0 "", extra = 0x55df9563f4d0, list = 0x55df9563f4d0, ulong = 94418772423888}, name = 0x55df9563f4b0 "BOTFL\n"}
```