### PR TITLE
Crash fix python.mod

### DIFF
--- a/src/mod/python.mod/pycmds.c
+++ b/src/mod/python.mod/pycmds.c
@@ -171,6 +171,7 @@ static PyObject *py_parse_tcl_list(PyObject *self, PyObject *args) {
   if (Tcl_ListObjLength(tclinterp, strobj, &max) != TCL_OK) {
     Tcl_DecrRefCount(strobj);
     PyErr_SetString(EggdropError, "Supplied string is not a Tcl list");
+    return NULL;
   }
   result = PyList_New(max);
   for (int i = 0; i < max; i++) {


### PR DESCRIPTION
Found by: [pagzlol](https://github.com/pagzlol)
Patch by: michaelortmann
Fixes: #1912

One-line summary:
Crash fix, break on error

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Before:
```
.load python
.python eggdrop.parse_tcl_list("{")
[01:23:26] tcl: builtin dcc call: *dcc:python -HQ 1 eggdrop.parse_tcl_list("{")
Python Error: <built-in function parse_tcl_list> returned a result with an exception set
eggdrop.error: Supplied string is not a Tcl list

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
SystemError: <built-in function parse_tcl_list> returned a result with an exception set
[... some seconds later ...]
SIGSEGV
```
After:
No more crash