### PR TITLE
Fix victim lookup after op mode binds

### DIFF
--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -682,7 +682,7 @@ static void got_dehalfop(struct chanset_t *chan, char *nick, char *from,
 {
   memberlist *m;
   char ch[sizeof chan->name];
-  char s[UHOSTLEN], s1[UHOSTLEN];
+  char s[UHOSTLEN];
   struct userrec *u;
   int had_halfop;
 
@@ -697,7 +697,7 @@ static void got_dehalfop(struct chanset_t *chan, char *nick, char *from,
   }
 
   strcpy(ch, chan->name);
-  simple_sprintf(s1, "%s!%s", nick, from);
+  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   u = get_user_from_member(m);
   get_user_flagrec(u, &victim, chan->dname);
 

--- a/src/mod/irc.mod/mode.c
+++ b/src/mod/irc.mod/mode.c
@@ -421,6 +421,7 @@ static void got_op(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
+  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   u = get_user_from_member(m);
 
   get_user_flagrec(u, &victim, chan->dname);
@@ -515,6 +516,7 @@ static void got_halfop(struct chanset_t *chan, char *nick, char *from,
     check_chan = 1;
 
   strcpy(ch, chan->name);
+  simple_sprintf(s, "%s!%s", m->nick, m->userhost);
   u = get_user_from_member(m);
 
   get_user_flagrec(u, &victim, chan->dname);


### PR DESCRIPTION
Found by: tkimball83
Patch by: tkimball83
Fixes:

One-line summary:

Initialize the mode target's nick/userhost before refreshing its user flags after op and halfop Tcl mode binds.

Additional description (if needed):

`got_op()` and `got_halfop()` pass the local `s` buffer to `modebind_refresh()` without initializing it. `modebind_refresh()` then uses that buffer as the host argument to `lookup_user_record()` while refreshing the target's flag record.

As a result, the refreshed victim flags can belong to no user or the wrong user. With `+bitch`, a recognized bot that has global op can then be treated as unauthorized and deopped immediately after receiving op.

Populate `s` from the channel member before invoking the Tcl mode bind, matching the existing pattern in `got_deop()` and the voice-mode handling.

Test cases demonstrating functionality (if applicable):

- Reproduced with two instances of the official `eggdrop:1.10.1` Linux image in a ten-bot network using `+bitch`.
- Before testing, both rebuilt bots' current IRC masks were confirmed saved exactly once in every bot's userfile, and the channel was allowed to finish NAMES/WHO synchronization.
- After each controlled deop, the target was correctly reopped, but a stock bot issued an unsolicited deop of the recognized target about one second later. This repeated throughout the test.
- Repeated the same post-synchronization mode churn with a 1.10.1 image containing only these two added lines: 20 controlled deop/reop cycles completed without an unsolicited deop.
- Current `develop` compiles successfully on macOS arm64 with `./configure --disable-tls && make config && make -j4`.
