### PR TITLE
Crash fix: Fix vsnprintf truncation in shareout_mod()

### DIFF
--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1474,8 +1474,8 @@ static void shareout_mod(struct chanset_t *chan, const char *format, ...)
 
     strcpy(s, "s ");
     if ((l = vsnprintf(s + 2, 509, format, va)) >= 509) {
-      debug0("shareout_mod(): truncated to 509 bytes");
-      l = 509;
+      debug0("shareout_mod(): truncated to 508 bytes");
+      l = 508;
     }
     for (i = 0; i < dcc_total; i++)
       if ((dcc[i].type->flags & DCT_BOT) &&

--- a/src/mod/share.mod/share.c
+++ b/src/mod/share.mod/share.c
@@ -1473,8 +1473,10 @@ static void shareout_mod(struct chanset_t *chan, const char *format, ...)
     va_start(va, format);
 
     strcpy(s, "s ");
-    if ((l = egg_vsnprintf(s + 2, 509, format, va)) < 0)
-      s[2 + (l = 509)] = 0;
+    if ((l = vsnprintf(s + 2, 509, format, va)) >= 509) {
+      debug0("shareout_mod(): truncated to 509 bytes");
+      l = 509;
+    }
     for (i = 0; i < dcc_total; i++)
       if ((dcc[i].type->flags & DCT_BOT) &&
           (dcc[i].status & STAT_SHARE) &&


### PR DESCRIPTION
Found by: michaelortmann
Patch by: michaelortmann
Fixes: 

One-line summary:


Additional description (if needed):


Test cases demonstrating functionality (if applicable):
Link a share bot and share the userfile to the linked bot, then:
`.+ban FpQfJaI>)uh"lbi5eYO6-om2{o0#;p0FM6[VZR(H6y:s)XpW\^a=M^oaL5cR.h;GftPa-.P43yt$Cv!6),c7a;+UoIog%GZd[Ny]1"\5ar%kaGJ-/=9:lX{}WST%4/}Cq^X;\EX,NHl)%fpx:fTB6;a)=?trP%E'/hL][jW>&7iNcb6}{|jFX'`Ou+6ooJj&VY7&wJOeH=$pa3&gabY(HmSwl"BNoK%^G&!xptC?u]_.a5ZVmAv&g#VWYjS7wB@Y0n0B+#gnx]}FJN46%Sw9o7C!jvguj+@H`EQj% zSou`F;Bs2yL!V?ee5t*6fF(&rzrn+a'1**97`{k)$/r-J]]+9ruM2x{%gzzCfA"*r[bN$`w0K+Oq)/u|Co'%rbo@g7C%%4$jt%#-2![TTzHlp'SJbs.NyXPuwz6:|a3v),Q}LjmBxuLAk7p!Jh8H4(5^|qKpp}{VXESo"01g1kg6|B`2L,B4`%0MFG51Kvji=(e5091v2#oYfHsW>sE[u<V*QLM0Zt*[_V-7x(?j3&UI*uFo?MY%6"Q!;MSL>GAN`c/^N_qIFI*\N<kHKy1uqPB`/|PaM*^<2`
Before:
```
==138947==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b6586d42ab9 at pc 0x7f658a729a22 bp 0x7ffe8085b9d0 sp 0x7ffe8085b178
READ of size 620 at 0x7b6586d42ab9 thread T0
    #0 0x7f658a729a21 in memcpy (/usr/lib/libasan.so.8+0x129a21) (BuildId: b8a4241051a1621937fdc46e867ba7ecb56d96ea)
    #1 0x7f658a23384d  (/usr/lib/libssl.so.3+0x1684d) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4)
    #2 0x7f658a2adcc7  (/usr/lib/libssl.so.3+0x90cc7) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4)
    #3 0x7f658a2ae6df  (/usr/lib/libssl.so.3+0x916df) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4)
    #4 0x7f658a2a04c5  (/usr/lib/libssl.so.3+0x834c5) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4)
    #5 0x7f658a2469bb in SSL_write (/usr/lib/libssl.so.3+0x299bb) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4)
    #6 0x55e6925b513f in tputs /home/michael/projects/eggdrop/src/net.c:1373
    #7 0x7f65887ad307 in shareout_mod .././share.mod/share.c:1488
    #8 0x7b65854f7e33 in u_addban .././channels.mod/userchan.c:537
    #9 0x7b658554c1f0 in cmd_pls_ban .././channels.mod/cmdschan.c:199
    #10 0x55e6925dc9a0 in builtin_dcc /home/michael/projects/eggdrop/src/tclhash.c:693
    #11 0x55e6925bb593 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:340
    #12 0x7f658a47b7e8 in TclNRRunCallbacks /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:4541
    #13 0x7f658a47d973 in TclEvalEx /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:5409
    #14 0x7f658a47e31a in Tcl_EvalEx /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:5075
    #15 0x7f658a47e33a in Tcl_Eval /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:6001
    #16 0x7f658a47e98f in Tcl_VarEvalVA /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:7001
    #17 0x7f658a47ea71 in Tcl_VarEval /usr/src/debug/tcl/tcl8.6.16/generic/tclBasic.c:7033
    #18 0x55e6925d8742 in trigger_bind /home/michael/projects/eggdrop/src/tclhash.c:745
    #19 0x55e6925de3a1 in check_tcl_bind /home/michael/projects/eggdrop/src/tclhash.c:941
    #20 0x55e6925dea98 in check_tcl_dcc /home/michael/projects/eggdrop/src/tclhash.c:973
    #21 0x55e69255c632 in dcc_chat /home/michael/projects/eggdrop/src/dcc.c:1102
    #22 0x55e69258cfde in mainloop main.c:789
    #23 0x55e6925905c3 in main main.c:1220
    #24 0x7f6589027780  (/usr/lib/libc.so.6+0x27780) (BuildId: 503200d7fda94a5dc6058d7e0694e5d1dcb2e372)
    #25 0x7f65890278b8 in __libc_start_main (/usr/lib/libc.so.6+0x278b8) (BuildId: 503200d7fda94a5dc6058d7e0694e5d1dcb2e372)
    #26 0x55e6924db4f4 in _start (/home/michael/eggdrop/eggdrop-1.10.2+0x21f4f4) (BuildId: 6e1b62139e56ccd2a239ef7f293000546af6e815)

Address 0x7b6586d42ab9 is located in stack of thread T0 at offset 697 in frame
    #0 0x7f65887ac78a in shareout_mod .././share.mod/share.c:1467

  This frame has 2 object(s):
    [32, 56) 'va' (line 1470)
    [96, 697) 's' (line 1469) <== Memory access at offset 697 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/usr/lib/libssl.so.3+0x1684d) (BuildId: f0da11a5d04c67efe453c6c66929f53bf314a9c4) 
Shadow bytes around the buggy address:
  0x7b6586d42800: f1 f1 f1 f1 00 00 00 f2 f2 f2 f2 f2 00 00 00 00
  0x7b6586d42880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7b6586d42900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7b6586d42980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7b6586d42a00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7b6586d42a80: 00 00 00 00 00 00 00[01]f3 f3 f3 f3 f3 f3 f3 f3
  0x7b6586d42b00: f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3
  0x7b6586d42b80: f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3
  0x7b6586d42c00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7b6586d42c80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7b6586d42d00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==138947==ABORTING
```
After:
`[03:59:08] shareout_mod(): truncated to 508 bytes`