### PR TITLE
Fix .reload to boot dangling users not in reloaded userfile

### DIFF
--- a/src/chanprog.c
+++ b/src/chanprog.c
@@ -39,7 +39,7 @@ extern char ver[], botnetnick[], firewall[], motdfile[], userfile[], helpdir[],
 extern time_t now, online_since, now2_last;
 extern int backgrd, term_z, con_chan, cache_hit, cache_miss, firewallport,
            default_flags, max_logs, conmask, protect_readonly, make_userfile,
-           noshare, ignore_time, max_socks;
+           noshare, ignore_time, max_socks, dcc_total;
 #ifdef TLS
 extern SSL_CTX *ssl_ctx;
 #endif
@@ -490,6 +490,15 @@ void reload()
     fatal(MISC_MISSINGUSERF, 0);
   reaffirm_owners();
   add_hq_user();
+
+  /* boot users not in userfile
+   * like when handle was changed before .reload
+   * dcc[idx].user is NULL for such users
+   */
+  for (int i = 0; i < dcc_total; i++)
+    if (!dcc[i].user && dcc[i].type->flags & DCT_CHAT)
+      do_boot(i, "-RELOAD", "user not in reloaded userfile");
+
   check_tcl_event("userfile-loaded");
   call_hook(HOOK_READ_USERFILE);
 }

--- a/src/userent.c
+++ b/src/userent.c
@@ -1672,8 +1672,10 @@ int set_user(struct user_entry_type *et, struct userrec *u, void *d)
   struct user_entry *e;
   int r;
 
-  if (!u || !et)
+  if (!u || !et) {
+    debug2("warning: set_user(%s, %s)\n", et ? et->name : "NULL", u ? u->handle : "NULL");
     return 0;
+  }
 
   if (!(e = find_user_entry(et, u))) {
     e = user_malloc(sizeof(struct user_entry));

--- a/src/userent.c
+++ b/src/userent.c
@@ -1673,7 +1673,7 @@ int set_user(struct user_entry_type *et, struct userrec *u, void *d)
   int r;
 
   if (!u || !et) {
-    debug2("warning: set_user(%s, %s)\n", et ? et->name : "NULL", u ? u->handle : "NULL");
+    debug2("warning: set_user(%s, %s)", et ? et->name : "NULL", u ? u->handle : "NULL");
     return 0;
   }
 


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: #1933

One-line summary:
Fix `.reload` to boot dangling users not in reloaded userfile
Fix small memleak under rare conditions described in #1933, plus user needs channel master priviledge to cause it
Bug found with fuzzing, fixed without any AI

Additional description (if needed):
Also added a debug warning message when `set_user()` is called with a NULL parameter

Test cases demonstrating functionality (if applicable):
**Before:**
memleak, see #1933
and user remains on partyline
**After:**
no memleak anymore
and dangling user is booted:
```
.handle foo
[14:44:36] Switched 0 notes from mallory to foo.
*** Handle change: mallory -> foo
[14:44:36] #mallory# handle foo
Okay, changed.
.reload
[14:44:38] #foo# reload
Reloading user file...
[14:44:38] Userfile loaded, unpacking...
-=- poof -=-
You've been booted from the bot by -RELOAD: user not in reloaded userfile
Connection closed by foreign host.
```