### PR TITLE
Fix counting for ret == -1 in net.c:safe_write()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -867,15 +867,18 @@ void safe_write(int fd, const void *buf, size_t count)
   static int inhere = 0;
 
   do {
-    if ((ret = write(fd, bytes, count)) == -1 && errno != EINTR) {
+    if ((ret = write(fd, bytes, count)) > -1) {
+      bytes += ret;
+      count -= ret;
+    } else if (errno != EINTR) {
       if (!inhere) {
         inhere = 1;
-        putlog(LOG_MISC, "*", "Unexpected write() failure on attempt to write %zd bytes to fd %d: %s.", count, fd, strerror(errno));
+        putlog(LOG_MISC, "*", "Unexpected write() failure on attempt to write %zu bytes to fd %d: %i: %s.", count, fd, errno, strerror(errno));
         inhere = 0;
       }
       break;
     }
-  } while ((bytes += ret, count -= ret));
+  } while (count > 0);
 }
 
 /* Attempts to read from all sockets in slist (upper array boundary slistmax-1)


### PR DESCRIPTION
Found by: [tuvok81](https://github.com/tuvok81)
Patch by: thommey and michaelortmann

One-line summary:
Fix counting for ret == -1 in net.c:safe_write(), enhance log msg and refactor to make it this func easier to read and understand

Additional description (if needed):
Doesn't fix #1734 


Test cases demonstrating functionality (if applicable):
