### PR TITLE
Task/normalizeextban

### DIFF
--- a/doc/sphinx_source/using/bans.rst
+++ b/doc/sphinx_source/using/bans.rst
@@ -6,7 +6,7 @@ Bans, Invites, and Exempts
 ==========================
 
 
-  I assume that you know how bans work on IRC. Eggdrop handles bans, exempts
+  Eggdrop handles bans, exempts
   and invites in various ways, and this file is intended to help clarify how
   these modes are used within the bot. From here on, 'mode' applies to all
   three modes (bans, exempts, and invites) unless otherwise specified. There
@@ -73,4 +73,18 @@ Bans, Invites, and Exempts
              (defined in config file) or until the channel goes -i again,
              whichever happens last.
 
-  Copyright (C) 1999 - 2025 Eggheads Development Team
+-----------------------
+Extended Bans (EXTBANS)
+-----------------------
+
+As of version 1.10.2, Eggdrop incorportes extended ban support. Exteneded bans give new functionality to the traditional IRC ban through the use of new prefix to the banmask. Eggdrop currently only supports single-character extended ban flags, not longform (ie "a", but not "account").
+
+When a ban is added through Eggdrop with the .+extban command, Eggdrop automatically takes the EXTBAN prefix for the server and prepends it to the EXTBAN flag the user provides. This is the preferred method of adding extbans to ensure they are functionally added to Eggdrop
+
+If you add an extended ban via .+ban instead of .+extban, Eggdrop assumes you know what you are doing and gives the user lattitude to set what they want. When an extban ban is added through Eggdrop with the .+ban command, Eggdrop identifies and parses the supplied mask as extban syntax before storing it. Eggdrop will then check whether the provided extban flag is supported by the current server, either through ACCOUNTEXTBAN or the advertised EXTBAN flags. If the flag is not supported, Eggdrop will save the ban internally but will not set it on the channel until connected to a server that supports that flag. If the flag is supported and locally matchable (ACCOUNTEXTBAN or one of UABCmNpqQT), Eggdrop will store it like a normal ban. 
+
+However, some extended bans cannot be matched by Eggdrop (for example, an extended ban that matches if a user is on a channel. If the extban is a valid flag but cannot be matched by Eggdrop, it is automatically stored as sticky. Because it cannot be matched, it will be kept set on the channel despite any dynamic-ban channel status set.
+
+If a user or server sets an extended ban directly on the channel and it contains a banmask that Eggdrop can match against, Eggdrop tracks it as a normal channel banlist entry, subject to normal channel banlist handling, including removal after ban-time when +dynamicbans is enabled (unless it corresponds to a sticky internal ban).
+
+The only extended bans that can be enforced with a kick via +enforcebans are the value of ACCOUNTEXTBAN, and U. These extended ban flags are eligible for Eggdrop’s local kick/enforcement behavior; other matchable extbans are set and tracked like bans but Eggdrop does lacks the ability to know if the user violates them and cannot kick users itself.

--- a/doc/sphinx_source/using/tcl-commands.rst
+++ b/doc/sphinx_source/using/tcl-commands.rst
@@ -2929,6 +2929,13 @@ account-extban
 
   Module: channel
 
+extban-flags
+^^^^^^^^^^^^
+  Value: a string containing the allowed extban flag characters advertised by EXTBAN in the 005 connection message. If EXTBAN advertises a prefix, such as "$,aUq", the prefix is omitted and this variable contains only the flags, such as "aUq".
+
+  Module: channel
+
+
 Binds
 -----
 

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -116,14 +116,14 @@ int extban_parse(const char *mask, char *type, const char **arg) {
   }
 
 /* If EXTBAN is unknown (e.g. before connect), retain the historical fallback
- * so stored prefixed extbans can still be parsed.
+ * so stored prefixed extbans can still be parsed. With any non-alnum prefixchar.
  */
-  if ((!value || !value[0]) && isalnum((unsigned char) mask[1]) &&
-      mask[2] == ':') {
+  if ((!value || !value[0]) && !isalnum((unsigned char) mask[0]) &&
+      isalnum((unsigned char) mask[1]) && mask[2] == ':') {
     if (type)
-      *type = mask[0];
+      *type = mask[1];
     if (arg)
-      *arg = mask + 2; /* a:x!y@z -- mask+2 = x */
+      *arg = mask + 3; /* ~a:x!y@z -- mask+2 = x */
     return 1;
   }
   return 0;
@@ -157,7 +157,7 @@ static int is_extban_mask(const char *mask)
 }
 
 /* Extban prefix from ISUPPORT EXTBAN, if present.
- * EXTBAN grammar is [prefix],<types> 
+ * EXTBAN grammar is [prefix],<types>
  */
 static void get_extban_prefix(char *prefix)
 {

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -71,25 +71,30 @@ static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
  * Supports both prefixed (<prefix><type>:<arg>) and non-prefixed (<type>:<arg>) forms.
  */
 int extban_parse(const char *mask, char *type, const char **arg) {
-  /* now we know mask is set, don't check it again later*/
+  char advertised_prefix = '\0';
   if (!mask || !mask[0] || strlen(mask) < 3)
     return 0;
 
-/* Break out no-prefix mask */
+/* Break out mask with no prefix  */
   if (isalnum((unsigned char) mask[0]) && mask[1] == ':') {
     if (type)
       *type = mask[0];
     if (arg)
-      *arg = mask + 2;
+      *arg = mask + 2; /* a:x!y@z -- mask+2 = x */
     return 1;
   }
 
-/* Break out prefix mask */
+/* Break out mask with a prefix */
   if (isalnum((unsigned char) mask[1]) && mask[2] == ':') {
+    get_extban_prefix(&advertised_prefix);
     if (type)
       *type = mask[1];
     if (arg)
-      *arg = mask + 3;
+      *arg = mask + 3; /* ~a:x!y@z -- mask+3 = x */
+    /* Prevent ee:x!y@z from sneaking through */
+    if (advertised_prefix && mask[0] != advertised_prefix) {
+      return 0;
+    }
     return 1;
   }
 

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -116,14 +116,14 @@ int extban_parse(const char *mask, char *type, const char **arg) {
   }
 
 /* If EXTBAN is unknown (e.g. before connect), retain the historical fallback
- * so stored prefixed extbans can still be parsed. With any non-alnum prefixchar.
+ * so stored prefixed extbans can still be parsediwth any non-alnum prefixchar.
  */
   if ((!value || !value[0]) && !isalnum((unsigned char) mask[0]) &&
       isalnum((unsigned char) mask[1]) && mask[2] == ':') {
     if (type)
       *type = mask[1];
     if (arg)
-      *arg = mask + 3; /* ~a:x!y@z -- mask+2 = x */
+      *arg = mask + 3; /* ~a:x!y@z -- mask+3 = x */
     return 1;
   }
   return 0;

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -121,21 +121,6 @@ int extban_parse(const char *mask, char *type, const char **arg) {
       *arg = mask + 2; /* a:x!y@z -- mask+2 = x */
     return 1;
   }
-
-/* Break out mask with a prefix */
-  if (isalnum((unsigned char) mask[1]) && mask[2] == ':') {
-    get_extban_prefix(&advertised_prefix);
-    if (type)
-      *type = mask[1];
-    if (arg)
-      *arg = mask + 3; /* ~a:x!y@z -- mask+3 = x */
-    /* Prevent ee:x!y@z from sneaking through */
-    if (advertised_prefix && mask[0] != advertised_prefix) {
-      return 0;
-    }
-    return 1;
-  }
-
   return 0;
 }
 

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -30,6 +30,7 @@
 static Function *global = NULL;
 static void get_extban_prefix(char *prefix);
 static int is_extban_mask(const char *mask);
+static int extban_is_matchable(const char *mask);
 static char chanfile[121], glob_chanmode[65];
 static char *lastdeletedmask;
 
@@ -126,6 +127,27 @@ int extban_parse(const char *mask, char *type, const char **arg) {
     return 1;
   }
   return 0;
+}
+
+/* Return 1 if the server currently advertises support for the given extban
+ * flag, either through ACCOUNTEXTBAN or the EXTBAN type list; otherwise return
+ * 0 so callers can avoid trying to set or recheck it on this server.
+ */
+int extban_flag_supported(char flag)
+{
+  const char *accountflag, *value, *comma, *types;
+
+  accountflag = servermod_isupport_get("ACCOUNTEXTBAN");
+  if (accountflag && accountflag[0] && flag == accountflag[0])
+    return 1;
+
+  value = servermod_isupport_get("EXTBAN");
+  if (!value || !value[0])
+    return 0;
+
+  comma = strchr(value, ',');
+  types = comma ? comma + 1 : value;
+  return strchr(types, flag) ? 1 : 0;
 }
 
 /* Return 1 if mask uses extban syntax. */
@@ -1108,6 +1130,7 @@ static Function channels_table[] = {
   /* 48 - 51 */
   (Function) & global_invite_time,
   (Function) extban_parse,
+  (Function) extban_flag_supported
 };
 
 char *channels_start(Function *global_funcs)

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -69,6 +69,10 @@ static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
 
 /* Parse extban mask into type and arg pointers.
  * Supports both prefixed (<prefix><type>:<arg>) and non-prefixed (<type>:<arg>) forms.
+ * Returns a 1 if mask is an extban mask, 0 otherwise
+ * If 1 is returned:
+ *   type is filled with the extban character
+ *   arg points to the extban value
  */
 int extban_parse(const char *mask, char *type, const char **arg) {
   const char *value, *comma;

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -71,12 +71,50 @@ static int gfld_chan_thr, gfld_chan_time, gfld_deop_thr, gfld_deop_time,
  * Supports both prefixed (<prefix><type>:<arg>) and non-prefixed (<type>:<arg>) forms.
  */
 int extban_parse(const char *mask, char *type, const char **arg) {
-  char advertised_prefix = '\0';
+  const char *value, *comma;
+  char prefix = 0;
+
+  /* now we know mask is set, don't check it again later*/
   if (!mask || !mask[0] || strlen(mask) < 3)
     return 0;
 
-/* Break out mask with no prefix  */
+  value = servermod_isupport_get("EXTBAN");
+  if (value && value[0]) {
+    comma = strchr(value, ',');
+    if (comma && comma - value == 1)
+      prefix = value[0];
+  }
+
+  /* Break out prefixed masks first when the server advertised a prefix. */
+  if (prefix && mask[0] == prefix && isalnum((unsigned char) mask[1]) &&
+      mask[2] == ':') {
+    if (type) {
+      *type = mask[1];
+    }
+    if (arg) {
+      *arg = mask + 3;
+    }
+    return 1;
+  }
+
+  /* Break out no-prefix mask. If EXTBAN is known and did not advertise a
+   * prefix, this is the only accepted form.
+   */
   if (isalnum((unsigned char) mask[0]) && mask[1] == ':') {
+    if (type) {
+      *type = mask[0];
+    }
+    if (arg) {
+      *arg = mask + 2;
+    }
+    return 1;
+  }
+
+/* If EXTBAN is unknown (e.g. before connect), retain the historical fallback
+ * so stored prefixed extbans can still be parsed.
+ */
+  if ((!value || !value[0]) && isalnum((unsigned char) mask[1]) &&
+      mask[2] == ':') {
     if (type)
       *type = mask[0];
     if (arg)
@@ -902,6 +940,27 @@ static char *traced_account_extban(ClientData cdata, Tcl_Interp *irp,
   return NULL;
 }
 
+static char *traced_extban_flags(ClientData cdata, Tcl_Interp *irp,
+                                  EGG_CONST char *name1,
+                                  EGG_CONST char *name2, int flags)
+{
+  const char *extban = servermod_isupport_get("EXTBAN");
+  const char *comma, *extban_flags = "";
+
+  if (extban && extban[0]) {
+    comma = strchr(extban, ',');
+    extban_flags = comma ? comma + 1 : extban;
+  }
+
+  Tcl_SetVar2(interp, name1, name2, extban_flags, TCL_GLOBAL_ONLY);
+  if (flags & TCL_TRACE_UNSETS) {
+    Tcl_TraceVar(interp, "extban-flags",
+                 TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
+                 traced_extban_flags, NULL);
+  }
+  return NULL;
+}
+
 static tcl_ints my_tcl_ints[] = {
   {"use-info",                 &use_info,                0},
   {"quiet-save",               &quiet_save,              0},
@@ -983,7 +1042,11 @@ static char *channels_close()
   Tcl_UntraceVar(interp, "account-extban",
                  TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                  traced_account_extban, NULL);
+  Tcl_UntraceVar(interp, "extban-flags",
+                 TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
+                 traced_extban_flags, NULL);
   traced_account_extban(NULL, interp, "account-extban", NULL, TCL_TRACE_READS);
+  traced_extban_flags(NULL, interp, "extban-flags", NULL, TCL_TRACE_READS);
   rem_help_reference("channels.help");
   rem_help_reference("chaninfo.help");
   module_undepend(MODULE_NAME);
@@ -1139,6 +1202,10 @@ char *channels_start(Function *global_funcs)
   Tcl_TraceVar(interp, "account-extban",
                TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
                traced_account_extban, NULL);
+  Tcl_TraceVar(interp, "extban-flags",
+               TCL_TRACE_READS | TCL_TRACE_WRITES | TCL_TRACE_UNSETS,
+               traced_extban_flags, NULL);
+  H_chanset = add_bind_table("chanset", HT_STACKABLE, builtin_chanset);
   H_chanset = add_bind_table("chanset", HT_STACKABLE, builtin_chanset);
   add_builtins(H_chon, my_chon);
   add_builtins(H_dcc, C_dcc_irc);

--- a/src/mod/channels.mod/channels.h
+++ b/src/mod/channels.mod/channels.h
@@ -129,6 +129,7 @@ static void remove_channel(struct chanset_t *);
 static intptr_t ngetudef(char *, char *);
 static int expired_mask(struct chanset_t *chan, char *who);
 static int check_tcl_chanset(const char *, const char *, const char *);
+static int extban_flag_supported(char flag);
 
 
 #else

--- a/src/mod/channels.mod/channels.h
+++ b/src/mod/channels.mod/channels.h
@@ -31,6 +31,16 @@
 #define MASKREASON_MAX 307    /* Max length of ban/invite/exempt/etc reasons. */
 #define MASKREASON_LEN (MASKREASON_MAX + 1)
 
+/* Extban flags Eggdrop can enforce by kicking matching users.
+ * ACCOUNTEXTBAN is also enforceable and is checked dynamically.
+ */
+#define ENFORCEABLE_EXTBANS "U"
+
+/* Extban flags Eggdrop can match against nick!user@host masks for
+ * dynamic ban placement/removal without enforcing kicks.
+ */
+#define MATCHABLE_EXTBANS "UABCmNpqQT"
+
 /* Flags for reset_chan_info() */
 #define CHAN_RESETMODES   0x01
 #define CHAN_RESETWHO     0x02

--- a/src/mod/channels.mod/channels.h
+++ b/src/mod/channels.mod/channels.h
@@ -191,6 +191,7 @@ static int check_tcl_chanset(const char *, const char *, const char *);
 /* 48 - 51 */
 #define global_invite_time (*(int *)(channels_funcs[48]))
 #define extban_parse ((int (*)(const char *, char *, const char **))channels_funcs[49])
+#define extban_flag_supported ((int (*)(char))channels_funcs[50])
 
 #endif /* MAKING_CHANNELS */
 

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -158,6 +158,10 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
       strlcpy(s, who, sizeof s);
       /* If its an extban, check if it needs to be set as a sticky ban */
       if (extban_parse(s, &extbanflag, NULL)) {
+        if (!isalnum((unsigned char) s[0]) && isalnum((unsigned char) s[1]) &&
+            s[2] == ':') {
+          extbanflag = s[1];
+        }
         extban_enabled = extban_flag_supported(extbanflag);
       }
     } else {

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -142,8 +142,12 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
       /* If its an extban, check if it is supported by the server */
       if (extban_parse(s, &extbanflag, NULL)) {
         extban_enabled = extban_flag_supported(extbanflag);
-        if (!extban_is_matchable(s))
+        if (!extban_is_matchable(s) && par[0] != '*') {
+          dprintf(idx, "Extban type '%c' cannot be matched by Eggdrop"
+                       ", so it is forced to be sticky.\n", extbanflag);
           sticky = 1;
+
+        }
       }
     } else {
       /* Fix missing ! or @ BEFORE checking against myself */

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -38,6 +38,23 @@ static int is_extban_flag_advertised(char flag)
 }
 */
 
+static int extban_flag_supported(char flag)
+{
+  const char *accountflag, *value, *comma, *types;
+
+  accountflag = servermod_isupport_get("ACCOUNTEXTBAN");
+  if (accountflag && accountflag[0] && flag == accountflag[0])
+    return 1;
+
+  value = servermod_isupport_get("EXTBAN");
+  if (!value || !value[0])
+    return 0;
+
+  comma = strchr(value, ',');
+  types = comma ? comma + 1 : value;
+  return strchr(types, flag) ? 1 : 0;
+}
+
 /* RFC 1035/2812- hostmasks can't be longer than 63 characters */
 static void truncate_mask_hostname(char *s) {
   char *r = NULL;
@@ -57,7 +74,6 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
   char *chname, *who, s[UHOSTLEN], s1[UHOSTLEN], *p, *p_expire;
   char extbanflag = 0;
   int extban_enabled = 1;
-  const char *value, *comma, *types;
   long expire_foo;
   unsigned long expire_time = 0;
   int sticky = 0;
@@ -142,14 +158,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
       strlcpy(s, who, sizeof s);
       /* If its an extban, check if it needs to be set as a sticky ban */
       if (extban_parse(s, &extbanflag, NULL)) {
-        value = servermod_isupport_get("EXTBAN");
-        if (value && value[0]) {
-          comma = strchr(value, ',');
-          types = comma ? comma + 1 : value;
-          extban_enabled = strchr(types, extbanflag) ? 1 : 0;
-        } else {
-          extban_enabled = 0;
-        }
+        extban_enabled = extban_flag_supported(extbanflag);
       }
     } else {
       /* Fix missing ! or @ BEFORE checking against myself */
@@ -194,7 +203,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
         if (!extbanflag || extban_enabled)
           (me->funcs[IRC_CHECK_THIS_BAN]) (chan, s, sticky);
         else
-          dprintf(idx, "%s%c%s%c%s", EXTBAN_NOT_ENABLED1, extbanflag, EXTBAN_NOT_ENABLED2,
+          dprintf(idx, "%s%c%s%c%s\n", EXTBAN_NOT_ENABLED1, extbanflag, EXTBAN_NOT_ENABLED2,
                                     extbanflag, EXTBAN_NOT_ENABLED3);
       }
     } else {

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -141,10 +141,6 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
       strlcpy(s, who, sizeof s);
       /* If its an extban, check if it is supported by the server */
       if (extban_parse(s, &extbanflag, NULL)) {
-        if (!isalnum((unsigned char) s[0]) && isalnum((unsigned char) s[1]) &&
-            s[2] == ':') {
-          extbanflag = s[1];
-        }
         extban_enabled = extban_flag_supported(extbanflag);
         if (!extban_is_matchable(s))
           sticky = 1;
@@ -1626,7 +1622,7 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
           if (tcl_channel_modify(0, chan, 1, list) == TCL_OK) {
             strlcpy(value, list[0], 2);
             len = strlen(answers);
-            egg_snprintf(answers + len, (sizeof answers) - len, 
+            egg_snprintf(answers + len, (sizeof answers) - len,
                 (len == 0) ? "%s" : " %s", list[0]);        /* Concatenation */
           } else if (!all || !chan->next)
             dprintf(idx, "Error trying to set %s for %s, invalid mode.\n",

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -38,23 +38,6 @@ static int is_extban_flag_advertised(char flag)
 }
 */
 
-static int extban_flag_supported(char flag)
-{
-  const char *accountflag, *value, *comma, *types;
-
-  accountflag = servermod_isupport_get("ACCOUNTEXTBAN");
-  if (accountflag && accountflag[0] && flag == accountflag[0])
-    return 1;
-
-  value = servermod_isupport_get("EXTBAN");
-  if (!value || !value[0])
-    return 0;
-
-  comma = strchr(value, ',');
-  types = comma ? comma + 1 : value;
-  return strchr(types, flag) ? 1 : 0;
-}
-
 /* RFC 1035/2812- hostmasks can't be longer than 63 characters */
 static void truncate_mask_hostname(char *s) {
   char *r = NULL;
@@ -156,13 +139,15 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
       who[UHOSTMAX - 4] = 0;
     if (is_extban_mask(who)) {
       strlcpy(s, who, sizeof s);
-      /* If its an extban, check if it needs to be set as a sticky ban */
+      /* If its an extban, check if it is supported by the server */
       if (extban_parse(s, &extbanflag, NULL)) {
         if (!isalnum((unsigned char) s[0]) && isalnum((unsigned char) s[1]) &&
             s[2] == ':') {
           extbanflag = s[1];
         }
         extban_enabled = extban_flag_supported(extbanflag);
+        if (!extban_is_matchable(s))
+          sticky = 1;
       }
     } else {
       /* Fix missing ! or @ BEFORE checking against myself */
@@ -229,7 +214,7 @@ static void cmd_pls_ban(struct userrec *u, int idx, char *par)
           for (chan = chanset; chan != NULL; chan = chan->next)
             (me->funcs[IRC_CHECK_THIS_BAN]) (chan, s, sticky);
         } else
-          dprintf(idx, "%s%c%s%c%s", EXTBAN_NOT_ENABLED1, extbanflag, EXTBAN_NOT_ENABLED2,
+          dprintf(idx, "%s%c%s%c%s\n", EXTBAN_NOT_ENABLED1, extbanflag, EXTBAN_NOT_ENABLED2,
                                     extbanflag, EXTBAN_NOT_ENABLED3);
       }
     }

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -241,30 +241,24 @@ static int u_match_mask(maskrec *rec, char *mask)
     }
   }
 
-  /* Loop through all ban records, see if user matches based on mask or
-   * flag (extban).
-   */
   accountflag = servermod_isupport_get("ACCOUNTEXTBAN");
+
   for (; rec; rec = rec->next) {
-    /* Am I an extban? */
     if (extban_parse(rec->mask, &type, &arg)) {
-      if (!m || !m->nick[0] || !m->account[0]) {
+      if (!m || !m->nick[0] || !m->account[0])
         continue;
-      }
       if (accountflag && (type == accountflag[0])) {
-        if (!rfc_casecmp(m->account, arg)) {
+        if (!rfc_casecmp(m->account, arg))
           return 1;
-        }
       } else if (type == 'U') {
-        if (!strcmp(m->account, "*") && match_addr((char *) arg, mask)) {
+        if (!strcmp(m->account, "*") && match_addr((char *) arg, mask))
           return 1;
-        }
       }
       continue;
     }
-
-    if (match_addr(rec->mask, mask))
+    if (match_addr(rec->mask, mask)) {
       return 1;
+    }
   }
   return 0;
 }

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -450,6 +450,7 @@ static void fix_broken_mask(char *newmask, const char *oldmask, size_t len)
   }
 }
 
+/* Takes mask in the full $a:mask format */
 static int extban_is_matchable(const char *mask)
 {
   char extflag;

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -245,7 +245,6 @@ static int u_match_mask(maskrec *rec, char *mask)
 
   for (; rec; rec = rec->next) {
     if (extban_parse(rec->mask, &type, &arg)) {
-<<<<<<< HEAD
       if (!m || !m->nick[0] || !m->account[0])
         continue;
       if (accountflag && (type == accountflag[0])) {

--- a/src/mod/channels.mod/userchan.c
+++ b/src/mod/channels.mod/userchan.c
@@ -245,6 +245,7 @@ static int u_match_mask(maskrec *rec, char *mask)
 
   for (; rec; rec = rec->next) {
     if (extban_parse(rec->mask, &type, &arg)) {
+<<<<<<< HEAD
       if (!m || !m->nick[0] || !m->account[0])
         continue;
       if (accountflag && (type == accountflag[0])) {
@@ -450,6 +451,21 @@ static void fix_broken_mask(char *newmask, const char *oldmask, size_t len)
   }
 }
 
+static int extban_is_matchable(const char *mask)
+{
+  char extflag;
+  const char *extarg, *acc;
+
+  if (!extban_parse(mask, &extflag, &extarg))
+    return 0;
+
+  acc = servermod_isupport_get("ACCOUNTEXTBAN");
+  if (acc && acc[0] && extflag == acc[0])
+    return 1;
+
+  return strchr(MATCHABLE_EXTBANS, extflag) ? 1 : 0;
+}
+
 /* Note: If first char of note is '*' it's a sticky ban.
  */
 static int u_addban(struct chanset_t *chan, char *ban, char *from, char *note,
@@ -461,6 +477,8 @@ static int u_addban(struct chanset_t *chan, char *ban, char *from, char *note,
 
   if (is_extban_mask(ban)) {
     strlcpy(host, ban, sizeof host);
+    if (!extban_is_matchable(host))
+      flags |= MASKREC_STICKY;
   } else {
     /* Choke check: fix broken bans (must have '!' and '@') */
     fix_broken_mask(host, ban, sizeof host);

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -94,25 +94,6 @@ static void update_idle(char *chname, char *nick)
   }
 }
 
-static int extban_is_matchable(const char *mask)
-{
-  char extflag;
-  const char *extarg, *acc;
-
-  if (!extban_parse(mask, &extflag, &extarg))
-    return 0;
-  acc = isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
-  if (acc && acc[0] && extflag == acc[0]) {
-    return 1;
-  }
-  return strchr(MATCHABLE_EXTBANS, extflag) ? 1 : 0;
-}
-
-static int extban_is_unmatchable(const char *mask)
-{
-  return extban_parse(mask, NULL, NULL) && !extban_is_matchable(mask);
-}
-
 /* Document whether a ban matches a specific channel member.
  * banmask can be normal or extban, user is the traditional userhost.
  * Returns 1 if the ban mask matches the member, 0 if not.
@@ -677,8 +658,7 @@ static void recheck_bans(struct chanset_t *chan)
       if (extban_parse(u->mask, &extflag, &extarg) && !extban_flag_supported(extflag)) {
         continue;
       }
-      if (!isbanned(chan, u->mask) && (!channel_dynamicbans(chan) ||
-          (u->flags & MASKREC_STICKY) || extban_is_unmatchable(u->mask))) {
+      if (!isbanned(chan, u->mask) && (!channel_dynamicbans(chan) || (u->flags & MASKREC_STICKY))) {
         add_mode(chan, '+', 'b', u->mask);
       }
     }
@@ -792,8 +772,7 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
       refresh_ban_kick(chan, user, m->nick);
     }
   }
-  if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky ||
-      extban_is_unmatchable(banmask))) {
+  if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky)) {
     add_mode(chan, '+', 'b', banmask);
   }
 }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -97,14 +97,20 @@ static void update_idle(char *chname, char *nick)
 static int extban_flag_supported(char flag)
 {
   module_entry *me;
-  const char *value = NULL, *comma, *types;
+  const char *accountflag = NULL, *value = NULL, *comma, *types;
 
   me = module_find("server", 0, 0);
   if (me && me->funcs && me->funcs[SERVER_GET_ISUPPORT]) {
+    accountflag = (const char *)isupport_get("ACCOUNTEXTBAN",
+        strlen("ACCOUNTEXTBAN"));
     value = (const char *)isupport_get("EXTBAN", strlen("EXTBAN"));
   }
-  if (!value || !value[0])
+  if (accountflag && accountflag[0] && flag == accountflag[0]) {
+    return 1;
+  }
+  if (!value || !value[0]) {
     return 0;
+  }
 
   comma = strchr(value, ',');
   types = comma ? comma + 1 : value;
@@ -114,22 +120,23 @@ static int extban_flag_supported(char flag)
   return 0;
 }
 
-static int extban_requires_server_matching(const char *mask)
+static int extban_is_matchable(const char *mask)
 {
   char extflag;
   const char *extarg, *acc;
 
   if (!extban_parse(mask, &extflag, &extarg))
     return 0;
-
-  if (extflag == 'U')
-    return 0;
-
   acc = isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
-  if (acc && acc[0] && extflag == acc[0])
-    return 0;
+  if (acc && acc[0] && extflag == acc[0]) {
+    return 1;
+  }
+  return strchr(MATCHABLE_EXTBANS, extflag) ? 1 : 0;
+}
 
-  return 1;
+static int extban_is_unmatchable(const char *mask)
+{
+  return extban_parse(mask, NULL, NULL) && !extban_is_matchable(mask);
 }
 
 /* Document whether a ban matches a specific channel member.
@@ -149,16 +156,41 @@ static int banmask_matches_member(const char *banmask, const char *user, memberl
   if (me && me->funcs && me->funcs[SERVER_GET_ISUPPORT]) {
     v = (const char *)isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
   }
-
-  if (v && v[0] && type == v[0])
-    return !rfc_casecmp(m->account, arg);
-
-  if (type == 'U')
-    return !strcmp(m->account, "*") && match_addr((char *) arg, (char *) user);
-
+  /* Try account extban matching */
+  if (v && v[0] && type == v[0]) {
+    return m->account[0] && !rfc_casecmp(m->account, arg);
+  }
+  /* Locally matchable extbans match their argument as a usermask. */
+  if (strchr(MATCHABLE_EXTBANS, type)) {
+    return match_addr((char *) arg, (char *) user);
+  }
   return 0;
 }
 
+static int banmask_enforces_member(const char *banmask, const char *user, memberlist *m)
+{
+  module_entry *me;
+  char type;
+  const char *v = NULL, *arg = NULL;
+
+  if (!extban_parse(banmask, &type, &arg)) {
+    return match_addr((char *) banmask, (char *) user);
+  }
+
+  me = module_find("server", 0, 0);
+  if (me && me->funcs && me->funcs[SERVER_GET_ISUPPORT]) {
+    v = (const char *)isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
+  }
+  if (v && v[0] && type == v[0]) {
+    return m->account[0] && !rfc_casecmp(m->account, arg);
+  }
+
+  if (strchr(ENFORCEABLE_EXTBANS, type)) {
+    return match_addr((char *) arg, (char *) user);
+  }
+
+  return 0;
+}
 
 static int banmask_list_matches_member(maskrec *list, const char *user, memberlist *m)
 {
@@ -517,7 +549,7 @@ static void kick_all(struct chanset_t *chan, char *hostmask, char *comment,
     sprintf(s, "%s!%s", m->nick, m->userhost);
     get_user_flagrec(get_user_from_member(m), &fr, chan->dname);
     if ((me_op(chan) || (me_halfop(chan) && !chan_hasop(m))) &&
-        banmask_matches_member(hostmask, s, m) && !chan_sentkick(m) &&
+        banmask_enforces_member(hostmask, s, m) && !chan_sentkick(m) &&
         !match_my_nick(m->nick) && !chan_issplit(m) &&
         !glob_friend(fr) && !chan_friend(fr) && !(use_exempts && ((bantype &&
         isexempted(chan, s)) || (u_match_mask(global_exempts, s) ||
@@ -563,6 +595,11 @@ static void refresh_ban_kick(struct chanset_t *chan, char *user, char *nick)
       if (banmask_matches_member(b->mask, user, m)) {
         struct flag_record fr = { FR_GLOBAL | FR_CHAN, 0, 0, 0, 0, 0 };
         char c[512];            /* The ban comment.     */
+        if (!banmask_enforces_member(b->mask, user, m)) {
+          do_mask(chan, chan->channel.ban, b->mask, 'b');
+          b->lastactive = now;
+          return;
+        }
         get_user_flagrec(get_user_from_member(m), &fr,
                          chan->dname);
         if (!glob_friend(fr) && !chan_friend(fr)) {
@@ -667,8 +704,7 @@ static void recheck_bans(struct chanset_t *chan)
         continue;
       }
       if (!isbanned(chan, u->mask) && (!channel_dynamicbans(chan) ||
-          (u->flags & MASKREC_STICKY) ||
-          extban_requires_server_matching(u->mask))) {
+          (u->flags & MASKREC_STICKY) || extban_is_unmatchable(u->mask)))
         add_mode(chan, '+', 'b', u->mask);
       }
     }
@@ -783,7 +819,7 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
     }
   }
   if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky ||
-      extban_requires_server_matching(banmask))) {
+      extban_is_unmatchable(banmask)))
     add_mode(chan, '+', 'b', banmask);
   }
 }
@@ -2273,7 +2309,7 @@ static int gotjoin(char *from, char *channame)
               (!use_exempts || !isexempted(chan, from)) && (me_op(chan) ||
               (me_halfop(chan) && !chan_hasop(m)))) {
             for (b = chan->channel.ban; b->mask[0]; b = b->next) {
-              if (banmask_matches_member(b->mask, from, m)) {
+              if (banmask_enforces_member(b->mask, from, m)) {
                 dprintf(DP_SERVER, "KICK %s %s :%s\n", chname, m->nick,
                         IRC_YOUREBANNED);
                 m->flags |= SENTKICK;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -772,6 +772,10 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
       refresh_ban_kick(chan, user, m->nick);
     }
   }
+  /* extbans overwrite sticky when not matchable, update local variable */
+  if (!sticky && (u_sticky_mask(chan->bans, banmask) || u_sticky_mask(global_bans, banmask))) {
+    sticky = 1;
+  }
   if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky)) {
     add_mode(chan, '+', 'b', banmask);
   }

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -94,32 +94,6 @@ static void update_idle(char *chname, char *nick)
   }
 }
 
-static int extban_flag_supported(char flag)
-{
-  module_entry *me;
-  const char *accountflag = NULL, *value = NULL, *comma, *types;
-
-  me = module_find("server", 0, 0);
-  if (me && me->funcs && me->funcs[SERVER_GET_ISUPPORT]) {
-    accountflag = (const char *)isupport_get("ACCOUNTEXTBAN",
-        strlen("ACCOUNTEXTBAN"));
-    value = (const char *)isupport_get("EXTBAN", strlen("EXTBAN"));
-  }
-  if (accountflag && accountflag[0] && flag == accountflag[0]) {
-    return 1;
-  }
-  if (!value || !value[0]) {
-    return 0;
-  }
-
-  comma = strchr(value, ',');
-  types = comma ? comma + 1 : value;
-  for (; *types; types++)
-    if (*types == flag)
-      return 1;
-  return 0;
-}
-
 static int extban_is_matchable(const char *mask)
 {
   char extflag;

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -114,21 +114,21 @@ static int extban_flag_supported(char flag)
   return 0;
 }
 
-/* True if mask is an extban whose flag eggdrop cannot enforce by kicking.
- * Decided at runtime from current ISUPPORT - never persisted to the userfile.
- */
-static int extban_is_unenforceable(const char *mask)
+static int extban_requires_server_matching(const char *mask)
 {
   char extflag;
   const char *extarg, *acc;
 
   if (!extban_parse(mask, &extflag, &extarg))
     return 0;
+
   if (extflag == 'U')
     return 0;
+
   acc = isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
   if (acc && acc[0] && extflag == acc[0])
     return 0;
+
   return 1;
 }
 
@@ -142,24 +142,20 @@ static int banmask_matches_member(const char *banmask, const char *user, memberl
   char type;
   const char *v = NULL, *arg = NULL;
 
-  /* Am I an extban? */
-  if (!extban_parse(banmask, &type, &arg)) {
+  if (!extban_parse(banmask, &type, &arg))
     return match_addr((char *) banmask, (char *) user);
-  }
 
   me = module_find("server", 0, 0);
   if (me && me->funcs && me->funcs[SERVER_GET_ISUPPORT]) {
     v = (const char *)isupport_get("ACCOUNTEXTBAN", strlen("ACCOUNTEXTBAN"));
   }
-  /* Try account extban matching */
-  if (v && v[0] && type == v[0]) {
-    return !rfc_casecmp(m->account, arg);
-  }
 
-  /* Try U (unregistered) extban matching */
-  if (type == 'U') {
+  if (v && v[0] && type == v[0])
+    return !rfc_casecmp(m->account, arg);
+
+  if (type == 'U')
     return !strcmp(m->account, "*") && match_addr((char *) arg, (char *) user);
-  }
+
   return 0;
 }
 
@@ -667,11 +663,14 @@ static void recheck_bans(struct chanset_t *chan)
       char extflag;
       const char *extarg;
 
-      if (extban_parse(u->mask, &extflag, &extarg) && !extban_flag_supported(extflag))
+      if (extban_parse(u->mask, &extflag, &extarg) && !extban_flag_supported(extflag)) {
         continue;
+      }
       if (!isbanned(chan, u->mask) && (!channel_dynamicbans(chan) ||
-          (u->flags & MASKREC_STICKY) || extban_is_unenforceable(u->mask)))
+          (u->flags & MASKREC_STICKY) ||
+          extban_requires_server_matching(u->mask))) {
         add_mode(chan, '+', 'b', u->mask);
+      }
     }
   }
 }
