### PR TITLE
Enhance tls default settings and docs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -314,10 +314,10 @@ sslstart:
 	fi
 
 sslcert: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
+	openssl req -new -x509 -nodes -days 200 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf
 
 sslsilent: sslstart
-	openssl req -new -x509 -nodes -days 365 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
+	openssl req -new -x509 -nodes -days 200 -keyout $(DEST)/eggdrop.key -out $(DEST)/eggdrop.crt -config ssl.conf \
 	    -subj "/O=Eggheads/OU=Eggdrop/CN=Self-generated Eggdrop Certificate"
 
 install: ainstall

--- a/doc/sphinx_source/using/core.rst
+++ b/doc/sphinx_source/using/core.rst
@@ -493,7 +493,7 @@ support.
     are required on the server side. Must be in PEM format.
     If you don't have one, you can create it using the following command::
 
-      openssl req -new -key eggdrop.key -x509 -out eggdrop.crt -days 365
+      openssl req -new -key eggdrop.key -x509 -out eggdrop.crt -days 200
 
     This is required for SSL hubs/listen ports, secure file transfer and
     /ctcp botnick schat

--- a/eggdrop.conf
+++ b/eggdrop.conf
@@ -398,7 +398,7 @@ set paranoid-telnet-flood 1
 # are required on the server side. Must be in PEM format.
 # If you don't have one, you can create it using the following command:
 #
-#   openssl req -new -key eggdrop.key -x509 -out eggdrop.crt -days 365
+#   openssl req -new -key eggdrop.key -x509 -out eggdrop.crt -days 200
 #
 # For your convenience, you can type 'make sslcert' after 'make install'
 # and you'll get a key and a certificate in your eggdrop directory.

--- a/ssl.conf
+++ b/ssl.conf
@@ -10,9 +10,9 @@ default_ca			= CA_default	# The default ca section
 ####################################################################
 [ CA_default ]
 
-default_days			= 365		# how long to certify for
+default_days			= 200		# how long to certify for
 default_crl_days		= 30		# how long before next CRL
-default_md			= sha1		# which md to use.
+default_md			= sha256	# which md to use.
 
 ####################################################################
 [ req ]


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Enhance tls default settings and docs

Additional description (if needed):
This is not only a theoretical enhancement but will also be a browser requirement regarding webui.mod via https. See https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.2.9.pdf section 6.3.2.

Test cases demonstrating functionality (if applicable):
No functional change