### PR TITLE
(WIP) Fix bursting / dequeuing

### DIFF
--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1180,6 +1180,11 @@ set extended-join 1
 # 512 bytes/2 seconds.
 set msg-rate 2
 
+# Limit messages to server to n messages / n seconds. Most IRC servers have a
+# threashold of 5. Only rise this value if you know what you are doing or
+# risk excess flood kill.
+set burst-rate 5
+
 # This setting makes the bot try to get his original nickname back if its
 # primary nickname is already in use.
 set keep-nick 1

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -189,7 +189,7 @@ static void deq_msg()
   if (serv < 0)
     return;
 
-  /* Send up to 4 msgs to server if the *critical queue* has anything in it */
+  /* Send up to 5 msgs to server if the *critical queue* has anything in it */
   if (modeq.head) {
     while (modeq.head && (burst < 5) && ((last_time - now) < MAXPENALTY)) {
       if (deq_kick(DP_MODE)) {

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -191,7 +191,7 @@ static void deq_msg()
 
   /* Send up to 4 msgs to server if the *critical queue* has anything in it */
   if (modeq.head) {
-    while (modeq.head && (burst < 4) && ((last_time - now) < MAXPENALTY)) {
+    while (modeq.head && (burst < 5) && ((last_time - now) < MAXPENALTY)) {
       if (deq_kick(DP_MODE)) {
         burst++;
         continue;
@@ -219,8 +219,7 @@ static void deq_msg()
     return;
   }
 
-  /* Send something from the normal msg q even if we're slightly bursting */
-  if (burst > 1)
+  if (modeq.head || (!modeq.head && (burst > 4)))
     return;
 
   if (mq.head) {

--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -145,6 +145,7 @@ static char cap_request[CAPMAX - 9];
 static int maxqmsg;
 static struct msgq_head mq, hq, modeq;
 static int burst;
+static int burstrate;
 
 #include "cmdsserv.c"
 #include "tclserv.c"
@@ -191,7 +192,7 @@ static void deq_msg()
 
   /* Send up to 5 msgs to server if the *critical queue* has anything in it */
   if (modeq.head) {
-    while (modeq.head && (burst < 5) && ((last_time - now) < MAXPENALTY)) {
+    while (modeq.head && (burst < burstrate) && ((last_time - now) < MAXPENALTY)) {
       if (deq_kick(DP_MODE)) {
         burst++;
         continue;
@@ -219,7 +220,7 @@ static void deq_msg()
     return;
   }
 
-  if (modeq.head || (!modeq.head && (burst > 4)))
+  if (modeq.head || (!modeq.head && (burst >= burstrate)))
     return;
 
   if (mq.head) {
@@ -1771,6 +1772,7 @@ static tcl_ints my_tcl_ints[] = {
   {"extended-join",     &extended_join,             0},
   {"account-notify",    &account_notify,            0},
   {"account-tag",       &account_tag,               0},
+  {"burst-rate",        &burstrate,                 0},
   {NULL,                NULL,                       0}
 };
 
@@ -2430,6 +2432,7 @@ char *server_start(Function *global_funcs)
 #ifdef TLS
   tls_vfyserver = 0;
 #endif
+  burstrate = 5;
 
   server_table[4] = (Function) botname;
   module_register(MODULE_NAME, server_table, 1, 5);


### PR DESCRIPTION
Found by: [Pixelz](https://github.com/Pixelz)
Patch by: michaelortmann
Fixes: #166

One-line summary:


Additional description (if needed):
This PR fixes a bug with bursting / dequeing, but its not a final solution to #166 yet.
It also experiments with making burstrate configurable.

Test cases demonstrating functionality (if applicable):
Eggdrop now fully joins/synch a channel on a vanilla irspircd within 9 instead of 15 seconds. And if we set burst-rate 20 in config, it connects and fully synches in just 3 seconds. Thats a good start and the reason why i think we should try hard to fix the dequeing limit issues.