### PR TITLE
Fix memory leak in server.mod monitor_add()

### DIFF
--- a/src/mod/server.mod/server.c
+++ b/src/mod/server.mod/server.c
@@ -1227,11 +1227,9 @@ static void next_server(int *ptr, char *serv, unsigned int *port, char *pass)
  * Returns 2 if maximum number of nicks to be monitored reached
  */
 static int monitor_add(char * nick, int send) {
-  struct monitor_list *entry = nmalloc(sizeof(struct monitor_list));
+  struct monitor_list *entry;
   struct monitor_list *current = monitor;
   int count = 0;
-
-  memset(entry, 0, sizeof *entry);
 
   /* Check for duplicates before adding */
   while (current != NULL) {
@@ -1244,13 +1242,14 @@ static int monitor_add(char * nick, int send) {
   if (count >= max_monitor) {
     return 2;
   }
+  entry = nmalloc(sizeof(struct monitor_list));
+  memset(entry, 0, sizeof *entry);
   strlcpy(entry->nick, nick, NICKLEN);
   entry->next = monitor;
   monitor = entry;
   if (send) {
     dprintf(DP_SERVER, "MONITOR + %s\n", nick);
   }
-
   return 0;
 }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1900

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