@@ -766,23 +765,27 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
   char user[NICKMAX+UHOSTLEN+1], extflag;
   const char *extarg;
 
-  if (HALFOP_CANTDOMODE('b'))
+  if (HALFOP_CANTDOMODE('b')) {
     return;
+  }
 
-  if (extban_parse(banmask, &extflag, &extarg) && !extban_flag_supported(extflag))
+  if (extban_parse(banmask, &extflag, &extarg) && !extban_flag_supported(extflag)) {
     return;
+  }
 
   for (m = chan->channel.member; m && m->nick[0]; m = m->next) {
     sprintf(user, "%s!%s", m->nick, m->userhost);
     if (banmask_matches_member(banmask, user, m) &&
         !(use_exempts &&
           (u_match_mask(global_exempts, user) ||
-           u_match_mask(chan->exempts, user))))
+           u_match_mask(chan->exempts, user)))) {
       refresh_ban_kick(chan, user, m->nick);
+    }
   }
   if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky ||
-      extban_is_unenforceable(banmask)))
+      extban_requires_server_matching(banmask))) {
     add_mode(chan, '+', 'b', banmask);
+  }
 }
 
 static void recheck_channel_modes(struct chanset_t *chan)

--- a/src/mod/irc.mod/chan.c
+++ b/src/mod/irc.mod/chan.c
@@ -704,7 +704,7 @@ static void recheck_bans(struct chanset_t *chan)
         continue;
       }
       if (!isbanned(chan, u->mask) && (!channel_dynamicbans(chan) ||
-          (u->flags & MASKREC_STICKY) || extban_is_unmatchable(u->mask)))
+          (u->flags & MASKREC_STICKY) || extban_is_unmatchable(u->mask))) {
         add_mode(chan, '+', 'b', u->mask);
       }
     }
