### PR TITLE
compress.mod: Limit size for output file for uncompress function

### DIFF
--- a/doc/sphinx_source/modules/mod/compress.rst
+++ b/doc/sphinx_source/modules/mod/compress.rst
@@ -1,4 +1,4 @@
-Last revised: May 27, 2004
+Last revised: June 20, 2026
 
 .. _compress:
 
@@ -26,6 +26,9 @@ There are also some variables you can set in your config file:
   set compress-level 9
     This is the default compression level used. These levels are the same
     as those used by GNU gzip.
+
+  set max-uncompress-size 16777216
+    Maximum size for output file for uncompress function in bytes.
 
 
 Copyright (C) 2000 - 2025 Eggheads Development Team

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -1493,6 +1493,9 @@ set share-compressed 1
 # those used by GNU gzip.
 #set compress-level 9
 
+# Maximum size for output file for uncompress function in bytes.
+#set max-uncompress-size 16777216
+
 
 #### FILESYSTEM MODULE ####
 

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -398,7 +398,7 @@ static uff_table_t compress_uff_table[] = {
 static tcl_ints my_tcl_ints[] = {
   {"share-compressed",    (int *)&share_compressed,    0},
   {"compress-level",      (int *)&compress_level,      0},
-  {"max_uncompress_size", (int *)&max_uncompress_size, 0},
+  {"max-uncompress-size", (int *)&max_uncompress_size, 0},
   {NULL,                  NULL,                        0}
 };
 

--- a/src/mod/compress.mod/compress.c
+++ b/src/mod/compress.mod/compress.c
@@ -46,15 +46,16 @@
 
 #include "compress.h"
 
-#define BUFLEN 512
+#define BUFLEN 1024
 
 
 static Function *global = NULL, *share_funcs = NULL;
 
-static unsigned int compressed_files;   /* Number of files compressed.      */
-static unsigned int uncompressed_files; /* Number of files uncompressed.    */
-static unsigned int share_compressed;   /* Compress userfiles when sharing? */
-static unsigned int compress_level;     /* Default compression used.        */
+static unsigned int compressed_files;    /* Number of files compressed.      */
+static unsigned int uncompressed_files;  /* Number of files uncompressed.    */
+static unsigned int share_compressed;    /* Compress userfiles when sharing? */
+static unsigned int compress_level;      /* Default compression used.        */
+static unsigned int max_uncompress_size; /* Maximum file size for uncompress */
 
 
 static int uncompress_to_file(char *f_src, char *f_target);
@@ -127,7 +128,7 @@ static int is_compressedfile(char *filename)
 static int uncompress_to_file(char *f_src, char *f_target)
 {
   char buf[BUFLEN];
-  int len;
+  int len, uncompress_size = 0;
   FILE *fout;
   gzFile fin;
 
@@ -161,6 +162,14 @@ static int uncompress_to_file(char *f_src, char *f_target)
     }
     if (!len)
       break;
+    uncompress_size += len;
+    if (uncompress_size > max_uncompress_size) {
+      putlog(LOG_MISC, "*", "Failed to uncompress file `%s': bigger than max size %i.",
+             f_src, max_uncompress_size);
+      gzclose(fin);
+      fclose(fout);
+      return COMPF_ERROR;
+    }
     if ((int) fwrite(buf, 1, (unsigned int) len, fout) != len) {
       putlog(LOG_MISC, "*", "Failed to uncompress file `%s': fwrite "
              "failed: %s.", f_src, strerror(errno));
@@ -387,9 +396,10 @@ static uff_table_t compress_uff_table[] = {
  */
 
 static tcl_ints my_tcl_ints[] = {
-  {"share-compressed", (int *)&share_compressed, 0},
-  {"compress-level",     (int *)&compress_level, 0},
-  {NULL,                                   NULL, 0}
+  {"share-compressed",    (int *)&share_compressed,    0},
+  {"compress-level",      (int *)&compress_level,      0},
+  {"max_uncompress_size", (int *)&max_uncompress_size, 0},
+  {NULL,                  NULL,                        0}
 };
 
 static int compress_expmem(void)
@@ -449,8 +459,9 @@ char *compress_start(Function *global_funcs)
   uncompressed_files = 0;
   share_compressed = 0;
   compress_level = 9;
+  max_uncompress_size = 16777216;
 
-  module_register(MODULE_NAME, compress_table, 1, 2);
+  module_register(MODULE_NAME, compress_table, 1, 3);
   if (!module_depend(MODULE_NAME, "eggdrop", 108, 0)) {
     module_undepend(MODULE_NAME);
     return "This module requires Eggdrop 1.8.0 or later.";

--- a/src/mod/compress.mod/help/compress.help
+++ b/src/mod/compress.mod/help/compress.help
@@ -5,5 +5,5 @@
    share process, saving bandwidth.
 
    Config file variables for configuring the compress module:
-      %bcompress-level  share-compressed%b
+      %bcompress-level  max-uncompress-size  share-compressed%b
    (Use %b'.help set <variable>'%b for more info)

--- a/src/mod/compress.mod/help/set/compress.help
+++ b/src/mod/compress.mod/help/set/compress.help
@@ -2,6 +2,9 @@
 ###  %bset share-compressed%b <0/1>
   Allow compressed sending of user files? The user files are compressed with
   the compression level defined in `compress-level'.
+%{help=set max-uncompress-size}%{+n}
+###  %bset max-uncompress-size%b <0-4294967295>
+  Maximum size for output file for uncompress function in bytes.
 %{help=set compress-level}%{+n}
 ###  %bset compress-level%b <0-9>
   This is the default compression level used. These levels are the same as


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Limit size for output file for uncompress function, add setting max-uncompress-size with default 16 mb, increase gz buffer size from 512 to 1024 bytes.

Additional description (if needed):
Prevent decompression bomb.

Test cases demonstrating functionality (if applicable):
