### PR TITLE
Fix webui version response when no patchlevel present

### DIFF
--- a/src/mod/webui.mod/webui.c
+++ b/src/mod/webui.mod/webui.c
@@ -70,7 +70,11 @@ static void put_404(int idx) {
     "Server: %s\r\n"
     "\r\n"
     "404 Not Found",
-    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #ifdef EGG_PATCH
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #else
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER);
+    #endif
   response = nmalloc(i + 1);
   sprintf(response,
     "HTTP/1.1 404 \r\n" /* textual phrase is OPTIONAL */
@@ -79,7 +83,11 @@ static void put_404(int idx) {
     "Server: %s\r\n"
     "\r\n"
     "404 Not Found",
-    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #ifdef EGG_PATCH
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #else
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER);
+    #endif
   tputs(dcc[idx].sock, response, i);
   nfree(response);
   killsock(dcc[idx].sock);
@@ -137,7 +145,11 @@ static void put_file(int idx, int file_cache_index) {
     "Server: %s\r\n"
     "\r\n",
     (intmax_t) sb.st_size, f->content_type,
-    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #ifdef EGG_PATCH
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #else
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER);
+    #endif
   response = nmalloc(i + sb.st_size);
   sprintf(response,
     "HTTP/1.1 200 \r\n" /* textual phrase is OPTIONAL */
@@ -146,7 +158,11 @@ static void put_file(int idx, int file_cache_index) {
     "Server: %s\r\n"
     "\r\n",
     (intmax_t) sb.st_size, f->content_type,
-    stealth_telnets ? "nginx/1.28.1" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #ifdef EGG_PATCH
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH);
+    #else
+    stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER);
+    #endif
   memcpy(response + i, f->data, sb.st_size);
   tputs(dcc[idx].sock, response, i + sb.st_size);
   nfree(response);

--- a/src/tls.c
+++ b/src/tls.c
@@ -1108,7 +1108,11 @@ int ssl_handshake(int sock, int flags, int verify, int loglevel, char *host,
         "Content-Type: text/plain; charset=utf-8\r\n"
         "Server: %s\r\n"
         "\r\n%s", strlen(body),
+          #ifdef EGG_PATCH
           stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH,
+          #else
+          stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER,
+          #endif
           body);
       response = nmalloc(j + 1);
       sprintf(response,
@@ -1117,7 +1121,11 @@ int ssl_handshake(int sock, int flags, int verify, int loglevel, char *host,
         "Content-Type: text/plain; charset=utf-8\r\n"
         "Server: %s\r\n"
         "\r\n%s", strlen(body),
+          #ifdef EGG_PATCH
           stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER "+" EGG_PATCH,
+          #else
+          stealth_telnets ? "nginx/1.28.0" : "Eggdrop/" EGG_STRINGVER,
+          #endif
           body);
       if (write(sock, response, j) < 0) /* tputs() cannot be used here */
         putlog(LOG_MISC, "*", "TLS: error: write(sock %i): %s", sock, strerror(errno));


### PR DESCRIPTION
Found by: Geo
Patch by: Geo

One-line summary:
Fix version when no patchlevel present

Additional description (if needed):
webui was built against the develop branch which has a patch level defined. On stable, it is not defined and causes an undefined compilation error in the ternary logic.

Note for the future: for 1.10.3, recommend centralizing the definition of this variable  and (unrelated) removing the nginx response from stealth_telnet. 

Test cases demonstrating functionality (if applicable):
