### PR TITLE
Fix for new openssl 4.0.0

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -191,7 +191,12 @@ void verify_cert_expiry(int idx) {
   x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
 #endif
   if (x509) {
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+    int e;
+    if (!X509_check_certificate_times(NULL, x509, &e) && (e == X509_V_ERR_CERT_HAS_EXPIRED)) {
+#else
     if (X509_cmp_current_time(X509_get_notAfter(x509)) < 0) {
+#endif
       if (idx) {
         dprintf(idx, "WARNING: SSL/TLS certificate %s expired\n", tls_certfile);
         dprintf(idx, "You can generate new certificates by running 'make sslcert' from the source directory\n\n");

--- a/src/tls.c
+++ b/src/tls.c
@@ -456,7 +456,13 @@ const char *ssl_getuid(int sock)
 {
   int idx;
   X509 *cert;
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+  const
+#endif
   X509_NAME *subj;
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+  const
+#endif
   ASN1_STRING *name;
 
   if (!(cert = ssl_getcert(sock)))
@@ -563,6 +569,9 @@ static int ssl_verifycn(X509 *cert, ssl_appdata *data)
     }
     sk_GENERAL_NAME_free(altname);
   } else { /* no subjectAltName, try to match against the subject CNs */
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+    const
+#endif
     X509_NAME *subj; /* certificate subject */
 
     /* the following is just for information */
@@ -583,6 +592,9 @@ static int ssl_verifycn(X509 *cert, ssl_appdata *data)
       match = 0;
     } else { /* we have a subject name, look at it */
       int pos = -1;
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+      const
+#endif
       ASN1_STRING *name;
 
       /* Look for commonName attributes in the subject name */
@@ -616,7 +628,11 @@ static int ssl_verifycn(X509 *cert, ssl_appdata *data)
  *
  * You need to nfree() the returned pointer.
  */
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+static char *ssl_printname(const X509_NAME *name)
+#else
 static char *ssl_printname(X509_NAME *name)
+#endif
 {
   long len;
   char *data, *buf;
@@ -727,6 +743,9 @@ static char *ssl_printnum(ASN1_INTEGER *i)
 static void ssl_showcert(X509 *cert, const int loglev)
 {
   char *buf, *from, *to;
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L /* 4.0.0 */
+  const
+#endif
   X509_NAME *name;
   unsigned int len;
   unsigned char md[EVP_MAX_MD_SIZE];


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix for new openssl 4.0.0

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
with new openssl 4.0.0:
```
make
[...]
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I.. -I/home/michael/opt/openssl-4.0.0/include -DHAVE_CONFIG_H -I/usr/include  -c tls.c
tls.c: In function ‘verify_cert_expiry’:
tls.c:194:5: warning: ‘X509_cmp_current_time’ is deprecated: Since OpenSSL 4.0 [-Wdeprecated-declarations]
  194 |     if (X509_cmp_current_time(X509_get_notAfter(x509)) < 0) {
      |     ^~
In file included from /home/michael/opt/openssl-4.0.0/include/openssl/ssl.h:34,
                 from eggdrop.h:222,
                 from main.h:88,
                 from tls.c:27:
/home/michael/opt/openssl-4.0.0/include/openssl/x509.h:694:27: note: declared here
  694 | OSSL_DEPRECATEDIN_4_0 int X509_cmp_current_time(const ASN1_TIME *s);
      |                           ^~~~~~~~~~~~~~~~~~~~~
tls.c: In function ‘ssl_getuid’:
tls.c:465:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  465 |   if (!(subj = X509_get_subject_name(cert))) {
      |              ^
tls.c:480:8: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  480 |   name = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subj, idx));
      |        ^
tls.c: In function ‘ssl_verifycn’:
tls.c:580:16: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  580 |     if (!(subj = X509_get_subject_name(cert))) {
      |                ^
tls.c:596:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  596 |         name = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subj, pos));
      |              ^
tls.c: In function ‘ssl_showcert’:
tls.c:735:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  735 |   if ((name = X509_get_subject_name(cert))) {
      |             ^
tls.c:741:13: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  741 |   if ((name = X509_get_issuer_name(cert))) {
      |             ^
tls.c: In function ‘tcl_tlsstatus’:
tls.c:1214:23: warning: passing argument 1 of ‘ssl_printname’ discards ‘const’ qualifier from pointer target type -Wdiscarded-qualifiers]
 1214 |     p = ssl_printname(X509_get_subject_name(cert));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
tls.c:619:39: note: expected ‘X509_NAME *’ {aka ‘struct X509_name_st *’} but argument is of type ‘const X509_NAME ’ {aka ‘const struct X509_name_st *’}
  619 | static char *ssl_printname(X509_NAME *name)
      |                            ~~~~~~~~~~~^~~~
tls.c:1218:23: warning: passing argument 1 of ‘ssl_printname’ discards ‘const’ qualifier from pointer target type -Wdiscarded-qualifiers]
 1218 |     p = ssl_printname(X509_get_issuer_name(cert));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
tls.c:619:39: note: expected ‘X509_NAME *’ {aka ‘struct X509_name_st *’} but argument is of type ‘const X509_NAME ’ {aka ‘const struct X509_name_st *’}
  619 | static char *ssl_printname(X509_NAME *name)
      |                            ~~~~~~~~~~~^~~~
```