### PR TITLE
Add location.pathname handling to webui

### DIFF
--- a/src/mod/webui.mod/index.html
+++ b/src/mod/webui.mod/index.html
@@ -32,7 +32,9 @@ avoid off-topic discussions)
       const input = document.getElementById("input");
       const ws = new WebSocket(
         (location.protocol === "https:" ? "wss:" : "ws:") +
+          "//" +
           location.host +
+          location.pathname.replace(/\/$/, "") +
           "/w",
       );
       let echo = true;


### PR DESCRIPTION
Found by: PeGaSuS
Patch by: PeGaSuS
Fixes: 

One-line summary:
Add location.pathname handling to webui

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
eggdrop behind proxy. PeGaSuS has a test setup.