### PR TITLE
Fix USERENTRY_DCCDIR

### DIFF
--- a/src/mod/filesys.mod/filesys.c
+++ b/src/mod/filesys.mod/filesys.c
@@ -1010,9 +1010,7 @@ char *filesys_start(Function *global_funcs)
   add_builtins(H_load, myload);
   add_help_reference("filesys.help");
   init_server_ctcps(0);
-  memcpy(&USERENTRY_DCCDIR, &USERENTRY_INFO,
-            sizeof(struct user_entry_type) - sizeof(char *));
-
+  memcpy(&USERENTRY_DCCDIR, &USERENTRY_INFO, sizeof(void *) * 12);
   USERENTRY_DCCDIR.got_share = 0;       /* We don't want it shared tho */
   add_entry_type(&USERENTRY_DCCDIR);
   DCC_FILES_PASS.timeout_val = &password_timeout;


### PR DESCRIPTION
Found by: nicoulaa
Patch by: michaelortmann
Fixes: #1927

One-line summary:
Fix `USERENTRY_DCCDIR`

Additional description (if needed):
Proper initialize `user_entry_type` fields when initializing USERENTRY_DCCDIR from USERENTRY_INFO. See also https://github.com/eggheads/eggdrop/blob/3e2e2877a1d3df51d905904f64367d21d8f85e00/src/mod/notes.mod/notes.c#L1236

Test cases demonstrating functionality (if applicable):
Before:
```
.info test
Your default info is now: test
.files
.cd /incoming
.quit
.info
Default info: incoming
```
After:
```
.info test
Your default info is now: test
.files
.cd /incoming
.quit
.info
Default info: test
```