@@ -819,7 +819,7 @@ static void check_this_ban(struct chanset_t *chan, char *banmask, int sticky)
     }
   }
   if (!isbanned(chan, banmask) && (!channel_dynamicbans(chan) || sticky ||
-      extban_is_unmatchable(banmask)))
+      extban_is_unmatchable(banmask))) {
     add_mode(chan, '+', 'b', banmask);
   }
 }

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -624,7 +624,6 @@ static void check_expired_chanstuff()
             if (now - b->timer > 60 * chan->ban_time &&
                 !u_sticky_mask(chan->bans, b->mask) &&
                 !u_sticky_mask(global_bans, b->mask) &&
-                !extban_is_unenforceable(b->mask) &&
                 expired_mask(chan, b->who)) {
               putlog(LOG_MODES, chan->dname,
                      "(%s) Channel ban on %s expired.", chan->dname, b->mask);

--- a/src/mod/irc.mod/irc.c
+++ b/src/mod/irc.mod/irc.c
@@ -703,12 +703,13 @@ static void check_expired_chanstuff()
     } else if (!channel_inactive(chan) && !channel_pending(chan)) {
 
       key = chan->channel.key[0] ? chan->channel.key : chan->key_prot;
-      if (key[0])
+      if (key[0]) {
         dprintf(DP_SERVER, "JOIN %s %s\n",
                 chan->name[0] ? chan->name : chan->dname, key);
-      else
+      } else {
         dprintf(DP_SERVER, "JOIN %s\n",
                 chan->name[0] ? chan->name : chan->dname);
+      }
     }
   }
 }

