### PR TITLE
Fix minor logic bug in tls.c

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1216,7 +1216,7 @@ static int tcl_tlsstatus STDVAR
     return TCL_ERROR;
   }
   j = findsock(dcc[i].sock);
-  if (!j || !dcc[i].ssl || !td->socklist[j].ssl) {
+  if ((j < 0) || !dcc[i].ssl || !td->socklist[j].ssl) {
     Tcl_AppendResult(irp, "not a TLS connection", NULL);
     return TCL_ERROR;
   }


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:
Fix minor logic bug in tls.c

Additional description (if needed):
the code checked the return value of `findsock()` against 0 to detect error, when in fact `findsock()` returns -1.

Test cases demonstrating functionality (if applicable):
