### PR TITLE
Add GNU/Hurd support

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -663,6 +663,9 @@ AC_DEFUN([EGG_CHECK_MODULE_SUPPORT],
     Minix)
       WEIRD_OS="no"
     ;;
+    GNU)
+      WEIRD_OS="no"
+    ;;
     *)
       # QNX apparently supports dlopen()... Fallthrough.
       if test -r /cmds; then
@@ -829,6 +832,10 @@ AC_DEFUN([EGG_CHECK_OS],
         ;;
       esac
       AC_DEFINE(BIND_8_COMPAT, 1, [Define if running on macOS with dns.mod.])
+    ;;
+    GNU)
+      SHLIB_CC="$CC -fPIC"
+      SHLIB_LD="$CC -shared -nostartfiles"
     ;;
     *)
       if test -r /cmds; then


### PR DESCRIPTION
Found by: me
Patch by: me

One-line summary: If Minix and Haiku are not "weird", GNU/Hurd isn't either

Test cases demonstrating functionality (if applicable):
This small fix is applied in the Debian package and it builds fine now https://buildd.debian.org/status/logs.php?pkg=eggdrop&arch=hurd-i386