--- a/tests/tests/test_extban.py
+++ b/tests/tests/test_extban.py
@@ -578,3 +578,87 @@ def test_partyline_pls_ban_extban_works_without_server_mod(
     # Nothing stored from the +extban attempt.
     assert bridge.eval_ok("isban a:foo") == "0"
     assert bridge.eval_ok("isban ~a:foo") == "0"
+
+# ---------- dynamic ban-time expiry for channel banlist masks ----------
+
+
+@pytest.mark.timeout(90)
+def test_dynamic_ban_time_expiry_removes_normal_and_extban_channel_modes(
+    eggdrop_config,
+    mock_ircd: MockIrcd,
+    request: pytest.FixtureRequest,
+) -> None:
+    """`+dynamicbans` expires normal and extended channel ban modes alike.
+
+    This drives server-side +b modes rather than internal userfile bans so the
+    assertions cover the channel banlist cleanup path in irc.mod. `ban-time` is
+    set negative to make the masks eligible on the next minutely hook without a
+    multi-minute sleep; the dynamicbans gate is still the real one.
+    """
+    eggdrop_config.render(
+        channels=[
+            {"name": "#dyn", "chanmode": "+nt"},
+            {"name": "#static", "chanmode": "+nt"},
+        ]
+    )
+    request.getfixturevalue("eggdrop_proc")
+    tcl_bridge: BridgeClient = request.getfixturevalue("tcl_bridge")
+
+    drive_registration(
+        mock_ircd,
+        isupport_tokens=["EXTBAN=$,aUq", "ACCOUNTEXTBAN=a"],
+    )
+    dyn_chan = drive_join_with_names(mock_ircd, "@TestBot")
+    static_chan = drive_join_with_names(mock_ircd, "@TestBot")
+    assert dyn_chan == "#dyn"
+    assert static_chan == "#static"
+
+    tcl_bridge.eval_ok(f'channel set "{dyn_chan}" +dynamicbans ban-time -1')
+    tcl_bridge.eval_ok(f'channel set "{static_chan}" -dynamicbans ban-time -1')
+    assert tcl_bridge.eval_ok(f'channel get "{dyn_chan}" dynamicbans') == "1"
+    assert tcl_bridge.eval_ok(f'channel get "{static_chan}" dynamicbans') == "0"
+
+    dynamic_masks = ["*!*@dynamic.example", "$a:geo"]
+    static_masks = ["*!*@static.example", "$a:staticgeo"]
+
+    for mask in dynamic_masks:
+        mock_ircd.send(f":Oper!oper@mock MODE {dyn_chan} +b {mask}")
+    for mask in static_masks:
+        mock_ircd.send(f":Oper!oper@mock MODE {static_chan} +b {mask}")
+
+    for mask in dynamic_masks:
+        wait_for(
+            lambda mask=mask: tcl_bridge.eval_ok(
+                f'ischanban "{dyn_chan}" "{mask}"'
+            ) == "1",
+            timeout=5.0,
+            description=f"{mask} to appear on {dyn_chan}",
+        )
+    for mask in static_masks:
+        wait_for(
+            lambda mask=mask: tcl_bridge.eval_ok(
+                f'ischanban "{static_chan}" "{mask}"'
+            ) == "1",
+            timeout=5.0,
+            description=f"{mask} to appear on {static_chan}",
+        )
+
+    removed_dynamic: set[str] = set()
+
+    def saw_dynamic_removal(line: str) -> bool:
+        if line.startswith(f"MODE {dyn_chan} ") and "-b" in line:
+            for mask in dynamic_masks:
+                if mask in line:
+                    removed_dynamic.add(mask)
+        return len(removed_dynamic) == len(dynamic_masks)
+
+    mock_ircd.drain_until(saw_dynamic_removal, timeout=70.0)
+    assert removed_dynamic == set(dynamic_masks)
+
+    with pytest.raises(MockIrcdError):
+        mock_ircd.drain_until(
+            lambda line: line.startswith(f"MODE {static_chan} ")
+            and "-b" in line
+            and any(mask in line for mask in static_masks),
+            timeout=2.0,
+        )


### PR DESCRIPTION
Found by: Robby
Patch by: Geo
Fixes: #1914 

One-line summary:
Have extbans follow normal ban expiration

Additional description (if needed):
The original intent, as included in the documentation ;) , was to only expire extbans that eggdrop itself could take some action on (ie, removing a user from the channel due to a matching hostmask). Because there are many conflicting extban modes and no clear intent for ircds to add flags similar to ACCOUNTEXTBAN, discussion moved to treating extbans just like normal bans, and respecting the dynamicban channel setting. If a user wants an extban to be set that is not removed even though dynamicbans is set, then it needs to have the sticky flag added to it so that it is not removed.
