### PR TITLE
Fix network connect and logging

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1024,11 +1024,10 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
                                 * otherwise it will connect. */
           *len = slist[i].sock;
           slist[i].flags &= ~SOCK_CONNECT;
-          debug1("net: eof!(read) socket %d", slist[i].sock);
+          debug2("net: eof!(read) socket %d error %s", slist[i].sock, strerror(errno));
           return -1;
         } else {
-          debug3("sockread EAGAIN: %d %d (%s)", slist[i].sock, errno,
-                 strerror(errno));
+          debug2("net: EAGAIN socket %d error %s", slist[i].sock, strerror(errno));
           continue;           /* EAGAIN */
         }
       }

--- a/src/net.c
+++ b/src/net.c
@@ -570,7 +570,7 @@ int connect_nonblock(int s, sockname_t *addr, int check_tcl_event_ident) {
         return -4;
       }
       if (res != 0) {
-        debug1("net: getsockopt error %d", res);
+        debug2("net: getsockopt() socket %i error %s", s, strerror(res));
         return -1;
       }
       return s; /* async success! */
@@ -914,6 +914,8 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
   struct dns_thread_node *dtn, *dtn_prev;
   void *res;
 #endif
+  int res2;
+  socklen_t res2_len;
 
   maxfd_r = preparefdset(&fdr, slist, slistmax, tclonly, TCL_READABLE);
 #ifdef EGG_TDNS
@@ -970,6 +972,14 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
 #else
         else if (!(slist[i].flags & SOCK_STRONGCONN)) {
 #endif
+          res2_len = sizeof(res2);
+          getsockopt(slist[i].sock, SOL_SOCKET, SO_ERROR, &res2, &res2_len);
+          if (res2 > 0 && res2 != EINPROGRESS) {
+            debug2("net: connect! sock %d error %s", slist[i].sock, strerror(res2));
+            s[0] = 0;
+            *len = slist[i].sock;
+            return -1;
+          }
           debug1("net: connect! sock %d", slist[i].sock);
           s[0] = 0;
           *len = 0;

--- a/src/net.c
+++ b/src/net.c
@@ -974,7 +974,7 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
 #endif
           res2_len = sizeof(res2);
           getsockopt(slist[i].sock, SOL_SOCKET, SO_ERROR, &res2, &res2_len);
-          if (res2 > 0 && res2 != EINPROGRESS) {
+          if ((res2 > 0) && (res2 != EINPROGRESS)) {
             debug2("net: connect! sock %d error %s", slist[i].sock, strerror(res2));
             s[0] = 0;
             *len = slist[i].sock;

--- a/src/net.c
+++ b/src/net.c
@@ -1024,10 +1024,16 @@ int sockread(char *s, int *len, sock_list *slist, int slistmax, int tclonly)
                                 * otherwise it will connect. */
           *len = slist[i].sock;
           slist[i].flags &= ~SOCK_CONNECT;
-          debug2("net: eof!(read) socket %d error %s", slist[i].sock, strerror(errno));
+          if (x < 0)
+            debug2("net: eof!(read) socket %d error %s", slist[i].sock, strerror(errno));
+          else
+            debug1("net: eof!(read) socket %d", slist[i].sock);
           return -1;
         } else {
-          debug2("net: EAGAIN socket %d error %s", slist[i].sock, strerror(errno));
+          if (x < 0)
+            debug2("net: EAGAIN socket %d error %s", slist[i].sock, strerror(errno));
+          else
+            debug1("net: EAGAIN socket %d", slist[i].sock);
           continue;           /* EAGAIN */
         }
       }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix network connect and logging

Additional description (if needed):
For unblocking `connect()` select returns. This PR adds a `getsockopt()` check to detect eof/unsuccessful connect early, before attempting to `read()`. Also log messages were enhanced.

Test cases demonstrating functionality (if applicable):
Set an irc server that is unreachable and `.set console +*`
Before:
```
[05:42:20] Trying server 192.168.16.141:6667
[05:42:20] net: open_telnet_raw(): idx 4 host 192.168.16.141 ip 192.168.16.141 port 6667 ssl 0
[05:42:20] [!m] CAP LS 302
[05:42:20] [m->] CAP LS 302
[05:42:20] [!m] NICK BotA
[05:42:20] [m->] NICK BotA
[05:42:20] [!m] USER BotA . . :A deranged product of evil coders
[05:42:20] [m->] USER BotA . . :A deranged product of evil coders
[05:42:23] net: connect! sock 8
[05:42:23] Connected to 192.168.16.141
[05:42:23] [@] 
[05:42:23] net: eof!(read) socket 8
[05:42:23] Disconnected from 192.168.16.141
```
After:
```
[05:43:32] Trying server 192.168.16.141:6667
[05:43:32] net: open_telnet_raw(): idx 4 host 192.168.16.141 ip 192.168.16.141 port 6667 ssl 0
[05:43:32] [!m] CAP LS 302
[05:43:32] [m->] CAP LS 302
[05:43:32] [!m] NICK BotA
[05:43:32] [m->] NICK BotA
[05:43:32] [!m] USER BotA . . :A deranged product of evil coders
[05:43:32] [m->] USER BotA . . :A deranged product of evil coders
[05:43:35] net: connect! sock 8 error No route to host
[05:43:35] Disconnected from 192.168.16.141
```