### PR TITLE
Fix make error with tcl9

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -273,8 +273,9 @@ void dcc_dnshostbyip(sockname_t *ip)
 static void dns_tcl_iporhostres(sockname_t *ip, char *hostn, int ok, void *other)
 {
   devent_tclinfo_t *tclinfo = (devent_tclinfo_t *) other;
-  int objc = 0, objc2;
+  int objc = 0;
   Tcl_Obj **objv, *list = NULL, **objv2;
+  Tcl_Size objc2;
   int i;
 
   objv = nmalloc(sizeof(Tcl_Obj *) * 4);


### PR DESCRIPTION
Found by: skydrome
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix type for tcl9+

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
with tcl 9:
```
gcc -std=gnu99 -g -O2 -pipe -Wall -I.. -I..  -DHAVE_CONFIG_H -I/home/michael/opt/tcl9.1a1/include  -c dns.c
dns.c: In function ‘dns_tcl_iporhostres’:
dns.c:292:46: error: passing argument 3 of ‘Tcl_ListObjGetElements’ from incompatible pointer type [-Wincompatible-pointer-types]
  292 |     if (Tcl_ListObjGetElements(interp, list, &objc2, &objv2) == TCL_OK) {
      |                                              ^~~~~~
      |                                              |
      |                                              int *
In file included from /home/michael/opt/tcl9.1a1/include/tcl.h:2363,
                 from ../lush.h:4,
                 from main.h:42,
                 from dns.c:27:
/home/michael/opt/tcl9.1a1/include/tclDecls.h:1800:61: note: expected ‘Tcl_Size *’ {aka ‘long int *’} but argument is of type ‘int *’
 1800 |                                 Tcl_Obj *listPtr, Tcl_Size *objcPtr,
      |                                                   ~~~~~~~~~~^~~~~~~
make[1]: *** [Makefile:86: dns.o] Error 1
make[1]: Leaving directory '/home/michael/projects/eggdrop/src'
make: *** [Makefile:244: eggdrop] Error 2
```