### PR TITLE
Add help for python.mod partyline command

### DIFF
--- a/src/mod/python.mod/help/python.help
+++ b/src/mod/python.mod/help/python.help
@@ -1,0 +1,18 @@
+%{help=python}%{+n}
+###  %bpython%b <code>
+   Executes the given Python code on the partyline. The code is run in the
+   global Python interpreter context and can access the eggdrop module.
+   Expression results are displayed, and errors are shown with a traceback.
+%{help=python module}%{+n}
+###  %bpython module%b
+   This module provides an embedded Python interpreter for extending Eggdrop
+   with Python scripts.
+
+   The following partyline commands are provided by the python module:
+
+   For global owners:
+      %bpython%b
+%{help=all}%{+n}
+###  %bpython module%b commands
+   For global owners:
+      %bpython%b

--- a/src/mod/python.mod/python.c
+++ b/src/mod/python.mod/python.c
@@ -159,6 +159,7 @@ char *python_start(Function *global_funcs)
   /* Add command table to bind list */
   add_builtins(H_dcc, mydcc);
   add_tcl_commands(my_tcl_cmds);
+  add_help_reference("python.help");
   add_hook(HOOK_PRE_SELECT, (Function)python_gil_unlock);
   add_hook(HOOK_POST_SELECT, (Function)python_gil_lock);
   return NULL;


### PR DESCRIPTION
Adds a python.help file so `.help python` and `.help all` display the python module's partyline command. Fixes #1856.

Found by: michaelortmann
Patch by: thommey
Fixes: #1856 
