### PR TITLE
Cleanup: misc/killwhitespace

### DIFF
--- a/src/language.c
+++ b/src/language.c
@@ -251,7 +251,7 @@ static void read_lang(char *langfile)
       }
       if ((ctmp = strchr(lbuf, ',')))
         strcpy(ltext, ctmp + 1);
-      else 
+      else
         putlog(LOG_MISC, "*", "LANG: Malformed text line (missing ,) in %s at %d.",
                langfile, lline);
     } else {

--- a/src/mod/channels.mod/channels.c
+++ b/src/mod/channels.mod/channels.c
@@ -103,7 +103,7 @@ static int is_extban_mask(const char *mask)
 }
 
 /* Extban prefix from ISUPPORT EXTBAN, if present.
- * EXTBAN grammar is [prefix],<types> 
+ * EXTBAN grammar is [prefix],<types>
  */
 static void get_extban_prefix(char *prefix)
 {

--- a/src/mod/channels.mod/cmdschan.c
+++ b/src/mod/channels.mod/cmdschan.c
@@ -1628,7 +1628,7 @@ static void cmd_chanset(struct userrec *u, int idx, char *par)
           if (tcl_channel_modify(0, chan, 1, list) == TCL_OK) {
             strlcpy(value, list[0], 2);
             len = strlen(answers);
-            egg_snprintf(answers + len, (sizeof answers) - len, 
+            egg_snprintf(answers + len, (sizeof answers) - len,
                 (len == 0) ? "%s" : " %s", list[0]);        /* Concatenation */
           } else if (!all || !chan->next)
             dprintf(idx, "Error trying to set %s for %s, invalid mode.\n",


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Run misc/killwhitespace every once in a while.

Additional description (if needed):


Test cases demonstrating functionality (if applicable):
No functional change