### PR TITLE
Fix log for writing to nonexistent socket

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1390,8 +1390,8 @@ void tputs(int z, char *s, unsigned int len)
     inhere = 1;
 
     putlog(LOG_MISC, "*", "!!! writing to nonexistent socket: %d", z);
-    s2[len - 1] = 0;
-    putlog(LOG_MISC, "*", "!-> '%s'", s2);
+    s[len - 1] = 0;
+    putlog(LOG_MISC, "*", "!-> '%s'", s);
 
     inhere = 0;
   }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix log for writing to nonexistent socket

Additional description (if needed):
Bug was introduced by #1467.

Test cases demonstrating functionality (if applicable):
```
./configure --disable-tls
...
make
...
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/usr/include  -c net.c
net.c: In function ‘tputs’:
net.c:1394:33: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
 1394 |     putlog(LOG_MISC, "*", "!-> '%s'", s2);
      |                                 ^~
```